### PR TITLE
Small fixes to support older browsers

### DIFF
--- a/chat-components/src/services/BroadcastService.ts
+++ b/chat-components/src/services/BroadcastService.ts
@@ -41,7 +41,11 @@ export const BroadcastServiceInitialize = (channelName: string) => {
 export const BroadcastService = {
     //broadcast a message
     postMessage: (message: ICustomEvent) => {
-        pubChannel.postMessage(message);
+        /**
+         * Omit copying methods to prevent 'DataCloneError' in older browsers when passing an object with functions
+         * This exception occurs when an object can't be clone with the 'structured clone algorithm' (used by postMessage)
+         */
+        pubChannel.postMessage(JSON.parse(JSON.stringify(message)));
     },
 
     getMessage: (message: ICustomEvent) => {

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -2,6 +2,7 @@ import { IStackStyles, Stack } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
 import { Components } from "botframework-webchat";
+import { BroadcastChannel } from "broadcast-channel";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
 import { ILiveChatWidgetContext } from "../../contexts/common/ILiveChatWidgetContext";
 import { IWebChatContainerStatefulProps } from "./interfaces/IWebChatContainerStatefulProps";


### PR DESCRIPTION
2 Changes to support older browsers: 

1. Deep clone message object before calling postMessage to prevent errors
2. Fixed missing import for BroadcastChannel (this was undefined in older versions of safari [supported from v. 15.4](https://caniuse.com/broadcastchannel)) 
