### PR TITLE
Auth chat - connect to same chat after refresh

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -46,3 +46,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Added exception for authenticated chat when context is passed 
 - Fixed description for new messages notification from screen reader.
 - Added default properties for background and color for  adaptive cards and properties for customization of the same.
+- Added a fix for auth chat to connect to the same chat after refresh.

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -19,7 +19,7 @@ import { setPostChatContextAndLoadSurvey } from "./setPostChatContextAndLoadSurv
 import { updateSessionDataForTelemetry } from "./updateSessionDataForTelemetry";
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { ActivityStreamHandler } from "./ActivityStreamHandler";
-import { handleAuthentication } from "./authHelper";
+import { getAuthClientFunction, handleAuthentication } from "./authHelper";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let optionalParams: any = {};
@@ -81,6 +81,15 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
     try {
         let isStartChatSuccessful = false;
 
+        const authClientFunction = getAuthClientFunction(chatConfig);
+        if (getAuthToken && authClientFunction) {
+            // set auth token to chat sdk before start chat
+            const authSuccess = await handleAuthentication(chatSDK, chatConfig, getAuthToken);
+            if (!authSuccess) {
+                return;
+            }
+        }
+
         //Check if chat retrieved from cache
         if (persistedState || params?.liveChatContext) {
             BroadcastService.postMessage({
@@ -103,9 +112,6 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
             // Set custom context params
             setCustomContextParams(chatSDK);
             optionalParams = Object.assign({}, params, optionalParams);
-
-            // set auth token to chat sdk before start chat
-            await handleAuthentication(chatSDK, chatConfig, getAuthToken);
 
             await chatSDK.startChat(optionalParams);
             isStartChatSuccessful = true;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -79,8 +79,6 @@ const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, params?: any, persistedState?: any) => {
     try {
-        let isStartChatSuccessful = false;
-
         const authClientFunction = getAuthClientFunction(chatConfig);
         if (getAuthToken && authClientFunction) {
             // set auth token to chat sdk before start chat
@@ -89,6 +87,8 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
                 return;
             }
         }
+
+        let isStartChatSuccessful = false;
 
         //Check if chat retrieved from cache
         if (persistedState || params?.liveChatContext) {

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -146,13 +146,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             return;
         }
 
-        // Check if auth settings enabled, do not connect to existing chat from cache during refresh/re-load
-        if (isAuthenticationSettingsEnabled === false) {
-            if (!isUndefinedOrEmpty(state.domainStates?.liveChatContext) && state.appStates.conversationState === ConversationState.Active) {
-                const optionalParams = { liveChatContext: state.domainStates?.liveChatContext };
-                initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams);
-                return;
-            }
+        if (!state.appStates.skipChatButtonRendering &&
+            !isUndefinedOrEmpty(state.domainStates?.liveChatContext)
+            && state.appStates.conversationState === ConversationState.Active) {
+            const optionalParams = { liveChatContext: state.domainStates?.liveChatContext };
+            initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams);
+            return;
         }
 
         // All other case should show start chat button, skipChatButtonRendering will take care of it own


### PR DESCRIPTION
Currently when there is auth chat and we refresh the page or start in another tab, it doesn't connect to the same chat, but starts a new chat instead. With this fix it will connect to the same chat.