### PR TITLE
Fix refresh for skipChatButtonRendering

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -53,3 +53,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Adding `typescript` sample
 - Adding support for customizing anchor tag color in webchat
 - Upgraded chat components in widget to replace proactive chat pane close button with header close button.
+- Fixed refreshing chat in popout mode and upgraded chat components in widget to fix footer icons.

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@fluentui/react": "^8.49.1",
-    "@microsoft/omnichannel-chat-components": "0.1.0-main.76f2e56",
+    "@microsoft/omnichannel-chat-components": "0.1.0-main.d40108a",
     "@microsoft/omnichannel-chat-sdk": "1.0.1-main.077d17c",
     "abort-controller-es5": "^2.0.1",
     "dompurify": "^2.3.4",

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -59,7 +59,7 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false) => {
+const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, params?: any) => {
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
@@ -73,7 +73,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | 
 
     //Initiate start chat
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
-    await initStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter);
+    await initStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, params);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -59,7 +59,7 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, params?: any) => {
+const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false) => {
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
@@ -73,7 +73,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | 
 
     //Initiate start chat
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
-    await initStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, params);
+    await initStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -187,10 +187,13 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                             eventName: BroadcastEvent.StartChatSkippingChatButtonRendering,
                         };
                         BroadcastService.postMessage(chatStartedSkippingChatButtonRendering);
-                        const optionalParams = (!isUndefinedOrEmpty(state.domainStates?.liveChatContext) && state.appStates.conversationState === ConversationState.Active) ?
-                            { liveChatContext: state.domainStates?.liveChatContext } :
-                            undefined;
-                        setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, undefined, undefined, optionalParams);
+                        if (!isUndefinedOrEmpty(state.domainStates?.liveChatContext)
+                            && state.appStates.conversationState === ConversationState.Active) {
+                            const optionalParams = { liveChatContext: state.domainStates?.liveChatContext };
+                            initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams);
+                        } else {
+                            setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, undefined, undefined);
+                        }
                     }
                 });
             }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -192,7 +192,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                             const optionalParams = { liveChatContext: state.domainStates?.liveChatContext };
                             initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams);
                         } else {
-                            setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, undefined, undefined);
+                            setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter);
                         }
                     }
                 });

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -187,7 +187,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                             eventName: BroadcastEvent.StartChatSkippingChatButtonRendering,
                         };
                         BroadcastService.postMessage(chatStartedSkippingChatButtonRendering);
-                        setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter);
+                        const optionalParams = (!isUndefinedOrEmpty(state.domainStates?.liveChatContext) && state.appStates.conversationState === ConversationState.Active) ?
+                            { liveChatContext: state.domainStates?.liveChatContext } :
+                            undefined;
+                        setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, undefined, undefined, optionalParams);
                     }
                 });
             }

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2163,10 +2163,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.1.1.tgz#2ca931aec33712746ee85df6aa43446f7b88edfd"
   integrity sha512-sJoHXWyEWfGOk0S5NP5zjMtH5vG/72Pezd6h4l0OpGWppvtXtuCrIM3O+oSDPkHsT7wH74X4bj5CSaKbONBn5w==
 
-"@microsoft/omnichannel-chat-components@0.1.0-main.76f2e56":
-  version "0.1.0-main.76f2e56"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-0.1.0-main.76f2e56.tgz#96435b897e002730dad0a216fa4611e9810fe724"
-  integrity sha512-Cfo+m9iqisM4fhtvcyVR6QiZRgcVmDtCS+E7R80ALESCsgEKhF5JVRh72ILnharmMA7L8cabweo86DvIKr08lA==
+"@microsoft/omnichannel-chat-components@0.1.0-main.d40108a":
+  version "0.1.0-main.d40108a"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-0.1.0-main.d40108a.tgz#59b5fbe1c2d2150eab4a6118ccd1a4f03c3e0441"
+  integrity sha512-WZUUe5r+OWzKtwrZE5WRaj04kbQmijxqOPB/mIpzkkaaPt591/uVo6AkcEmqoskvEEEux0r25KXh5Gf4s0/ffA==
   dependencies:
     "@fluentui/react" "^8.46.0"
     adaptivecards "^2.10.0"


### PR DESCRIPTION
- When skipChatButtonRendering prop is set to true and we refresh the chat, it starts a new chat instead of connecting to the same chat. This fixes this issue.
- Upgrading components