### PR TITLE
Clearing live chat context when error is raised

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -68,3 +68,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Removed isReconnectEnabled from props
 - Fixed OutOfOffice Chat Button Icon appearance
 - Adding support for customizing widget scroll bar
+- Clearing live chat context for raise error event

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -47,6 +47,7 @@ export enum BroadcastEvent {
     CloseChat = "CloseChat",
     InitiateEndChatOnBrowserUnload = "InitiateEndChatOnBrowserUnload",
     ClosePopoutWindow = "ClosePopoutWindow",
+    RaiseErrorEvent = "RaiseErrorEvent"
 }
 
 // Events being logged

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -324,6 +324,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_SIZE, payload: msg?.payload });
         });
 
+        // Remove from local storage and reset state
+        BroadcastService.getMessageByEventName(BroadcastEvent.RaiseErrorEvent).subscribe(() => {
+            dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONFIG, payload: undefined });
+            dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: undefined });
+            dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: undefined });
+            dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
+        });
+
         return () => {
             disposeTelemetryLoggers();
         };

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -324,7 +324,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_SIZE, payload: msg?.payload });
         });
 
-        // Remove from local storage and reset state
+        // Reset state variables
         BroadcastService.getMessageByEventName(BroadcastEvent.RaiseErrorEvent).subscribe(() => {
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONFIG, payload: undefined });
             dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: undefined });

--- a/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
@@ -212,4 +212,10 @@ export enum LiveChatWidgetActionType {
         any: Set widget instance id
     */
     SET_WIDGET_INSTANCE_ID,
+
+    /*
+        Parameters:
+        any: Set live chat config
+    */
+    SET_LIVE_CHAT_CONFIG,
 }

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -306,6 +306,16 @@ export const createReducer = () => {
                         widgetInstanceId: action.payload as string
                     }
                 };
+            
+            case LiveChatWidgetActionType.SET_LIVE_CHAT_CONFIG:
+                return {
+                    ...state,
+                    domainStates: {
+                        ...state.domainStates,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        liveChatConfig: action.payload as any
+                    }
+                };
 
             default:
                 return state;

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -137,6 +137,7 @@ Refer to the below table to understand different broadcast events raised during 
 | `CloseChat`                         |On SDK `closeChat` method call |
 | `InitiateEndChatOnBrowserUnload`      | End active chats on browser unload |
 | `ClosePopoutWindow`      | Event to close popout window  |
+| `RaiseErrorEvent`                 | On raising error events |
 
 ### Telemetry Events
 


### PR DESCRIPTION
Clearing live chat context, live chat config, custom context, chat token, when error event is raised