### PR TITLE
Refactoring input validation pane

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -69,4 +69,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Fixed OutOfOffice Chat Button Icon appearance
 - Adding support for customizing widget scroll bar
 - Clearing live chat context for raise error event
-- Refactoring input validation pane
+- Refactoring input validation pane and replacing keyDown event with keyUp

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -69,3 +69,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Fixed OutOfOffice Chat Button Icon appearance
 - Adding support for customizing widget scroll bar
 - Clearing live chat context for raise error event
+- Refactoring input validation pane

--- a/chat-components/src/components/inputvalidationpane/InputValidationPane.test.tsx
+++ b/chat-components/src/components/inputvalidationpane/InputValidationPane.test.tsx
@@ -220,14 +220,14 @@ describe("Input Validation Pane component", () => {
     });
 
     act(() => {
-        it("input validation pane input textfield key down", () => {
-            const handleInputKeyDown = jest.fn();
+        it("input validation pane input textfield key up", () => {
+            const handleInputKeyUp = jest.fn();
 
             const inputValidationPaneProps: IInputValidationPaneProps = {
                 ...defaultInputValidationPaneProps,
                 controlProps: {
                     ...defaultInputValidationPaneProps.controlProps,
-                    onSend: handleInputKeyDown,
+                    onSend: handleInputKeyUp,
                     checkInput: undefined
                 }
             };
@@ -236,10 +236,10 @@ describe("Input Validation Pane component", () => {
 
             const textfields = screen.getAllByRole("textbox");
             const input = textfields[0];
-            fireEvent.keyDown(input, {
+            fireEvent.keyUp(input, {
                 code: "Enter"
             });
-            expect(handleInputKeyDown).toHaveBeenCalledTimes(1);
+            expect(handleInputKeyUp).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/chat-components/src/components/inputvalidationpane/InputValidationPane.tsx
+++ b/chat-components/src/components/inputvalidationpane/InputValidationPane.tsx
@@ -1,6 +1,6 @@
 import { DefaultButton, PrimaryButton } from "@fluentui/react/lib/Button";
 import { IButtonStyles, ILabelStyles, IStackStyles, IStyle, ITextFieldStyles, Label, Stack, TextField } from "@fluentui/react";
-import React, {useEffect, useState} from "react";
+import React, {useCallback, useEffect, useState} from "react";
 
 import { BroadcastService } from "../../services/BroadcastService";
 import { ICustomEvent } from "../../interfaces/ICustomEvent";
@@ -30,21 +30,27 @@ function InputValidationPane(props: IInputValidationPaneProps) {
     const [isInvalidInput, setIsInvalidInput] = useState(false);
     const [isSendButtonEnabled, setIsSendButtonEnabled] = useState(false);
     
-    const isValidInput = () => {
-        return props.controlProps?.checkInput ? (inputValue && props.controlProps?.checkInput(inputValue)) : true;
-    };
+    const isValidInput = useCallback(() => {
+        if (!props.controlProps?.checkInput) {
+            return true;
+        }
+        if (!inputValue) {
+            return false;
+        }
+        return props.controlProps?.checkInput(inputValue);
+    }, [inputValue]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleInputChange = (e: any) => {
+    const handleInputChange = useCallback((e: any) => {
         setInputValue(e.target.value);
 
         e.target.value ? setIsSendButtonEnabled(props.controlProps?.enableSendButton || e.target.value !== "")
             : setIsSendButtonEnabled(props.controlProps?.enableSendButton ?? false);
 
         setIsInvalidInput(false);
-    };
+    }, []);
 
-    const send = (controlId: string, suffix: string) => {
+    const send = useCallback((controlId: string, suffix: string) => {
         if (props.controlProps?.onSend) {
             if (isValidInput()) {
                 const eventName = generateEventName(controlId, "on", suffix);
@@ -57,20 +63,20 @@ function InputValidationPane(props: IInputValidationPaneProps) {
                 setIsInvalidInput(true);
             }
         }
-    };
+    }, [inputValue]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleInputKeyDown = (e: any) => {
+    const handleInputKeyUp = useCallback((e: any) => {
         if (e.code === KeyCodes.ENTER) {
-            send(elementId + "-textField", "KeyDown");
+            send(elementId + "-textField", "KeyUp");
         }
-    };
+    }, [inputValue]);
 
-    const handleSendClick = () => {
+    const handleSendClick = useCallback(() => {
         send(elementId + "-sendbutton", "Click");
-    };
+    }, [inputValue]);
 
-    const cancel = (controlId: string, suffix: string) => {
+    const cancel = useCallback((controlId: string, suffix: string) => {
         if (props.controlProps?.onCancel) {
             setInputValue("");
             setIsInvalidInput(false);
@@ -81,18 +87,18 @@ function InputValidationPane(props: IInputValidationPaneProps) {
             BroadcastService.postMessage(customEvent);
             props.controlProps?.onCancel();
         }
-    };
+    }, []);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handleEscKeyDown = (e: any) => {
+    const handleEscKeyDown = useCallback((e: any) => {
         if (e.code === KeyCodes.ESCAPE) {
             cancel(elementId as string, "KeyDown");
         }
-    };
+    }, []);
 
-    const handleCancelClick = () => {
+    const handleCancelClick = useCallback(() => {
         cancel(elementId + "-cancelbutton", "Click");
-    };
+    }, []);
 
     useEffect(() => {
         setInputValue(props.controlProps?.inputInitialText ?? "");
@@ -229,7 +235,7 @@ function InputValidationPane(props: IInputValidationPaneProps) {
                             ariaLabel={props.controlProps?.inputAriaLabel || defaultInputValidationPaneControlProps.inputAriaLabel}
                             borderless={isInvalidInput}
                             onChange={handleInputChange}
-                            onKeyDown={handleInputKeyDown}
+                            onKeyUp={handleInputKeyUp}
                         />) }
 
                         { isInvalidInput && (decodeComponentString(props.componentOverrides?.invalidInputErrorMessage) ||


### PR DESCRIPTION
1) Used useCallback hook
2) Replaced keydown with keyup for input field, as keydown causes an issue later in the stitching layer by creating an extra keyup or keydown event on focused element. Here is what happens in the stitching layer:
Press Enter on the input field -> it closes email transcript pane and puts the focus on email transcript footer action -> it creates an extra keydown or keyup event on that focused element, which causes email transcript pane to show again.
