### PR TITLE
Add pva order middleware

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -21,7 +21,7 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Added font-family property to preChat Survey button
 - Added `lcw:chatRetrieved` event
 - Multi-widget support on same browser
-
+- Added support to ensure order of messages from PVA bot for orgs using ACS.
 ## [0.1.0] - 2022-7-19
 ### Added
 - Updated the version of @microsoft/omnichannel-chat-components to @0.1.0-main.423d0ce

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -52,8 +52,6 @@ export class Constants {
     public static readonly prefixTimestampTag = "ServerMessageTimestamp_";
     public static readonly acsChannel = "ACS_CHANNEL";
     public static readonly publicMessageTag = "public";
-    public static readonly UserMessageTag = "user";
-    public static readonly SystemMessageTag = "system";
 
     //attachmentMiddleware
     public static readonly supportedAdaptiveCardContentTypes: Array<string> = [

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -48,6 +48,13 @@ export class Constants {
     public static readonly message = "message";
     public static readonly hiddenTag = "Hidden";
 
+    // messageTimestampMiddleware
+    public static readonly prefixTimestampTag = "ServerMessageTimestamp_";
+    public static readonly acsChannel = "ACS_CHANNEL";
+    public static readonly publicMessageTag = "public";
+    public static readonly UserMessageTag = "user";
+    public static readonly SystemMessageTag = "system";
+
     //attachmentMiddleware
     public static readonly supportedAdaptiveCardContentTypes: Array<string> = [
         "application/vnd.microsoft.card.adaptive",

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -92,6 +92,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, chatSDK: any, s
             createMessageTimeStampMiddleware,
             gifUploadMiddleware,
             htmlPlayerMiddleware,
+            htmlTextMiddleware,
             createMaxMessageSizeValidator(localizedTexts),
             sanitizationMiddleware,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -35,6 +35,7 @@ import htmlTextMiddleware from "../../webchatcontainerstateful/webchatcontroller
 import preProcessingMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/preProcessingMiddleware";
 import sanitizationMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/sanitizationMiddleware";
 import { createCardActionMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/cardActionMiddleware";
+import { createMessageTimeStampMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const initWebChatComposer = (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setWebChatStyles: any) => {
@@ -93,6 +94,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, chatSDK: any, s
             htmlTextMiddleware,
             createMaxMessageSizeValidator(localizedTexts),
             sanitizationMiddleware,
+            createMessageTimeStampMiddleware,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ...(props.webChatContainerProps?.storeMiddlewares as any[] ?? [])
         );

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -35,7 +35,7 @@ import htmlTextMiddleware from "../../webchatcontainerstateful/webchatcontroller
 import preProcessingMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/preProcessingMiddleware";
 import sanitizationMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/sanitizationMiddleware";
 import { createCardActionMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/cardActionMiddleware";
-import { createMessageTimeStampMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware";
+import createMessageTimeStampMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const initWebChatComposer = (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setWebChatStyles: any) => {
@@ -89,12 +89,11 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, chatSDK: any, s
             channelDataMiddleware,
             createConversationEndMiddleware(conversationEndCallback),
             createDataMaskingMiddleware(state.domainStates.liveChatConfig?.DataMaskingInfo as IDataMaskingInfo),
+            createMessageTimeStampMiddleware,
             gifUploadMiddleware,
             htmlPlayerMiddleware,
-            htmlTextMiddleware,
             createMaxMessageSizeValidator(localizedTexts),
             sanitizationMiddleware,
-            createMessageTimeStampMiddleware,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ...(props.webChatContainerProps?.storeMiddlewares as any[] ?? [])
         );

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
@@ -55,6 +55,21 @@ const handleSystemMessage = (next: any, args: any[], card: any, systemMessageSty
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isTagIncluded = (card: any, tag: string): boolean => {
+    return isDataTagsPresent(card) &&
+        card.activity.channelData.tags.includes(tag);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const isDataTagsPresent = (card: any) => {
+    return card &&
+        card.activity &&
+        card.activity.channelData &&
+        card.activity.channelData.tags &&
+        card.activity.channelData.tags.length > 0;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createActivityMiddleware = (systemMessageStyleProps?: React.CSSProperties, userMessageStyleProps?: React.CSSProperties) => () => (next: any) => (...args: any) => {
     const [card] = args;
     if (card.activity) {
@@ -68,14 +83,12 @@ export const createActivityMiddleware = (systemMessageStyleProps?: React.CSSProp
             return () => false;
         }
 
-        if (card.activity.channelData.tags) {
-            if (card.activity.channelData.tags.includes(Constants.hiddenTag)) {
-                return () => false;
-            }
-
-            if (card.activity.channelData.tags.includes(Constants.systemMessageTag)) {
-                return handleSystemMessage(next, args, card, systemMessageStyleProps);
-            }
+        if (isTagIncluded(card, Constants.hiddenTag)) {
+            return () => false;
+        }
+        
+        if (isTagIncluded(card, Constants.systemMessageTag)) {
+            return handleSystemMessage(next, args, card, systemMessageStyleProps);
         } else if (card.activity.text
             && card.activity.type === DirectLineActivityType.Message
         ) {

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
@@ -1,0 +1,108 @@
+import { IWebChatAction } from "../../../interfaces/IWebChatAction";
+import { WebChatActionType } from "../../enums/WebChatActionType";
+import { Constants } from "../../../../../common/Constants";
+
+
+export const createMessageTimeStampMiddleware = () => ({dispatch} : {dispatch:any}) => (next : any) => (action:IWebChatAction)=>{
+
+if (isApplicable(action)){
+   return next (evaluateTagsAndOverrideTimeStamp(action));
+}
+
+return next(action);
+}
+
+const isApplicable = (action :IWebChatAction) : boolean => {
+    return action.type === WebChatActionType.DIRECT_LINE_INCOMING_ACTIVITY &&
+    isPVAConversation(action) &&
+    isPayloadValid(action) &&
+    isValidChannel(action);
+}
+
+const isPayloadValid = (action: any)  => {
+    return action &&
+        action.payload &&
+        action.payload.activity;
+}
+
+const isValidChannel = (action: any): boolean => {
+    return action &&
+        action.payload &&
+        action.payload.activity &&
+        action.payload.activity.channelId &&
+        action.payload.activity.channelId === Constants.acsChannel;
+}
+
+const isPVAConversation = (action: any): boolean => {
+    return !isTagIncluded(action, Constants.systemMessageTag) &&
+        !isTagIncluded(action, Constants.publicMessageTag) &&
+        !isRoleUserOn(action);
+}
+
+const isTagIncluded = (action: any, tag: string): boolean => {
+    return isDataTagsPresent(action) &&
+        action.payload.activity.channelData.tags.includes(tag);
+
+}
+
+const  isRoleUserOn = (action: any) => {
+    return action.payload.activity &&
+        action.payload.activity.from &&
+        action.payload.activity.from.role === Constants.userMessageTag;
+}
+
+const overrideTimeStamp = (timestampOriginal: string, timeStampNew: string): string {
+    return isTimestampValid(timeStampNew) ? timeStampNew : timestampOriginal;
+}
+
+const isTimestampValid = (timeStamp: string): boolean {
+    const regex: RegExp = /(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])(T)(\d{2})(:{1})(\d{2})(:{1})(\d{2})(.\d+)([Z]{1}))/;
+    return regex.test(timeStamp);
+}
+
+const isDataTagsPresent = (action: IWebChatAction) => {
+    return action.payload &&
+        action.payload.activity &&
+        action.payload.activity.channelData &&
+        action.payload.activity.channelData.tags &&
+        action.payload.activity.channelData.tags.length > 0;
+}
+
+const evaluateTagsAndOverrideTimeStamp =  (action : IWebChatAction): IWebChatAction => {
+    const tagValue = tagLookup(action, Constants.prefixTimestampTag);
+    if (tagValue) {
+        const newTimestamp = extractTimeStamp(tagValue);
+        action.payload.activity.timestamp = overrideTimeStamp(action.payload.activity.timestamp, newTimestamp);
+    }
+    return action;
+}
+
+const extractTimeStamp = (timeStamp: string): string  => {
+    if (timeStamp && timeStamp.length > 0) {
+        let ts = timeStamp.split(Constants.prefixTimestampTag);
+        if (ts && ts.length > 1) {
+            return ts[1];
+        }
+    }
+    return timeStamp;
+}
+
+const tagLookup = (action: IWebChatAction, tag: string): string | null => {
+    if (!isDataTagsPresent(action)) {
+        return null;
+    }
+
+    const tags = action.payload.activity.channelData.tags;
+    let value;
+
+    if (tags && tags.length > 0) {
+        for (let i = 0; i < tags.length; i++) {
+            value = tags[i];
+            if (value && value.indexOf(tag) > -1) {
+                return value;
+            }
+        }
+    }
+    return null;
+}
+

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
@@ -3,62 +3,62 @@ import { WebChatActionType } from "../../enums/WebChatActionType";
 import { Constants } from "../../../../../common/Constants";
 
 
-export const createMessageTimeStampMiddleware = () => ({dispatch} : {dispatch:any}) => (next : any) => (action:IWebChatAction)=>{
+export const createMessageTimeStampMiddleware = () => ({ dispatch }: { dispatch: any }) => (next: any) => (action: IWebChatAction) => {
 
-if (isApplicable(action)){
-   return next (evaluateTagsAndOverrideTimeStamp(action));
-}
+    if (isApplicable(action)) {
+        return next(evaluateTagsAndOverrideTimeStamp(action));
+    }
 
-return next(action);
-}
+    return next(action);
+};
 
-const isApplicable = (action :IWebChatAction) : boolean => {
+const isApplicable = (action: IWebChatAction): boolean => {
     return action.type === WebChatActionType.DIRECT_LINE_INCOMING_ACTIVITY &&
-    isPVAConversation(action) &&
-    isPayloadValid(action) &&
-    isValidChannel(action);
-}
+        isPVAConversation(action) &&
+        isPayloadValid(action) &&
+        isValidChannel(action);
+};
 
-const isPayloadValid = (action: any)  => {
+const isPayloadValid = (action: IWebChatAction) => {
     return action &&
         action.payload &&
         action.payload.activity;
-}
+};
 
-const isValidChannel = (action: any): boolean => {
+const isValidChannel = (action: IWebChatAction): boolean => {
     return action &&
         action.payload &&
         action.payload.activity &&
         action.payload.activity.channelId &&
         action.payload.activity.channelId === Constants.acsChannel;
-}
+};
 
-const isPVAConversation = (action: any): boolean => {
+const isPVAConversation = (action: IWebChatAction): boolean => {
     return !isTagIncluded(action, Constants.systemMessageTag) &&
         !isTagIncluded(action, Constants.publicMessageTag) &&
         !isRoleUserOn(action);
-}
+};
 
 const isTagIncluded = (action: any, tag: string): boolean => {
     return isDataTagsPresent(action) &&
         action.payload.activity.channelData.tags.includes(tag);
 
-}
+};
 
-const  isRoleUserOn = (action: any) => {
+const isRoleUserOn = (action: IWebChatAction) => {
     return action.payload.activity &&
         action.payload.activity.from &&
         action.payload.activity.from.role === Constants.userMessageTag;
-}
+};
 
-const overrideTimeStamp = (timestampOriginal: string, timeStampNew: string): string {
+const overrideTimeStamp = (timestampOriginal: string, timeStampNew: string): string => {
     return isTimestampValid(timeStampNew) ? timeStampNew : timestampOriginal;
-}
+};
 
-const isTimestampValid = (timeStamp: string): boolean {
-    const regex: RegExp = /(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])(T)(\d{2})(:{1})(\d{2})(:{1})(\d{2})(.\d+)([Z]{1}))/;
+const isTimestampValid = (timeStamp: string): boolean => {
+    const regex = /(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])(T)(\d{2})(:{1})(\d{2})(:{1})(\d{2})(.\d+)([Z]{1}))/;
     return regex.test(timeStamp);
-}
+};
 
 const isDataTagsPresent = (action: IWebChatAction) => {
     return action.payload &&
@@ -66,26 +66,26 @@ const isDataTagsPresent = (action: IWebChatAction) => {
         action.payload.activity.channelData &&
         action.payload.activity.channelData.tags &&
         action.payload.activity.channelData.tags.length > 0;
-}
+};
 
-const evaluateTagsAndOverrideTimeStamp =  (action : IWebChatAction): IWebChatAction => {
+const evaluateTagsAndOverrideTimeStamp = (action: IWebChatAction): IWebChatAction => {
     const tagValue = tagLookup(action, Constants.prefixTimestampTag);
     if (tagValue) {
         const newTimestamp = extractTimeStamp(tagValue);
         action.payload.activity.timestamp = overrideTimeStamp(action.payload.activity.timestamp, newTimestamp);
     }
     return action;
-}
+};
 
-const extractTimeStamp = (timeStamp: string): string  => {
+const extractTimeStamp = (timeStamp: string): string => {
     if (timeStamp && timeStamp.length > 0) {
-        let ts = timeStamp.split(Constants.prefixTimestampTag);
+        const ts = timeStamp.split(Constants.prefixTimestampTag);
         if (ts && ts.length > 1) {
             return ts[1];
         }
     }
     return timeStamp;
-}
+};
 
 const tagLookup = (action: IWebChatAction, tag: string): string | null => {
     if (!isDataTagsPresent(action)) {
@@ -104,5 +104,4 @@ const tagLookup = (action: IWebChatAction, tag: string): string | null => {
         }
     }
     return null;
-}
-
+};

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
@@ -2,13 +2,11 @@ import { IWebChatAction } from "../../../interfaces/IWebChatAction";
 import { WebChatActionType } from "../../enums/WebChatActionType";
 import { Constants } from "../../../../../common/Constants";
 
-
-export const createMessageTimeStampMiddleware = () => ({ dispatch }: { dispatch: any }) => (next: any) => (action: IWebChatAction) => {
-
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+const createMessageTimeStampMiddleware = ({ dispatch }: { dispatch: any }) => (next: any) => (action: IWebChatAction) => {
     if (isApplicable(action)) {
         return next(evaluateTagsAndOverrideTimeStamp(action));
     }
-
     return next(action);
 };
 
@@ -70,6 +68,7 @@ const isDataTagsPresent = (action: IWebChatAction) => {
 
 const evaluateTagsAndOverrideTimeStamp = (action: IWebChatAction): IWebChatAction => {
     const tagValue = tagLookup(action, Constants.prefixTimestampTag);
+
     if (tagValue) {
         const newTimestamp = extractTimeStamp(tagValue);
         action.payload.activity.timestamp = overrideTimeStamp(action.payload.activity.timestamp, newTimestamp);
@@ -105,3 +104,5 @@ const tagLookup = (action: IWebChatAction, tag: string): string | null => {
     }
     return null;
 };
+
+export default createMessageTimeStampMiddleware;

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/mesageTimestampMiddleware.tsx
@@ -18,17 +18,11 @@ const isApplicable = (action: IWebChatAction): boolean => {
 };
 
 const isPayloadValid = (action: IWebChatAction) => {
-    return action &&
-        action.payload &&
-        action.payload.activity;
+    return action?.payload?.activity;
 };
 
 const isValidChannel = (action: IWebChatAction): boolean => {
-    return action &&
-        action.payload &&
-        action.payload.activity &&
-        action.payload.activity.channelId &&
-        action.payload.activity.channelId === Constants.acsChannel;
+    return action?.payload?.activity?.channelId === Constants.acsChannel;
 };
 
 const isPVAConversation = (action: IWebChatAction): boolean => {
@@ -44,9 +38,7 @@ const isTagIncluded = (action: any, tag: string): boolean => {
 };
 
 const isRoleUserOn = (action: IWebChatAction) => {
-    return action.payload.activity &&
-        action.payload.activity.from &&
-        action.payload.activity.from.role === Constants.userMessageTag;
+    return action?.payload?.activity?.from?.role === Constants.userMessageTag;
 };
 
 const overrideTimeStamp = (timestampOriginal: string, timeStampNew: string): string => {
@@ -59,10 +51,7 @@ const isTimestampValid = (timeStamp: string): boolean => {
 };
 
 const isDataTagsPresent = (action: IWebChatAction) => {
-    return action.payload &&
-        action.payload.activity &&
-        action.payload.activity.channelData &&
-        action.payload.activity.channelData.tags &&
+    return action?.payload?.activity?.channelData?.tags &&
         action.payload.activity.channelData.tags.length > 0;
 };
 


### PR DESCRIPTION
## description

changes were done in current LCW as part of efforts to ensure the integrity of order of the messages from PVA bot, this work needed to be replicated for OCW as well.

## Solution
- changes required to ensure order of messages from PVA bots keeps proper order based on timestamp tags 
- includes update to ensure proper CSS style is applied to the messages.

## Evidence 

<img width="306" alt="image" src="https://user-images.githubusercontent.com/981914/181843305-1b653aa6-bdce-483a-b574-de1cb46be3a4.png">

<img width="318" alt="image" src="https://user-images.githubusercontent.com/981914/181843319-831a4df0-9b8d-458f-90b9-38f7cba6ad94.png">


