### PR TITLE
Fixed border color

### DIFF
--- a/chat-components/src/components/loadingpane/common/defaultProps/defaultStyles/defaultLoadingPaneIconStyles.ts
+++ b/chat-components/src/components/loadingpane/common/defaultProps/defaultStyles/defaultLoadingPaneIconStyles.ts
@@ -3,7 +3,7 @@ import { IStyle } from "@fluentui/react";
 export const defaultLoadingPaneIconStyles: IStyle = {
     borderRadius: "50%",
     backgroundColor: "#F1F1F1",
-    boxShadow: "0px 0px 0.5px 7px #3F75AB",
+    boxShadow: "0px 0px 0.5px 7px rgba(196, 196, 196, 0.15)",
     width: "86px",
     height: "86px",
     margin: "0px 0px 20px 0px",


### PR DESCRIPTION
Making border color for loading pane icon more transparent based on the background color
![LoadingPaneBlue](https://user-images.githubusercontent.com/104658006/186757474-c5f08338-0134-4141-aeba-539a14bba48d.png)

![LoadingPaneGreen](https://user-images.githubusercontent.com/104658006/186757495-cd0ca2cf-495e-4908-b804-14ed32872757.png)

