### PR TITLE
missing return for specific chat adapter from shim wrapper

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/createAdapter.ts
+++ b/chat-widget/src/components/livechatwidget/common/createAdapter.ts
@@ -29,6 +29,7 @@ export const createAdapter = async (chatSDK: any) => {
     //so far, there is no need to convert to the shim adapter when using visual tests
     if(chatSDK.isMockModeOn !== true){
         adapter = new ChatAdapterShim(adapter);
+        return adapter.chatAdapter;
     }
     return adapter;
 };

--- a/chat-widget/src/components/livechatwidget/common/createAdapter.ts
+++ b/chat-widget/src/components/livechatwidget/common/createAdapter.ts
@@ -27,7 +27,7 @@ export const createAdapter = async (chatSDK: any) => {
     };
     let adapter = await chatSDK.createChatAdapter(chatAdapterOptionalParams);
     //so far, there is no need to convert to the shim adapter when using visual tests
-    if(chatSDK.isMockModeOn !== true){
+    if (chatSDK.isMockModeOn !== true) {
         adapter = new ChatAdapterShim(adapter);
         return adapter.chatAdapter;
     }


### PR DESCRIPTION
missing return that may causes problem when registering activities

evidence chat working with middleware in action ->

<img width="344" alt="image" src="https://user-images.githubusercontent.com/981914/186967873-a6c13e00-5ed1-4863-94f4-aba2a87c8662.png">
