### PR TITLE
replace htmlelement with string as state variable

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -54,3 +54,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Adding support for customizing anchor tag color in webchat
 - Upgraded chat components in widget to replace proactive chat pane close button with header close button.
 - Fixed refreshing chat in popout mode and upgraded chat components in widget to fix footer icons.
+- Replaced HTMLElement with string in state variables.

--- a/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.tsx
+++ b/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.tsx
@@ -54,11 +54,11 @@ export const ConfirmationPaneStateful = (props: IConfirmationPaneStatefulParams)
                 Description: "Confirmation pane Cancel button clicked."
             });
             dispatch({ type: LiveChatWidgetActionType.SET_SHOW_CONFIRMATION, payload: false });
-            const previousFocused = state.appStates.previousElementOnFocusBeforeModalOpen;
+            const previousFocusedElementId = state.appStates.previousElementIdOnFocusBeforeModalOpen;
 
-            if (previousFocused) {
-                setFocusOnElement(previousFocused);
-                dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT, payload: null });
+            if (previousFocusedElementId) {
+                setFocusOnElement("#" + previousFocusedElementId);
+                dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT_ID, payload: null });
             } else {
                 setFocusOnSendBox();
             }

--- a/chat-widget/src/components/emailtranscriptpanestateful/EmailTranscriptPaneStateful.tsx
+++ b/chat-widget/src/components/emailtranscriptpanestateful/EmailTranscriptPaneStateful.tsx
@@ -26,13 +26,13 @@ export const EmailTranscriptPaneStateful = (props: IEmailTranscriptPaneProps) =>
     const [initialEmail, setInitialEmail] = useState("");
     const closeEmailTranscriptPane = () => {
         dispatch({ type: LiveChatWidgetActionType.SET_SHOW_EMAIL_TRANSCRIPT_PANE, payload: false });
-        const previousFocused = state.appStates.previousElementOnFocusBeforeModalOpen;
-        if (previousFocused) {
-            setFocusOnElement(previousFocused);
+        const previousFocusedElementId = state.appStates.previousElementIdOnFocusBeforeModalOpen;
+        if (previousFocusedElementId) {
+            setFocusOnElement("#" + previousFocusedElementId);
         } else {
             setFocusOnSendBox();
         }
-        dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT, payload: null });
+        dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT_ID, payload: null });
         setTabIndices(elements, initialTabIndexMap, true);
     };
 

--- a/chat-widget/src/components/footerstateful/FooterStateful.tsx
+++ b/chat-widget/src/components/footerstateful/FooterStateful.tsx
@@ -46,10 +46,9 @@ export const FooterStateful = (props: any) => {
         },
         onEmailTranscriptClick: () => {
             TelemetryHelper.logActionEvent(LogLevel.INFO, { Event: TelemetryEvent.EmailTranscriptButtonClicked, Description: "Email Transcript button clicked." });
-            const emailTranscriptButtonId = footerProps?.controlProps?.emailTranscriptButtonProps?.id ?? "oc-lcw-footer-emailtranscript-button";
-            const emailTranscriptButton: HTMLElement | null = document.getElementById(emailTranscriptButtonId);
-            if (emailTranscriptButton) {
-                dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT, payload: emailTranscriptButton });
+            const emailTranscriptButtonId = footerProps?.controlProps?.emailTranscriptButtonProps?.id ??  `${controlProps.id}-emailtranscript-button`;
+            if (emailTranscriptButtonId) {
+                dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT_ID, payload: emailTranscriptButtonId });
             }
             dispatch({ type: LiveChatWidgetActionType.SET_SHOW_EMAIL_TRANSCRIPT_PANE, payload: true });
         },

--- a/chat-widget/src/components/headerstateful/HeaderStateful.tsx
+++ b/chat-widget/src/components/headerstateful/HeaderStateful.tsx
@@ -42,7 +42,10 @@ export const HeaderStateful = (props: IHeaderStatefulParams) => {
                 const postMessageToOtherTabs = true;
                 await endChat(adapter, skipEndChatSDK, skipCloseChat, postMessageToOtherTabs);
             }
-            dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT, payload: document.getElementById(`${controlProps.id}-closebutton`) });
+            const closeButtonId = props.headerProps?.controlProps?.closeButtonProps?.id ?? `${controlProps.id}-close-button`;
+            if (closeButtonId) {
+                dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT_ID, payload: closeButtonId });
+            }
         },
         ...headerProps?.controlProps,
         hideTitle: state.appStates.conversationState === ConversationState.Loading || state.appStates.conversationState === ConversationState.PostchatLoading || headerProps?.controlProps?.hideTitle,

--- a/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
@@ -28,7 +28,7 @@ export interface ILiveChatWidgetContext {
     appStates: {
         conversationState: ConversationState; // The state that the conversation is currently in
         isMinimized: boolean; // true when chat button is visible & chat widget is hidden & chat is ongoing
-        previousElementOnFocusBeforeModalOpen: HTMLElement | null; // The previous element on focus before a modal opened. Focus will return to this element after the modal is closed by default
+        previousElementIdOnFocusBeforeModalOpen: string | null; // The previous element id on focus before a modal opened. Focus will return to this element after the modal is closed by default
         outsideOperatingHours: boolean; // true when chat session failed to start
         preChatResponseEmail: string; // The email from preChat survey response
         isAudioMuted: boolean | null; // true/false if the sound notification is on/off. Initial value is null, in such case it gets set to true if audio notification icon is set, otherwise it gets set to false

--- a/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
@@ -39,9 +39,9 @@ export enum LiveChatWidgetActionType {
 
     /*
         Parameters:
-        HTML element: The element that the control will return to after a popup/modal is closed
+        string or null: The element id that the control will return to after a popup/modal is closed
     */
-    SET_PREVIOUS_FOCUSED_ELEMENT,
+    SET_PREVIOUS_FOCUSED_ELEMENT_ID,
 
     /*
         Parameters:

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -33,7 +33,7 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         appStates: {
             conversationState: ConversationState.Closed,
             isMinimized: false,
-            previousElementOnFocusBeforeModalOpen: null,
+            previousElementIdOnFocusBeforeModalOpen: null,
             outsideOperatingHours: false,
             preChatResponseEmail: "",
             isAudioMuted: null,

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -93,12 +93,12 @@ export const createReducer = () => {
                     }
                 };
 
-            case LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT:
+            case LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT_ID:
                 return {
                     ...state,
                     appStates: {
                         ...state.appStates,
-                        previousElementOnFocusBeforeModalOpen: action.payload as HTMLElement
+                        previousElementIdOnFocusBeforeModalOpen: action.payload as string | null
                     }
                 };
 


### PR DESCRIPTION
Replaced previousElementOnFocusBeforeModalOpen state variable with previousElementIdOnFocusBeforeModalOpen. The reason is to not have HTMLElement type as state variable.