### PR TITLE
Fixing Oval chat button Icon for OutOfOffice Hours

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -65,3 +65,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Fixed multiple scrollbars in PostChat to display single scroll bar.
 - Fixed chat loading issue, Updating datamasking events
 - Added Customer Voice Form Event loggin for PostChat Survey (V1 Parity)
+- Fixed OutOfOffice Chat Button Icon appearance

--- a/chat-widget/src/components/chatbuttonstateful/common/styleProps/defaultOutOfOfficeChatButtonStyleProps.ts
+++ b/chat-widget/src/components/chatbuttonstateful/common/styleProps/defaultOutOfOfficeChatButtonStyleProps.ts
@@ -3,5 +3,8 @@ import { IChatButtonStyleProps } from "@microsoft/omnichannel-chat-components/li
 export const defaultOutOfOfficeChatButtonStyleProps: IChatButtonStyleProps = {
     iconStyleProps: {
         backgroundColor: "#000000"
+    },
+    subtitleStyleProps: {
+        margin: "0px 10px 0px 10px"
     }
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30007388/197255953-8bb35a21-09a0-4d0d-9668-ab5abe967ecf.png)

Fixing Bug: [V2][A11Y] OOH button style is off
