### PR TITLE
2904088_fix logic for markdown

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -7,20 +7,25 @@ import { Constants } from "../../../common/Constants";
 export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disableNewLineMarkdownSupport: boolean) => {
     let markdown: MarkdownIt;
 
-    if (!disableMarkdownMessageFormatting) {
+    if (disableMarkdownMessageFormatting) {
         markdown = new MarkdownIt(
-            Constants.Default,
+            Constants.Zero,
             {
                 html: true,
                 linkify: true,
                 breaks: (!disableNewLineMarkdownSupport)
             }
         );
+
+        markdown.enable([
+            "linkify", // Rule to replace link-like texts with link nodes
+        ], true);
+
         // ToDo: Commenting below usage of plugin until deferred bug is resolved: https://github.com/mayashavin/markdown-it-slack/issues/1
         // markdown.use(MarkdownSlack);
     } else {
+        disableNewLineMarkdownSupport = false;
         markdown = new MarkdownIt(
-            Constants.Zero,
             {
                 html: true,
                 linkify: true,
@@ -33,7 +38,7 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
             "html_block", // Rule to process html blocks and paragraphs
             "html_inline", // Rule to process html tags
             "newline" // Rule to proceess '\n'
-        ]);
+        ], true);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
# Description

it started as checking for the issue when using tags and the org doesnt have enabled markdown, the expected result is that the markdown is in action if presented the data tag.

# Solution 

- fix for wrong logic around flags disableMarkdownMessageFormatting (wrong flow)
-  for for creation of markdown object, which was broken, it was never creating a healthy object, so therefore render was not happening 
-  this fix an issue with links and erroneous render of markdown
-  support bold markdown for links ex -> **[hi](www.hi.com)**


# EVIDENCE

### TESTS CASES ###

### org markdown disabled , no data tag present

<img width="300" alt="image" src="https://user-images.githubusercontent.com/981914/188572040-82db67e0-1fd8-41c7-a99e-84a86f7dec02.png">

### org markdown disabled , data tag present

<img width="311" alt="image" src="https://user-images.githubusercontent.com/981914/188572238-fec32d16-6a39-4e85-b988-cc295dc5fe6d.png">

### org markdown disabled , no data tag, custom config present

<img width="329" alt="image" src="https://user-images.githubusercontent.com/981914/188572512-b3080d04-afbd-4853-abff-c50987082d54.png">

### org markdown disabled ,  data tag, custom config present to disable format enable

<img width="320" alt="image" src="https://user-images.githubusercontent.com/981914/188572885-51392db9-4d03-43f3-8f60-25a7a542d0a8.png">



