### PR TITLE
adding handling of default messages and proper display of alerts

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -44,3 +44,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Adding `WidgetInstanceId` to support same widget with multi origin
 - Fixed custom context when `skipchatbuttonrendering` is enabled
 - Added exception for authenticated chat when context is passed 
+- Fixed description for new messages notification from screen reader.

--- a/chat-components/src/components/chatbutton/ChatButton.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.tsx
@@ -15,6 +15,8 @@ import { defaultChatButtonTextContainerStyles } from "./common/defaultStyles/def
 import { defaultChatButtonTitleStyles } from "./common/defaultStyles/defaultChatButtonTitleStyles";
 
 function NotificationBubble(props: IChatButtonProps, parentId: string) {
+
+
     const notificationBubbleStyles: ILabelStyles = {
         root: Object.assign({}, defaultChatButtonNotificationBubbleStyles, props.styleProps?.notificationBubbleStyleProps)
     };
@@ -23,12 +25,13 @@ function NotificationBubble(props: IChatButtonProps, parentId: string) {
     if (unreadMessageCount !== "0") {
         return (decodeComponentString(props.componentOverrides?.notificationBubble) || 
             <Stack
-                role="alert"
+                aria-live="polite" 
                 styles={notificationBubbleStyles}
+                aria-label = {props.controlProps?.ariaLabelUnreadMessageString?? defaultChatButtonControlProps.ariaLabelUnreadMessageString}
                 className={props.styleProps?.classNames?.notificationBubbleClassName}
                 id={parentId + "-notification-bubble"}>
                 {unreadMessageCount}
-                <span style={HiddenTextStyles}>{props.controlProps?.unreadMessageString}</span>
+                <span style={HiddenTextStyles}>{props.controlProps?.unreadMessageString?? defaultChatButtonControlProps.unreadMessageString}</span>
             </Stack>
         );
     }
@@ -100,6 +103,8 @@ function TextContainer(props: IChatButtonProps, parentId: string) {
 }
 
 function ChatButton(props: IChatButtonProps) {
+
+    console.log("ELOPEZANAYA building chat button");
     const elementId = props.controlProps?.id ?? "lcw-components-chat-button";
     const defaultAriaLabel = props.controlProps?.ariaLabel ?? "live chat button";
     const defaultRole = props.controlProps?.role ?? defaultChatButtonControlProps?.role;

--- a/chat-components/src/components/chatbutton/ChatButton.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.tsx
@@ -103,8 +103,6 @@ function TextContainer(props: IChatButtonProps, parentId: string) {
 }
 
 function ChatButton(props: IChatButtonProps) {
-
-    console.log("ELOPEZANAYA building chat button");
     const elementId = props.controlProps?.id ?? "lcw-components-chat-button";
     const defaultAriaLabel = props.controlProps?.ariaLabel ?? "live chat button";
     const defaultRole = props.controlProps?.role ?? defaultChatButtonControlProps?.role;

--- a/chat-components/src/components/chatbutton/ChatButton.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.tsx
@@ -15,8 +15,6 @@ import { defaultChatButtonTextContainerStyles } from "./common/defaultStyles/def
 import { defaultChatButtonTitleStyles } from "./common/defaultStyles/defaultChatButtonTitleStyles";
 
 function NotificationBubble(props: IChatButtonProps, parentId: string) {
-
-
     const notificationBubbleStyles: ILabelStyles = {
         root: Object.assign({}, defaultChatButtonNotificationBubbleStyles, props.styleProps?.notificationBubbleStyleProps)
     };
@@ -27,11 +25,11 @@ function NotificationBubble(props: IChatButtonProps, parentId: string) {
             <Stack
                 aria-live="polite" 
                 styles={notificationBubbleStyles}
-                aria-label = {props.controlProps?.ariaLabelUnreadMessageString?? defaultChatButtonControlProps.ariaLabelUnreadMessageString}
+                aria-label={props.controlProps?.ariaLabelUnreadMessageString ? props.controlProps?.ariaLabelUnreadMessageString : defaultChatButtonControlProps.ariaLabelUnreadMessageString}
                 className={props.styleProps?.classNames?.notificationBubbleClassName}
                 id={parentId + "-notification-bubble"}>
                 {unreadMessageCount}
-                <span style={HiddenTextStyles}>{props.controlProps?.unreadMessageString?? defaultChatButtonControlProps.unreadMessageString}</span>
+                <span style={HiddenTextStyles}>{props.controlProps?.unreadMessageString ? props.controlProps?.unreadMessageString : defaultChatButtonControlProps.unreadMessageString}</span>
             </Stack>
         );
     }

--- a/chat-components/src/components/chatbutton/common/defaultProps/defaultChatButtonControlProps.ts
+++ b/chat-components/src/components/chatbutton/common/defaultProps/defaultChatButtonControlProps.ts
@@ -18,5 +18,7 @@ export const defaultChatButtonControlProps: IChatButtonControlProps = {
     hideChatTitle: false,
     hideNotificationBubble: true,
     unreadMessageString: "new messages",
-    largeUnreadMessageString: "99+"
+    largeUnreadMessageString: "99+",
+    ariaLabelUnreadMessageString: "you have new messages"
+
 };

--- a/chat-components/src/components/chatbutton/common/defaultProps/defaultChatButtonControlProps.ts
+++ b/chat-components/src/components/chatbutton/common/defaultProps/defaultChatButtonControlProps.ts
@@ -20,5 +20,4 @@ export const defaultChatButtonControlProps: IChatButtonControlProps = {
     unreadMessageString: "new messages",
     largeUnreadMessageString: "99+",
     ariaLabelUnreadMessageString: "you have new messages"
-
 };

--- a/chat-components/src/components/chatbutton/interfaces/IChatButtonControlProps.ts
+++ b/chat-components/src/components/chatbutton/interfaces/IChatButtonControlProps.ts
@@ -15,4 +15,5 @@ export interface IChatButtonControlProps {
     hideNotificationBubble?: boolean;
     unreadMessageString?: string;
     largeUnreadMessageString?: string;
+    ariaLabelUnreadMessageString? : string;
 }

--- a/chat-components/src/components/chatbutton/interfaces/IChatButtonControlProps.ts
+++ b/chat-components/src/components/chatbutton/interfaces/IChatButtonControlProps.ts
@@ -8,12 +8,12 @@ export interface IChatButtonControlProps {
     unreadMessageCount?: string;
     onClick?: () => void;
     hideChatButton?: boolean;
-    hideChatIcon?:boolean; 
+    hideChatIcon?: boolean;
     hideChatTextContainer?: boolean;
     hideChatSubtitle?: boolean;
     hideChatTitle?: boolean;
     hideNotificationBubble?: boolean;
     unreadMessageString?: string;
     largeUnreadMessageString?: string;
-    ariaLabelUnreadMessageString? : string;
+    ariaLabelUnreadMessageString?: string;
 }

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -299,7 +299,8 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
             hideChatTitle: false,
             hideNotificationBubble: true,
             unreadMessageString: "new messages",
-            largeUnreadMessageString: "99+"
+            largeUnreadMessageString: "99+",
+            ariaLabelUnreadMessageString: "you have new messages"
         },
         styleProps: {
             generalStyleProps: {

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -299,7 +299,8 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
             hideChatTitle: false,
             hideNotificationBubble: true,
             unreadMessageString: "new messages",
-            largeUnreadMessageString: "99+"        },
+            largeUnreadMessageString: "99+",
+        },
         styleProps: {
             generalStyleProps: {
                 height: "60px",

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -299,9 +299,7 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
             hideChatTitle: false,
             hideNotificationBubble: true,
             unreadMessageString: "new messages",
-            largeUnreadMessageString: "99+",
-            ariaLabelUnreadMessageString: "you have new messages"
-        },
+            largeUnreadMessageString: "99+"        },
         styleProps: {
             generalStyleProps: {
                 height: "60px",


### PR DESCRIPTION
# Description

it was detected that screen readers were not properly announcing new messages when the chat is minimized

# Solution
add default values , and enhance the aria-label description

# Acceptance criteria and evidence

- JAWS, NVDA , MSFT Narrator should announce the incoming messages when chat is minimized
- There is a known issue already discussed with A11y helpldesk with Edge and Narrator, which doesnt recognize the hidden spam message, so it only announces "you have new messages", for this scenario is not expected to announce the number of messages.

You said:numbers Sent at September 10 at 12:09 PM   
Bot WC said:hello my friend Sent at September 10 at 12:09 PM   
Minimize  button
live chat button  button
2new messages 
you have new messages
3new messages 
you have new messages
4new messages 
