### PR TITLE
Replace proactive chat close button

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -48,3 +48,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Added default properties for background and color for  adaptive cards and properties for customization of the same.
 - Added a fix for auth chat to connect to the same chat after refresh.
 - Fixed the sound notification when the footer is hidden.
+- Replaced proactive chat pane close button with header close button.

--- a/chat-components/src/common/Constants.ts
+++ b/chat-components/src/common/Constants.ts
@@ -31,7 +31,7 @@ export const Regex = class {
 
 export enum ElementType {
     ChatButton = "ChatButton",
-    HeaderCloseButton = "HeaderCloseButton",
+    CloseButton = "CloseButton",
     HeaderMinimizeButton = "HeaderMinimizeButton",
     FooterDownloadTranscriptButton = "FooterDownloadTranscriptButton",
     FooterEmailTranscriptButton = "FooterEmailTranscriptButton",

--- a/chat-components/src/components/common/commandbutton/CommandButton.tsx
+++ b/chat-components/src/components/common/commandbutton/CommandButton.tsx
@@ -49,7 +49,7 @@ function CommandButton(props: ICommandButtonProps) {
                 <IconButton
                     id={props.id}
                     iconProps={iconProp}
-                    title={props.ariaLabel}
+                    title={props.hideButtonTitle ? undefined : props.ariaLabel}
                     ariaLabel={props.ariaLabel}
                     disabled={props.disabled}
                     styles={buttonStyles}

--- a/chat-components/src/components/common/interfaces/ICommandButtonControlProps.ts
+++ b/chat-components/src/components/common/interfaces/ICommandButtonControlProps.ts
@@ -15,4 +15,5 @@ export interface ICommandButtonControlProps {
     onClick?: () => void;
     className?: string;
     disabled?: boolean;
+    hideButtonTitle?: boolean;
 }

--- a/chat-components/src/components/common/interfaces/ICommandButtonProps.ts
+++ b/chat-components/src/components/common/interfaces/ICommandButtonProps.ts
@@ -20,4 +20,5 @@ export interface ICommandButtonProps {
     className?: string;
     disabled?: boolean;
     customEvent?: ICustomEvent;
+    hideButtonTitle?: boolean;
 }

--- a/chat-components/src/components/common/subcomponents/CloseButton.tsx
+++ b/chat-components/src/components/common/subcomponents/CloseButton.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { ElementType } from "../../../common/Constants";
 import { ICustomEvent } from "../../../interfaces/ICustomEvent";
-import CommandButton from "../../common/commandbutton/CommandButton";
-import { ICommandButtonProps } from "../../common/interfaces/ICommandButtonProps";
+import CommandButton from "../commandbutton/CommandButton";
+import { ICommandButtonProps } from "../interfaces/ICommandButtonProps";
 
 function CloseButton(props: ICommandButtonProps) {
     const { type } = props;
     const customEvent: ICustomEvent = {
-        elementType: ElementType.HeaderCloseButton,
+        elementType: ElementType.CloseButton,
         elementId: props?.id,
         eventName: "OnClick"
     };
@@ -20,12 +20,13 @@ function CloseButton(props: ICommandButtonProps) {
             styles={props.styles}
             hoverStyles={props.hoverStyles}
             focusStyles={props.focusStyles}
-            iconName={props.iconName?? "ChromeClose"}
+            iconName={props.iconName ?? "ChromeClose"}
             imageIconProps={props.imageIconProps}
             onClick={props.onClick}
             ariaLabel={props.ariaLabel ?? "Close"}
             className={props.className} 
-            customEvent={customEvent} />
+            customEvent={customEvent} 
+            hideButtonTitle = {props.hideButtonTitle}/>
     );
 }
 

--- a/chat-components/src/components/header/Header.tsx
+++ b/chat-components/src/components/header/Header.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { IImageStyles, ILabelStyles, IStackStyles, Image, Label, Stack, initializeIcons } from "@fluentui/react";
 
-import CloseButton from "./subcomponents/CloseButton";
+import CloseButton from "../common/subcomponents/CloseButton";
 import { IHeaderProps } from "./interfaces/IHeaderProps";
 import MinimizeButton from "./subcomponents/MinimizeButton";
 import { decodeComponentString } from "../../common/decodeComponentString";

--- a/chat-components/src/components/proactivechatpane/ProactiveChatPane.tsx
+++ b/chat-components/src/components/proactivechatpane/ProactiveChatPane.tsx
@@ -1,16 +1,15 @@
-import { IButtonStyles, IStackStyles, IconButton, Label, Stack } from "@fluentui/react";
+import { IButtonStyles, IStackStyles, Label, Stack } from "@fluentui/react";
 import React, { useCallback } from "react";
 
 import { BroadcastService } from "../../services/BroadcastService";
 import { DefaultButton } from "@fluentui/react/lib/Button";
 import { ICustomEvent } from "../../interfaces/ICustomEvent";
+import CloseButton from "../common/subcomponents/CloseButton";
 import { IProactiveChatPaneProps } from "./interfaces/IProactiveChatPaneProps";
 import { KeyCodes } from "../../common/Constants";
 import { decodeComponentString } from "../../common/decodeComponentString";
 import { defaultProactiveChatPaneBodyContainerStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneBodyContainerStyles";
 import { defaultProactiveChatPaneBodyTitleStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneBodyTitleStyles";
-import { defaultProactiveChatPaneCloseButtonHoveredStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneCloseButtonHoveredStyles";
-import { defaultProactiveChatPaneCloseButtonStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneCloseButtonStyles";
 import { defaultProactiveChatPaneControlProps } from "./common/default/defaultProps/defaultProactiveChatPaneControlProps";
 import { defaultProactiveChatPaneGeneralStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneGeneralStyles";
 import { defaultProactiveChatPaneHeaderContainerStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneHeaderContainerStyles";
@@ -20,6 +19,7 @@ import { defaultProactiveChatPaneSubtitleStyles } from "./common/default/default
 import { defaultProactiveChatPaneTextContainerStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneTextContainerStyles";
 import { defaultProactiveChatPaneTitleStyles } from "./common/default/defaultStyles/defaultProactiveChatPaneTitleStyles";
 import { generateEventName } from "../../common/utils";
+import { defaultProactiveChatPaneProps } from "./common/default/defaultProps/defaultProactiveChatPaneProps";
 
 function ProactiveChatPane(props: IProactiveChatPaneProps) {
 
@@ -60,6 +60,9 @@ function ProactiveChatPane(props: IProactiveChatPaneProps) {
         }
     }, []);
 
+    const closeButtonProps = Object.assign({}, defaultProactiveChatPaneProps.controlProps?.closeButtonProps,
+        props.controlProps?.closeButtonProps);
+
     const containerStyles: IStackStyles = {
         root: Object.assign({}, defaultProactiveChatPaneGeneralStyles, props.styleProps?.generalStyleProps)
     };
@@ -80,11 +83,11 @@ function ProactiveChatPane(props: IProactiveChatPaneProps) {
         root: Object.assign({}, defaultProactiveChatPaneSubtitleStyles, props.styleProps?.subtitleStyleProps)
     };
 
-    const closeButtonStyles: IButtonStyles = {
-        root: Object.assign({}, defaultProactiveChatPaneCloseButtonStyles, props.styleProps?.closeButtonStyleProps),
-        rootHovered: Object.assign({}, defaultProactiveChatPaneCloseButtonHoveredStyles, props.styleProps?.closeButtonHoveredStyleProps),
-        rootPressed: Object.assign({}, defaultProactiveChatPaneCloseButtonHoveredStyles, props.styleProps?.closeButtonHoveredStyleProps)
-    };
+    const closeButtonStyles = Object.assign({}, defaultProactiveChatPaneProps.styleProps?.closeButtonStyleProps,
+        props.styleProps?.closeButtonStyleProps);
+
+    const closeButtonHoverStyles = Object.assign({}, defaultProactiveChatPaneProps.styleProps?.closeButtonHoveredStyleProps,
+        props.styleProps?.closeButtonHoveredStyleProps);
 
     const bodyContainerStyles: IStackStyles = {
         root: Object.assign({}, defaultProactiveChatPaneBodyContainerStyles, props.styleProps?.bodyContainerStyleProps)
@@ -142,14 +145,13 @@ function ProactiveChatPane(props: IProactiveChatPaneProps) {
                         </Stack>
 
                         {!props.controlProps?.hideCloseButton && (decodeComponentString(props.componentOverrides?.closeButton) ||
-                        <IconButton
+                        <CloseButton
+                            {...closeButtonProps}
                             className={props.styleProps?.classNames?.closeButtonClassName}
-                            styles={closeButtonStyles}
-                            tabIndex={0}
                             onClick={handleCloseClick}
-                            id={elementId + "-closebutton"}
-                            aria-label={props.controlProps?.closeButtonAriaLabel || defaultProactiveChatPaneControlProps.closeButtonAriaLabel}
-                        />) }
+                            styles={closeButtonStyles}
+                            hoverStyles={closeButtonHoverStyles}
+                            id={elementId + "-closebutton"}/>) }
                     </Stack>
                     <Stack horizontal={props.controlProps?.isBodyContainerHorizantal || defaultProactiveChatPaneControlProps.isBodyContainerHorizantal}
                         className={props.styleProps?.classNames?.bodyContainerClassName}

--- a/chat-components/src/components/proactivechatpane/common/default/defaultProps/defaultProactiveChatPaneControlProps.ts
+++ b/chat-components/src/components/proactivechatpane/common/default/defaultProps/defaultProactiveChatPaneControlProps.ts
@@ -13,7 +13,11 @@ export const defaultProactiveChatPaneControlProps: IProactiveChatPaneControlProp
     subtitleText: "Live chat support!",
 
     hideCloseButton: false,
-    closeButtonAriaLabel: "Close Button",
+    closeButtonProps: {
+        type: "icon",
+        iconName: "ChromeClose",
+        hideButtonTitle: true
+    },
 
     isBodyContainerHorizantal: false,
 

--- a/chat-components/src/components/proactivechatpane/common/default/defaultStyles/defaultProactiveChatPaneCloseButtonStyles.ts
+++ b/chat-components/src/components/proactivechatpane/common/default/defaultStyles/defaultProactiveChatPaneCloseButtonStyles.ts
@@ -1,15 +1,6 @@
-import { CloseChatButtonIconBase64 } from "../../../../../assets/Icons";
 import { IStyle } from "@fluentui/react";
 
 export const defaultProactiveChatPaneCloseButtonStyles: IStyle = {
-    backgroundImage: `url(${CloseChatButtonIconBase64})`,
-    backgroundPosition: "center",
-    backgroundRepeat: "no-repeat", 
-    color: "#605e5c",
-    cursor: "pointer",
-    height: "14px",
-    lineHeight: "14px",
-    textAlign: "center",
-    width: "14px",
-    zIndex: "inherit"
+    color: "white",
+    fontSize: "12px"
 };

--- a/chat-components/src/components/proactivechatpane/common/presetOne/presetOneProps/presetOneProactiveChatPaneControlProps.ts
+++ b/chat-components/src/components/proactivechatpane/common/presetOne/presetOneProps/presetOneProactiveChatPaneControlProps.ts
@@ -13,7 +13,11 @@ export const presetOneProactiveChatPaneControlProps: IProactiveChatPaneControlPr
     subtitleText: "Live chat support!",
 
     hideCloseButton: false,
-    closeButtonAriaLabel: "Close Button",
+    closeButtonProps: {
+        type: "icon",
+        iconName: "ChromeClose",
+        hideButtonTitle: true
+    },
 
     isBodyContainerHorizantal: true,
 

--- a/chat-components/src/components/proactivechatpane/common/presetThree/presetThreeProps/presetThreeProactiveChatPaneControlProps.ts
+++ b/chat-components/src/components/proactivechatpane/common/presetThree/presetThreeProps/presetThreeProactiveChatPaneControlProps.ts
@@ -13,7 +13,11 @@ export const presetThreeProactiveChatPaneControlProps: IProactiveChatPaneControl
     subtitleText: "Live chat support!",
 
     hideCloseButton: false,
-    closeButtonAriaLabel: "Close Button",
+    closeButtonProps: {
+        type: "icon",
+        iconName: "ChromeClose",
+        hideButtonTitle: true
+    },
 
     isBodyContainerHorizantal: false,
 

--- a/chat-components/src/components/proactivechatpane/interfaces/IProactiveChatPaneControlProps.ts
+++ b/chat-components/src/components/proactivechatpane/interfaces/IProactiveChatPaneControlProps.ts
@@ -1,3 +1,5 @@
+import { ICommandButtonControlProps } from "../../common/interfaces/ICommandButtonControlProps";
+
 export interface IProactiveChatPaneControlProps {
     id?: string;
     dir?: "ltr" | "rtl" | "auto";
@@ -11,7 +13,7 @@ export interface IProactiveChatPaneControlProps {
     subtitleText?: string;
 
     hideCloseButton?: boolean;
-    closeButtonAriaLabel?: string;
+    closeButtonProps?: ICommandButtonControlProps;
 
     isBodyContainerHorizantal?: boolean;
     


### PR DESCRIPTION
Currently header and proactive chat pane have different close button. Header uses fluent ui icon, but for proactive chat we provide the icon image.

With this change we replace proactive chat pane's close button with header's close button.

![proactivechatpane](https://user-images.githubusercontent.com/104658006/193352249-1f375e18-43bd-4ac1-9947-dfb42bee879f.png)
