### PR TITLE
Fixed LiveChatWidget import since its not default exported and Security link at the bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const render = async () => {
     const chatSDK = new OmnichannelChatSDK(omnichannelConfig);
     await chatSDK.initialize(); // mandatory
     const chatConfig = await chatSDK.getLiveChatConfig();
-    liveChatWidgetProps = {
+    const liveChatWidgetProps = {
         styleProps: {
             generalStyles: {
                 width: "700px",

--- a/README.md
+++ b/README.md
@@ -217,4 +217,4 @@ const customizedFooterProp: IFooterProps = {
 [Telemetry](./docs/Telemetry.md)\
 [Omnichannel Features](./docs/Features.md)\
 [How to Add Visual Regression Tests](./docs/VisualRegressionTestingGuide.md)\
-[Security](./Security.md)
+[Security](./SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The basic example below takes in the ```<LiveChatWidget/>``` component along wit
 ```js
 import * as React from "react";
 
-import LiveChatWidget from "@microsoft/omnichannel-chat-widget";
+import { LiveChatWidget } from "@microsoft/omnichannel-chat-widget";
 import { OmnichannelChatSDK } from "@microsoft/omnichannel-chat-sdk";
 import ReactDOM from "react-dom";
 


### PR DESCRIPTION
The LiveChatWidget is not default exported from omnichannel-chat-widget. As a result, changed the reference code to use named import.