### PR TITLE
Allow to start new chat if localStorage state is stale, reconnect chat refactoring

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -69,3 +69,9 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Fixed OutOfOffice Chat Button Icon appearance
 - Adding support for customizing widget scroll bar
 - Clearing live chat context for raise error event
+- Renaming `skipChatButtonRendering` to `hideStartChatButton`
+- Refactoring reconnect functionality code
+- Fixing chat widget refresh bug showing reconnect pane
+- Supporting to start new chat if localStorage has stale Active state
+- Fixing end chat to gracefully if auth token has expired
+ 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -73,5 +73,5 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Refactoring reconnect functionality code
 - Fixing chat widget refresh bug showing reconnect pane
 - Supporting to start new chat if localStorage has stale Active state
-- Fixing end chat to gracefully if auth token has expired
+- Fixing end chat to gracefully complete if auth token has expired
  

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -212,6 +212,14 @@ export enum E2VVOptions{
     VoiceOnly = "192350002"
 }
 
+export enum LiveWorkItemState  {
+    Active = "Active",
+    Closed = "Closed",
+    Open = "Open",
+    Waiting = "Waiting",
+    WrapUp = "WrapUp"
+}
+
 export class TranscriptConstants {
     public static readonly ChatTranscriptsBodyColor = "#F5F5F5";
     public static readonly TranscriptMessageEmojiMessageType = "http://schema.skype.com/emoji";

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -206,6 +206,12 @@ export enum EnvironmentVersion {
     test = "test"
 }
 
+export enum E2VVOptions{
+    NoCalling = "192350000",
+    VideoAndVoiceCalling = "192350001",
+    VoiceOnly = "192350002"
+}
+
 export class TranscriptConstants {
     public static readonly ChatTranscriptsBodyColor = "#F5F5F5";
     public static readonly TranscriptMessageEmojiMessageType = "http://schema.skype.com/emoji";

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -132,6 +132,7 @@ export enum TelemetryEvent {
     GetConversationDetailsException = "GetConversationDetailsException",
     BrowserUnloadEventStarted = "BrowserUnloadEventStarted",
     GetAuthTokenCalled = "GetAuthTokenCalled",
+    GetAuthTokenFailed = "GetAuthTokenFailed",
     ReceivedNullOrEmptyToken = "ReceivedNullOrEmptyToken",
     CustomerVoiceResponsePageLoaded = "CustomerVoiceResponsePageLoaded",
     CustomerVoiceFormResponseSubmitted = "CustomerVoiceFormResponseSubmitted",

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -92,6 +92,7 @@ export enum TelemetryEvent {
     WebChatLoaded = "WebChatLoaded",
     LCWChatButtonClicked = "LCWChatButtonClicked",
     LCWChatButtonShow = "LCWChatButtonShow",
+    WidgetLoadStarted = "WidgetLoadStarted",
     WidgetLoadComplete = "WidgetLoadComplete",
     WidgetLoadFailed = "WidgetLoadFailed",
     StartChatMethodException = "StartChatMethodException",

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -37,7 +37,6 @@ export enum BroadcastEvent {
     HistoryMessageReceived = "HistoryMessageReceived",
     RedirectPageRequest = "RedirectPageRequest",
     StartChat = "StartChat",
-    StartChatSkippingChatButtonRendering = "StartChatSkippingChatButtonRendering",
     StartUnauthenticatedReconnectChat = "StartUnauthenticatedReconnectChat",
     InitiateEndChat = "InitiateEndChat",
     SetCustomContext = "SetCustomContext",

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.stories.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.stories.tsx
@@ -759,7 +759,7 @@ const liveChatWidgetPopoutStyleProps: ILiveChatWidgetProps = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     chatSDK: new MockChatSDK() as any,
     controlProps: {
-        skipChatButtonRendering: true,
+        hideStartChatButton: true,
         hideHeader: true
     },
     styleProps: {

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -555,7 +555,7 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
         hideProactiveChatPane: false,
         hideReconnectChatPane: false,
         hideWebChatContainer: false,
-        skipChatButtonRendering: false
+        hideStartChatButton: false
     },
     directLine: new MockAdapter(),
     downloadTranscriptProps: {

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -79,6 +79,7 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdapter: an
     dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
+    dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
 
     if (!skipCloseChat) {
         try {

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -1,103 +1,95 @@
 import "regenerator-runtime/runtime";
-
 import ChatConfig from "@microsoft/omnichannel-chat-sdk/lib/core/ChatConfig";
-import AuthSettings from "@microsoft/omnichannel-chat-sdk/lib/core/AuthSettings";
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { ConversationState } from "../../../contexts/common/ConversationState";
 import { Dispatch } from "react";
 import { ICustomEvent } from "@microsoft/omnichannel-chat-components/lib/types/interfaces/ICustomEvent";
 import { ILiveChatWidgetAction } from "../../../contexts/common/ILiveChatWidgetAction";
-import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
 import { IReconnectChatContext } from "../../reconnectchatpanestateful/interfaces/IReconnectChatContext";
 import { IReconnectChatOptionalParams } from "../../reconnectchatpanestateful/interfaces/IReconnectChatOptionalParams";
 import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { handleAuthentication, removeAuthTokenProvider } from "./authHelper";
+import { isNullOrEmptyString, isNullOrUndefined } from "../../../common/utils";
 
-const isReconnectEnabled = (chatConfig: ChatConfig | undefined) => {
-    return chatConfig &&
-    chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect &&
-    (chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect === "true" || chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect === true);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any) => {
+
+    if (!isReconnectEnabled(props.chatConfig)) return;
+    
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const isAuthenticatedChat = (props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
+
+    // Get chat reconnect context
+    const reconnectChatContext: IReconnectChatContext = await getChatReconnectContext(chatSDK, props.chatConfig, props, isAuthenticatedChat);
+
+    if (hasReconnectId(reconnectChatContext)) {
+        //Redirect if enabled
+        if (reconnectChatContext.redirectURL) {
+            redirectPage(reconnectChatContext.redirectURL, props.reconnectChatPaneProps?.redirectInSameWindow);
+            return;
+        }
+
+        //if reconnect id is provided in props, don't show reconnect pane
+        if (props.reconnectChatPaneProps?.reconnectId && !isNullOrEmptyString(props.reconnectChatPaneProps?.reconnectId)) {
+            const reconnectChatContext: IReconnectChatContext = await getChatReconnectContext(chatSDK, props.chatConfig, props, isAuthenticatedChat);
+            await setReconnectIdAndStartChat(isAuthenticatedChat, chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, reconnectChatContext.reconnectId ?? "", initStartChat);
+            return;
+        }
+
+        //show reconnect pane
+        dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: reconnectChatContext.reconnectId ?? "" });
+        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.ReconnectChat });
+        return;
+    }
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getChatReconnectContext = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, reconnectId?: string) => {
-    if (isReconnectEnabled(chatConfig)) {
-        try {
-            if (reconnectId) {
-                const chatReconnectOptionalParams: IReconnectChatOptionalParams = {
-                    reconnectId: reconnectId
-                };
-                return await chatSDK?.getChatReconnectContext(chatReconnectOptionalParams);
-            } else {
-                // set auth token to chat sdk to get reconnectId for auth chat
-                await handleAuthentication(chatSDK, chatConfig, getAuthToken);
-                const reconnectChatContext = await chatSDK?.getChatReconnectContext();
-                // remove auth token after reconnectId is fetched
-                // this will be reset later at start chat
-                removeAuthTokenProvider(chatSDK);
-                return reconnectChatContext;
+const getChatReconnectContext = async (chatSDK: any, chatConfig: ChatConfig, props: any, isAuthenticatedChat: boolean) => {
+    try {
+        const chatReconnectOptionalParams: IReconnectChatOptionalParams = {
+            reconnectId: props.reconnectChatPaneProps?.reconnectId
+        };
+        if (isAuthenticatedChat) {
+            // Get auth token for for getting chat reconnect context
+            await handleAuthentication(chatSDK, chatConfig, props.getAuthToken);
+        }
+        const reconnectChatContext = await chatSDK?.getChatReconnectContext(chatReconnectOptionalParams);
+        if (isAuthenticatedChat) {
+            // remove auth token after reconnectId is fetched
+            // this will be reset later at start chat
+            removeAuthTokenProvider(chatSDK);
+        }
+        return reconnectChatContext;
+    }
+    catch (error) {
+        TelemetryHelper.logSDKEvent(LogLevel.ERROR, {
+            Event: TelemetryEvent.GetChatReconnectContextSDKCallFailed,
+            ExceptionDetails: {
+                exception: error
             }
-        } catch (ex) {
-            TelemetryHelper.logSDKEvent(LogLevel.ERROR, {
-                Event: TelemetryEvent.GetChatReconnectContextSDKCallFailed,
-                ExceptionDetails: {
-                    exception: ex
-                }
-            });
-        }
+        });
     }
-    return null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getReconnectIdForAuthenticatedChat = async (props: ILiveChatWidgetProps, chatSDK: any) => {
-    let authClientFunction = undefined;
-    if (props.chatConfig?.LiveChatConfigAuthSettings) {
-        authClientFunction = (props.chatConfig?.LiveChatConfigAuthSettings as AuthSettings)?.msdyn_javascriptclientfunction ?? undefined;
-    }
-    if (isReconnectEnabled(props.chatConfig)
-        && authClientFunction
-    // TODO: Implement this after storage is in place
-    /* && !isLoadWithState() */) {
-        const previousActiveSessionResponse: IReconnectChatContext = await getChatReconnectContext(chatSDK, props.chatConfig, props.getAuthToken);
-        if (previousActiveSessionResponse && previousActiveSessionResponse.reconnectId) {
-            return previousActiveSessionResponse.reconnectId;
-        }
-    }
-    return undefined;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const handleUnauthenticatedReconnectChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, reconnectId: string, initStartChat: any, redirectInSameWindow: boolean | undefined) => {
-    const reconnectAvailabilityResponse: IReconnectChatContext = await getChatReconnectContext(chatSDK, chatConfig, getAuthToken, reconnectId);
-    if (shouldRedirectOrStartNewChat(reconnectAvailabilityResponse)) {
-        await redirectOrStartNewChat(reconnectAvailabilityResponse, chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, initStartChat, redirectInSameWindow);
+const setReconnectIdAndStartChat = async (isAuthenticatedChat: boolean, chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, reconnectId: string, initStartChat: any) => {
+    if (isAuthenticatedChat) {
+        // Get auth token for for getting chat reconnect context
+        await handleAuthentication(chatSDK, chatConfig, getAuthToken);
     } else {
-        await setReconnectIdAndStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, reconnectId, initStartChat);
+        const startUnauthenticatedReconnectChat: ICustomEvent = {
+            eventName: BroadcastEvent.StartUnauthenticatedReconnectChat,
+        };
+        BroadcastService.postMessage(startUnauthenticatedReconnectChat);
     }
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const startUnauthenticatedReconnectChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, reconnectId: string, initStartChat: any) => {
-    const reconnectAvailabilityResponse: IReconnectChatContext = await getChatReconnectContext(chatSDK, chatConfig, getAuthToken, reconnectId);
-    if (!shouldRedirectOrStartNewChat(reconnectAvailabilityResponse)) {
-        await setReconnectIdAndStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, reconnectId, initStartChat);
-    }
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setReconnectIdAndStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, reconnectId: string, initStartChat: any) => {
-    const startUnauthenticatedReconnectChat: ICustomEvent = {
-        eventName: BroadcastEvent.StartUnauthenticatedReconnectChat,
-    };
-    BroadcastService.postMessage(startUnauthenticatedReconnectChat);
     const optionalParams = { reconnectId: reconnectId };
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: reconnectId });
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
     await initStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, optionalParams);
 };
+
 
 const redirectPage = (redirectURL: string, redirectInSameWindow: boolean | undefined) => {
     const redirectPageRequest: ICustomEvent = {
@@ -112,43 +104,14 @@ const redirectPage = (redirectURL: string, redirectInSameWindow: boolean | undef
     }
 };
 
-const shouldRedirectOrStartNewChat = (reconnectAvailabilityResponse: IReconnectChatContext) => {
-    return reconnectAvailabilityResponse && !reconnectAvailabilityResponse.reconnectId;
+const isReconnectEnabled = (chatConfig: ChatConfig | undefined) => {
+    return chatConfig &&
+        chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect &&
+        (chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect === "true" || chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect === true);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const startNewChatEmptyRedirectionUrl = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any) => {
-    const startUnauthenticatedReconnectChat: ICustomEvent = {
-        eventName: BroadcastEvent.StartUnauthenticatedReconnectChat,
-    };
-    BroadcastService.postMessage(startUnauthenticatedReconnectChat);
-    // Getting PreChat Survey Context
-    const parseToJson = false;
-    const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
-    if (preChatSurveyResponse) {
-        dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
-        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
-    } else {
-        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
-        await initStartChat(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter);
-    }
+const hasReconnectId = (reconnectAvailabilityResponse: IReconnectChatContext) => {
+    return reconnectAvailabilityResponse && !isNullOrUndefined(reconnectAvailabilityResponse.reconnectId);
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const handleRedirectUnauthenticatedReconnectChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, reconnectId: string, redirectInSameWindow: boolean | undefined) => {
-    const reconnectAvailabilityResponse: IReconnectChatContext = await getChatReconnectContext(chatSDK, chatConfig, getAuthToken, reconnectId);
-    if (shouldRedirectOrStartNewChat(reconnectAvailabilityResponse)) {
-        await redirectOrStartNewChat(reconnectAvailabilityResponse, chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, initStartChat, redirectInSameWindow);
-    }
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const redirectOrStartNewChat = async (reconnectAvailabilityResponse: IReconnectChatContext, chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, redirectInSameWindow: boolean | undefined) => {
-    if (reconnectAvailabilityResponse.redirectURL) {
-        redirectPage(reconnectAvailabilityResponse.redirectURL, redirectInSameWindow);
-    } else {
-        await startNewChatEmptyRedirectionUrl(chatSDK, chatConfig, getAuthToken, dispatch, setAdapter, initStartChat);
-    }
-};
-
-export { isReconnectEnabled, getChatReconnectContext, getReconnectIdForAuthenticatedChat, handleUnauthenticatedReconnectChat, startUnauthenticatedReconnectChat, handleRedirectUnauthenticatedReconnectChat };
+export { handleChatReconnect, isReconnectEnabled, getChatReconnectContext };

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -12,12 +12,13 @@ import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidge
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { handleAuthentication, removeAuthTokenProvider } from "./authHelper";
 import { isNullOrEmptyString, isNullOrUndefined } from "../../../common/utils";
+import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any) => {
+const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, state: ILiveChatWidgetContext) => {
 
     if (!isReconnectEnabled(props.chatConfig)) return;
-    
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = (props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
 
@@ -39,6 +40,7 @@ const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<
         }
 
         //show reconnect pane
+        state.appStates.conversationState = ConversationState.ReconnectChat;
         dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: reconnectChatContext.reconnectId ?? "" });
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.ReconnectChat });
         return;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -36,7 +36,7 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
         return;
     }
 
-    await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat);
+    await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
 
     // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
     if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
@@ -52,7 +52,16 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false) => {
+const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
+    //Handle reconnect scenario
+    if (state) {
+        await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+        // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
+        if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
+            return;
+        }
+    }
+
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
@@ -72,7 +81,6 @@ const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, params?: any, persistedState?: any) => {
     try {
-        console.log("Starting chat");
         const authClientFunction = getAuthClientFunction(chatConfig);
         if (getAuthToken && authClientFunction) {
             // set auth token to chat sdk before start chat
@@ -106,7 +114,6 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
             // Set custom context params
             setCustomContextParams(chatSDK);
             optionalParams = Object.assign({}, params, optionalParams);
-            console.log("optional param:" + JSON.stringify(optionalParams));
             await chatSDK.startChat(optionalParams);
             isStartChatSuccessful = true;
         } catch (error) {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -81,6 +81,14 @@ const setPreChatAndInitiateChat = async (chatSDK: any, chatConfig: ChatConfig | 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, getAuthToken: ((authClientFunction?: string) => Promise<string | null>) | undefined, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, params?: any, persistedState?: any) => {
     try {
+        //Start widget load timer
+        TelemetryTimers.WidgetLoadTimer = createTimer();
+
+        TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
+            Event: TelemetryEvent.WidgetLoadStarted,
+            Description: "Widget loading started",
+        });
+
         const authClientFunction = getAuthClientFunction(chatConfig);
         if (getAuthToken && authClientFunction) {
             // set auth token to chat sdk before start chat
@@ -104,9 +112,6 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
         }
 
         try {
-            //Start widget load timer
-            TelemetryTimers.WidgetLoadTimer = createTimer();
-
             TelemetryHelper.logSDKEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.StartChatSDKCall
             });
@@ -140,7 +145,7 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
 
         if (persistedState) {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_STATE, payload: persistedState });
-            await setPostChatContextAndLoadSurvey(chatSDK, dispatch, true);
+            setPostChatContextAndLoadSurvey(chatSDK, dispatch, true);
             return;
         }
 

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -172,7 +172,7 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
             return;
         }
-        // Show the loading pane in other cases for failure, this will help for both skipchatbuttonrending case
+        // Show the loading pane in other cases for failure, this will help for both hideStartChatButton case
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
     } finally {
         optionalParams = {};
@@ -183,7 +183,7 @@ const initStartChat = async (chatSDK: any, chatConfig: ChatConfig | undefined, g
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const canConnectToExistingChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any) => {
     // By pass this function in case of popout chat
-    if (state.appStates.skipChatButtonRendering === true) {
+    if (state.appStates.hideStartChatButton === true) {
         return false;
     }
 
@@ -241,6 +241,8 @@ const checkIfConversationStillValid = async (chatSDK: any, props: any, requestId
             }
         }
     }
+
+    //Preserve old requestId
     const oldRequestId = chatSDK.requestId;
     try {
         chatSDK.requestId = requestId;

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetControlProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetControlProps.ts
@@ -13,6 +13,6 @@ export interface ILiveChatWidgetControlProps {
     hideProactiveChatPane?: boolean;
     hideReconnectChatPane?: boolean;
     hideWebChatContainer?: boolean;
-    skipChatButtonRendering?: boolean;
+    hideStartChatButton?: boolean;
     widgetInstanceId?: string | undefined;
 }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -97,16 +97,18 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     let optionalParams: any;
     let activeCachedChatExist = false;
 
-    if (!isUndefinedOrEmpty(state.appStates?.reconnectId)) {
-        activeCachedChatExist = true;
-        optionalParams = { reconnectId: state.appStates.reconnectId };
-    } else if (!isUndefinedOrEmpty(state.domainStates?.liveChatContext)) {
-        activeCachedChatExist = true;
-        optionalParams = { liveChatContext: state.domainStates?.liveChatContext };
-    } else {
-        activeCachedChatExist = false;
-        optionalParams = undefined;
-    }
+    const setOptionalParams = () => {
+        if (!isUndefinedOrEmpty(state.appStates?.reconnectId)) {
+            activeCachedChatExist = true;
+            optionalParams = { reconnectId: state.appStates.reconnectId };
+        } else if (!isUndefinedOrEmpty(state.domainStates?.liveChatContext)) {
+            activeCachedChatExist = true;
+            optionalParams = { liveChatContext: state.domainStates?.liveChatContext };
+        } else {
+            activeCachedChatExist = false;
+            optionalParams = undefined;
+        }
+    };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const startChat = async (props: any, localState?: any) => {
@@ -129,7 +131,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         if (isChatValid === false) {
             if (localState) {
-                await setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, undefined, undefined, localState, props);
+                await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, undefined, undefined, localState, props);
                 return;
             } else {
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
@@ -168,6 +170,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         // Initialize global dir
         const globalDir = props.controlProps?.dir ?? getLocaleDirection(props.chatConfig?.ChatWidgetLanguage?.msdyn_localeid);
         dispatch({ type: LiveChatWidgetActionType.SET_GLOBAL_DIR, payload: globalDir });
+
+        setOptionalParams();
 
         // Unauth chat
         if (state.appStates.hideStartChatButton === false) {

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -64,6 +64,7 @@ import { registerBroadcastServiceForLocalStorage } from "../../../common/storage
 import { defaultClientDataStoreProvider } from "../../../common/storage/default/defaultClientDataStoreProvider";
 import { IScrollBarProps } from "../interfaces/IScrollBarProps";
 import { defaultScrollBarProps } from "../common/defaultProps/defaultScrollBarProps";
+import { E2VVOptions } from "../../../common/Constants";
 
 export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
@@ -156,10 +157,13 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         if (props.controlProps?.widgetInstanceId && !isNullOrEmptyString(props.controlProps?.widgetInstanceId)) {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_INSTANCE_ID, payload: props.controlProps?.widgetInstanceId });
         }
-        initCallingSdk(chatSDK, setVoiceVideoCallingSDK)
-            .then((sdkCreated: boolean) => {
-                sdkCreated && dispatch({ type: LiveChatWidgetActionType.SET_E2VV_ENABLED, payload: true });
-            });
+
+        if (props.chatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_callingoptions !== E2VVOptions.NoCalling) {
+            initCallingSdk(chatSDK, setVoiceVideoCallingSDK)
+                .then((sdkCreated: boolean) => {
+                    sdkCreated && dispatch({ type: LiveChatWidgetActionType.SET_E2VV_ENABLED, payload: true });
+                });
+        }
 
         // Initialize global dir
         const globalDir = props.controlProps?.dir ?? getLocaleDirection(props.chatConfig?.ChatWidgetLanguage?.msdyn_localeid);

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -129,7 +129,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         if (isChatValid === false) {
             if (localState) {
-                await setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter);
+                await setPreChatAndInitiateChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, undefined, undefined, localState, props);
                 return;
             } else {
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -95,17 +95,15 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let optionalParams: any;
     let activeCachedChatExist = false;
-    let canReconnectChat = false;
 
     if (!isUndefinedOrEmpty(state.appStates?.reconnectId)) {
-        canReconnectChat = true;
+        activeCachedChatExist = true;
         optionalParams = { reconnectId: state.appStates.reconnectId };
     } else if (!isUndefinedOrEmpty(state.domainStates?.liveChatContext)) {
         activeCachedChatExist = true;
         optionalParams = { liveChatContext: state.domainStates?.liveChatContext };
     } else {
         activeCachedChatExist = false;
-        canReconnectChat = false;
         optionalParams = undefined;
     }
 
@@ -113,13 +111,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const startChat = async (props: any, localState?: any) => {
         let isChatValid = false;
 
-        //Start a chat from cache
-        if (activeCachedChatExist === true && canReconnectChat === false) {
+        //Start a chat from cache/reconnectid
+        if (activeCachedChatExist === true) {
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
             if (localState) {
                 localState.appStates.conversationState = ConversationState.Loading;
             }
 
+            //Check if conversation state is not in wrapup or closed state
             isChatValid = await checkIfConversationStillValid(chatSDK, props, state.domainStates?.liveChatContext?.requestId);
             if (isChatValid === true) {
                 await initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams);

--- a/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
@@ -70,7 +70,7 @@ export const PreChatSurveyPaneStateful = (props: IPreChatSurveyPaneStatefulParam
                 if (persistedState &&
                     !isUndefinedOrEmpty(persistedState?.domainStates?.liveChatContext) &&
                     persistedState?.appStates?.conversationState === ConversationState.Active &&
-                    !state.appStates.skipChatButtonRendering) {
+                    state.appStates.hideStartChatButton === false) {
                     optionalParams = { liveChatContext: persistedState?.domainStates?.liveChatContext };
 
                     await initStartChat(optionalParams, persistedState);

--- a/chat-widget/src/components/reconnectchatpanestateful/ReconnectChatPaneStateful.tsx
+++ b/chat-widget/src/components/reconnectchatpanestateful/ReconnectChatPaneStateful.tsx
@@ -22,9 +22,10 @@ export const ReconnectChatPaneStateful = (props: IReconnectChatPaneStatefulParam
     const startChat = async (continueChat: boolean) => {
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
         if (continueChat && state.appStates.reconnectId) {
-            const optionalParams = {reconnectId: state.appStates.reconnectId};
+            const optionalParams = { reconnectId: state.appStates.reconnectId };
             await initStartChat(optionalParams);
         } else {
+            dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
             const parseToJson = false;
             const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
             if (preChatSurveyResponse) {
@@ -68,7 +69,7 @@ export const ReconnectChatPaneStateful = (props: IReconnectChatPaneStatefulParam
         setFocusOnElement(document.getElementById(controlProps.id as string) as HTMLElement);
         TelemetryHelper.logLoadingEvent(LogLevel.INFO, { Event: TelemetryEvent.ReconnectChatPaneLoaded });
     }, []);
-    
+
     return (
         <ReconnectChatPane
             componentOverrides={reconnectChatProps?.componentOverrides}

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
@@ -27,7 +27,7 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
         return action;
     }
 
-    let isRuleMatched = false;
+    // let isRuleMatched = false;
     for (const ruleId of Object.keys(regexCollection)) {
         const item = regexCollection[ruleId];
         if (item) {
@@ -42,7 +42,6 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
                         Event: TelemetryEvent.DataMaskingRuleApplied,
                         Description: `Data Masking Rule Id: ${ruleId} applied.`
                     });
-                    isRuleMatched = true;
                 }
             } catch (err) {
                 TelemetryHelper.logActionEvent(LogLevel.ERROR, {
@@ -53,10 +52,6 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
                     }
                 });
             }
-        }
-        // Exit if rule matched
-        if (isRuleMatched === true) {
-            break;
         }
     }
 

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
@@ -27,7 +27,7 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
         return action;
     }
 
-    // let isRuleMatched = false;
+    let isRuleMatched = false;
     for (const ruleId of Object.keys(regexCollection)) {
         const item = regexCollection[ruleId];
         if (item) {
@@ -42,6 +42,7 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
                         Event: TelemetryEvent.DataMaskingRuleApplied,
                         Description: `Data Masking Rule Id: ${ruleId} applied.`
                     });
+                    isRuleMatched = true;
                 }
             } catch (err) {
                 TelemetryHelper.logActionEvent(LogLevel.ERROR, {
@@ -52,6 +53,11 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
                     }
                 });
             }
+        }
+
+        // Exit if rule matched
+        if (isRuleMatched === true) {
+            break;
         }
     }
 

--- a/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
@@ -33,7 +33,7 @@ export interface ILiveChatWidgetContext {
         preChatResponseEmail: string; // The email from preChat survey response
         isAudioMuted: boolean | null; // true/false if the sound notification is on/off. Initial value is null, in such case it gets set to true if audio notification icon is set, otherwise it gets set to false
         newMessage: boolean; // new message state
-        skipChatButtonRendering: boolean; // true if we want to open popout chat
+        hideStartChatButton: boolean; // true if we want to open popout chat
         reconnectId: string | undefined; // used to reconnect to previous chat if one exists
         proactiveChatStates: {
             proactiveChatBodyTitle: string; // proactive chat body title

--- a/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
@@ -144,9 +144,9 @@ export enum LiveChatWidgetActionType {
 
     /*
         Parameters:
-        true/false: Decides whether to skip the chat button rendering
+        true/false: Decides whether to show the start chat button
     */
-    SET_SKIP_CHAT_BUTTON_RENDERING,
+    SET_START_CHAT_BUTTON_DISPLAY,
 
     /*
         Parameters:

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -16,7 +16,7 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
     if (!isNullOrUndefined(initialState)) {
         return JSON.parse(initialState);
     }
-    
+
     const LiveChatWidgetContextInitialState: ILiveChatWidgetContext = {
         domainStates: {
             liveChatConfig: props.chatConfig,
@@ -41,7 +41,7 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
             preChatResponseEmail: "",
             isAudioMuted: null,
             newMessage: false,
-            skipChatButtonRendering: false,
+            hideStartChatButton: false,
             reconnectId: undefined,
             proactiveChatStates: {
                 proactiveChatBodyTitle: "",

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -6,14 +6,17 @@ import { getWidgetCacheId, isNullOrUndefined } from "../../common/utils";
 import { defaultClientDataStoreProvider } from "../../common/storage/default/defaultClientDataStoreProvider";
 
 export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps) => {
+
     const widgetCacheId = getWidgetCacheId(props?.chatSDK?.omnichannelConfig?.orgId,
         props?.chatSDK?.omnichannelConfig?.widgetId,
         props?.controlProps?.widgetInstanceId ?? "");
+
     const initialState = defaultClientDataStoreProvider().getData(widgetCacheId, "localStorage");
+
     if (!isNullOrUndefined(initialState)) {
         return JSON.parse(initialState);
     }
-
+    
     const LiveChatWidgetContextInitialState: ILiveChatWidgetContext = {
         domainStates: {
             liveChatConfig: props.chatConfig,

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -216,12 +216,12 @@ export const createReducer = () => {
                         e2vvEnabled: action.payload as boolean
                     }
                 };
-            case LiveChatWidgetActionType.SET_SKIP_CHAT_BUTTON_RENDERING:
+            case LiveChatWidgetActionType.SET_START_CHAT_BUTTON_DISPLAY:
                 return {
                     ...state,
                     appStates: {
                         ...state.appStates,
-                        skipChatButtonRendering: action.payload as boolean
+                        hideStartChatButton: action.payload as boolean
                     }
                 };
             case LiveChatWidgetActionType.SET_PROACTIVE_CHAT_PARAMS:

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -4,7 +4,7 @@ import { ILiveChatWidgetContext } from "../contexts/common/ILiveChatWidgetContex
 export const shouldShowChatButton = (state: ILiveChatWidgetContext) => {
     return (state.appStates.isMinimized ||
         (state.appStates.conversationState === ConversationState.Closed)) 
-        && state.appStates.skipChatButtonRendering == false; // Do not show chat button in case of popout
+        && state.appStates.hideStartChatButton === false; // Do not show chat button in case of popout
 };
 
 export const shouldShowProactiveChatPane = (state: ILiveChatWidgetContext) => {

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -2,12 +2,12 @@
 
 ### Pop-Out Chat
 
-The chat can be enabled in a pop-out window with the help of the prop "skipChatButtonRendering". When this is turned on, the button will be automatically clicked on widget load. See the below chat widget example:
+The chat can be enabled in a pop-out window with the help of the prop "hideStartChatButton". When this is turned on, the button will be automatically clicked on widget load. See the below chat widget example:
 
 ```js
 liveChatWidgetProps = {
     controlProps: {
-        skipChatButtonRendering: true
+        hideStartChatButton: true
     }
 };
 

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -208,6 +208,7 @@ Refer to the below table to understand different critical telemetry events raise
 | `SuppressBotMagicCodeSucceeded` | On sending magic code behind the scenes succeeded |
 | `SuppressBotMagicCodeFailed` | On sending magic code behind the scenes failed |
 | `GetAuthTokenCalled` | On getting auth token |
+| `GetAuthTokenFailed` | On getting auth token failed |
 | `ReceivedNullOrEmptyToken` | On receiving null or empty auth token |
 
 #### Calling Events

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -147,6 +147,7 @@ Refer to the below table to understand different critical telemetry events raise
 
 | Event Name | Scenario |
 | -------- | -------- |
+| `WidgetLoadStarted`     |On Chat Widget load started |
 | `WebChatLoaded`     | On `WebChatContainer` load complete |
 | `WidgetLoadComplete`     |On Chat Widget load complete |
 | `WidgetLoadFailed`     |On Chat Widget load failure |
@@ -165,6 +166,7 @@ Refer to the below table to understand different critical telemetry events raise
 | `CustomerVoiceResponsePageLoaded` | On survey page load complete|
 | `CustomerVoiceFormResponseSubmitted` | On survey submitted |
 | `CustomerVoiceFormResponseError` | On survey response error|
+
 #### Action Events
 
 | Event Name| Scenario |
@@ -187,11 +189,11 @@ Refer to the below table to understand different critical telemetry events raise
 |`AverageWaitTimeMessageRecieved`|On Average Wait Time system message Received|
 |`QueuePositionMessageRecieved`|On Queue Position system message Received|
 |`IC3ThreadUpdateEventReceived`|On `IC3 ThreadUpdateEvent` Received|
-| `ConversationEndedThreadEventReceived`     |On Conversation ended by agent side or by timeout |
-| `InvalidConfiguration`     |On Invalid data masking regex rule collection |
-| `DataMaskingRuleApplied`     |On data masking regex rule applied |
-| `DataMaskingRuleApplyFailed`     |On data masking regex rule failed to apply |
-| `EmailTranscriptSent`     |On transcript sent to email successfully |
+|`ConversationEndedThreadEventReceived`     |On Conversation ended by agent side or by timeout |
+|`InvalidConfiguration`     |On Invalid data masking regex rule collection |
+|`DataMaskingRuleApplied`     |On data masking regex rule applied |
+|`DataMaskingRuleApplyFailed`     |On data masking regex rule failed to apply |
+|`EmailTranscriptSent`     |On transcript sent to email successfully |
 |`EmailTranscriptFailed`|On transcript sent to email failure|
 |`EmailTranscriptButtonClicked`|On Email Transcript footer button clicked|
 |`EmailTranscriptCancelButtonClicked`|On Email Transcript Pane Cancel button clicked|
@@ -206,26 +208,26 @@ Refer to the below table to understand different critical telemetry events raise
 |`MessageSent`|On Message Sent|
 |`MessageReceived`|On Message Received|
 |`CustomContextReceived`|On Custom Context Received|
-| `SuppressBotMagicCodeSucceeded` | On sending magic code behind the scenes succeeded |
-| `SuppressBotMagicCodeFailed` | On sending magic code behind the scenes failed |
-| `GetAuthTokenCalled` | On getting auth token |
-| `GetAuthTokenFailed` | On getting auth token failed |
-| `ReceivedNullOrEmptyToken` | On receiving null or empty auth token |
+|`SuppressBotMagicCodeSucceeded` | On sending magic code behind the scenes succeeded |
+|`SuppressBotMagicCodeFailed` | On sending magic code behind the scenes failed |
+|`GetAuthTokenCalled` | On getting auth token |
+|`GetAuthTokenFailed` | On getting auth token failed |
+|`ReceivedNullOrEmptyToken` | On receiving null or empty auth token |
 
 #### Calling Events
 
 | Event Name | Scenario |
 | -------- |-------- |
-| `VideoCallAcceptButtonClick`      |On accepting call with video on |
-| `CallAdded`     |      On receiving incoming call |
-| `LocalVideoStreamAdded`     |      On local video stream added |
-| `LocalVideoStreamRemoved`     |      On local video stream removed |
-| `RemoteVideoStreamAdded`     |      On remote video stream added |
-| `RemoteVideoStreamRemoved`     |      On remote video stream removed |
-| `CallDisconnected`     |      On call disconnected successfully  |
-| `IncomingCallEnded`           |On incoming call reject button clicked |
-| `VoiceVideoSdkInitialize`     |      On video and voice calling SDK initialization |
-| `VoiceVideoSdkInitializeException`           |On exception while video and voice calling SDK initialization |
+|`VideoCallAcceptButtonClick`      |On accepting call with video on |
+|`CallAdded`     |      On receiving incoming call |
+|`LocalVideoStreamAdded`     |      On local video stream added |
+|`LocalVideoStreamRemoved`     |      On local video stream removed |
+|`RemoteVideoStreamAdded`     |      On remote video stream added |
+|`RemoteVideoStreamRemoved`     |      On remote video stream removed |
+|`CallDisconnected`     |      On call disconnected successfully  |
+|`IncomingCallEnded`           |On incoming call reject button clicked |
+|`VoiceVideoSdkInitialize`     |      On video and voice calling SDK initialization |
+|`VoiceVideoSdkInitializeException`           |On exception while video and voice calling SDK initialization |
 |`VoiceVideoAcceptCallException`|On failed to accept call without video|
 |`VoiceVideoAcceptCallWithVideoException`|On failed to accept call with video|
 |`VoiceCallAcceptButtonClick`|On accepting incoming call without video|


### PR DESCRIPTION
Fixes includes:
1. Allow to start a new chat if the localStorage chat state is Active, but ended by Agent already. Fixed by rechecking conversation state is not in Wrapup or Closed
2. Refactored the reconnect chat code for simplicity and readable
3. Renamed the `skipChatButtonRendering` to `hideStartChatButton` for simplicity
4. Fixed the bug showing reconnect pane on page refresh
5. End chat was unable to perform when auth token has already expired
6. Avoid E2VV call if calling is enabled
7. Adding new telemetry for widget start loading
