### PR TITLE
Users/hmargaryan/fix conversation state

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -55,3 +55,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Upgraded chat components in widget to replace proactive chat pane close button with header close button.
 - Fixed refreshing chat in popout mode and upgraded chat components in widget to fix footer icons.
 - Replaced HTMLElement with string in state variables.
+- Fixed conversation state for auth chat.

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -81,9 +81,11 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
     try {
         const authClientFunction = getAuthClientFunction(chatConfig);
         if (getAuthToken && authClientFunction) {
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
             // set auth token to chat sdk before start chat
             const authSuccess = await handleAuthentication(chatSDK, chatConfig, getAuthToken);
             if (!authSuccess) {
+                dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
                 return;
             }
         }


### PR DESCRIPTION
1) Currently when refreshing auth chat, if there is no auth token, it keeps the active state, even though start chat isn't called. Changing the state to show the chat button.

2) Adding loading pane, while it is getting auth token.