### PR TITLE
Corrected for Sound notifications

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -47,3 +47,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Fixed description for new messages notification from screen reader.
 - Added default properties for background and color for  adaptive cards and properties for customization of the same.
 - Added a fix for auth chat to connect to the same chat after refresh.
+- Fixed the sound notification when the footer is hidden.

--- a/chat-widget/src/components/footerstateful/FooterStateful.tsx
+++ b/chat-widget/src/components/footerstateful/FooterStateful.tsx
@@ -64,19 +64,15 @@ export const FooterStateful = (props: any) => {
         },
     };
 
-    const footerId = controlProps?.id ?? "oc-lcw-footer";
-    const footer: HTMLElement | null = document.getElementById(footerId);
-    if (footer) {
-        footer.style.display = hideFooterDisplay ? "none" : "";
-    }
-
     return (
         <>
-            <Footer
-                componentOverrides={footerProps?.componentOverrides}
-                controlProps={controlProps}
-                styleProps={footerProps?.styleProps}
-            />
+            {!hideFooterDisplay &&
+                <Footer
+                    componentOverrides={footerProps?.componentOverrides}
+                    controlProps={controlProps}
+                    styleProps={footerProps?.styleProps}
+                />
+            }
             <AudioNotificationStateful
                 audioSrc={audioNotificationProps?.audioSrc ?? NewMessageNotificationSoundBase64}
                 isAudioMuted={state.appStates.isAudioMuted === null ? 

--- a/chat-widget/src/components/livechatwidget/common/createFooter.tsx
+++ b/chat-widget/src/components/livechatwidget/common/createFooter.tsx
@@ -1,5 +1,4 @@
 import FooterStateful from "../../footerstateful/FooterStateful";
-import { IFooterProps } from "@microsoft/omnichannel-chat-components/lib/types/components/footer/interfaces/IFooterProps";
 import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
 import React from "react";
@@ -7,19 +6,8 @@ import { decodeComponentString } from "@microsoft/omnichannel-chat-components";
 import { shouldShowFooter } from "../../../controller/componentController";
 
 export const createFooter = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext) => {
-    const footerPropsHidden: IFooterProps = {
-        ...props.footerProps,
-        controlProps: {
-            ...props.footerProps?.controlProps,
-            hideDownloadTranscriptButton: true,
-            hideEmailTranscriptButton: true,
-            hideAudioNotificationButton: true
-        }
-    };
-
-    const footer = (!props.controlProps?.hideFooter && shouldShowFooter(state)) ?
-        (decodeComponentString(props.componentOverrides?.footer) || <FooterStateful footerProps={props.footerProps} downloadTranscriptProps={props.downloadTranscriptProps} audioNotificationProps={props.audioNotificationProps} hideFooterDisplay={false}/>) :
-        (decodeComponentString(props.componentOverrides?.footer) || <FooterStateful footerProps={footerPropsHidden} downloadTranscriptProps={props.downloadTranscriptProps} audioNotificationProps={props.audioNotificationProps} hideFooterDisplay={true}/>);
+    const hideFooterDisplay = (!props.controlProps?.hideFooter && shouldShowFooter(state)) ? false : true;
+    const footer = (decodeComponentString(props.componentOverrides?.footer) || <FooterStateful footerProps={props.footerProps} downloadTranscriptProps={props.downloadTranscriptProps} audioNotificationProps={props.audioNotificationProps} hideFooterDisplay={hideFooterDisplay}/>);
 
     return footer;
 };


### PR DESCRIPTION
Issue: Sound notifications are not working when minimized; The initial props were getting overridden by the props defaulting to disable mode for the sound notification when hiding the whole footer.
Scenarios tested:
a. Sound notification enabled at the widget level
  - Sound notification works fine when enabled and both minimized and non-minimized works fine.
  - Toggled the sound notification button; works fine 
   
b. Sound notification disabled at the widget level
 - No sounds in case of non-minimized mode, working fine
 - No sound when in minimized state, working fine
 - Toggled the sound notification button; works fine 
 
Validated the footer coming correctly when sound notification button is disabled, and other buttons are enabled or none of them are enabled.
