### PR TITLE
Fix download and email transcript after post chat survey is sent / rendered

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -75,3 +75,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Supporting to start new chat if localStorage has stale Active state
 - Fixing end chat to gracefully complete if auth token has expired
 - Refactoring input validation pane and replacing keyDown event with keyUp
+- Fixed download and email transcript after post chat survey is sent / rendered

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -58,6 +58,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdap
         const chatSession = await chatSDK?.getCurrentLiveChatContext();
         await endChat(props, chatSDK, setAdapter, setWebChatStyles, dispatch, adapter, skipEndChatSDK, skipCloseChat, false);
         if (chatSession) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (chatSDK as any).chatToken = chatSession.chatToken ?? {};
             chatSDK.requestId = chatSession.requestId;
         }

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -55,8 +55,13 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdap
     if (isPostChatEnabled === "true" && conversationDetails?.canRenderPostChat === Constants.truePascal) {
         const skipEndChatSDK = false;
         const skipCloseChat = true;
+        const chatSession = await chatSDK?.getCurrentLiveChatContext();
         await endChat(props, chatSDK, setAdapter, setWebChatStyles, dispatch, adapter, skipEndChatSDK, skipCloseChat, false);
-
+        if (chatSession) {
+            (chatSDK as any).chatToken = chatSession.chatToken ?? {};
+            chatSDK.requestId = chatSession.requestId;
+        }
+        
         if (postChatSurveyMode === PostChatSurveyMode.Embed) {
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.PostchatLoading });
             await addDelayInMs(Constants.PostChatLoadingDurationInMs);


### PR DESCRIPTION
**Issue:**
Download and email transcript does not work after Post Chat Survey is displayed. Investigations traced issue to endChat SDK call happening after PCS flow is triggered, which resets the chatToken (which has chatId) and requestId necessary for the download and email transcript API calls.
<img width="957" alt="image" src="https://user-images.githubusercontent.com/13504205/200962809-1e319f30-4fd5-4b89-bc14-2b5ac5c24793.png">
Here we see the chatId as part of the API request is undefined, which gives 500 internal server error.
https://unq2ef66d93e33c443aadbbbf19627d3-crm10.oc.crmlivetie.com/livechatconnector/v2/getchattranscripts/**undefined**/6ffd4907-11ac-4af6-8fad-c0e2cae5db41?channelId=lcw

**Solution:**
Save the chatToken and requestId before the endChat SDK call is made, and re-assign those values to the chatSDK object such that the download and email transcript API calls can be made successfully.

**Testing:**
Tested download and email transcript for link mode PCS, embed mode PCS, and no PCS, with C1 and C2 ending for the aforementioned scenarios. Here's some screenshots for link mode PCS testing:
<img width="964" alt="image" src="https://user-images.githubusercontent.com/13504205/200963478-a3be585a-2d68-490a-b4ff-256bc6fe2b85.png">
<img width="921" alt="image" src="https://user-images.githubusercontent.com/13504205/200963518-d9d3a4e6-695e-4533-ac3d-edfb79550eb4.png">
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/13504205/200963564-81205eef-134a-42a2-8e15-070ea7edfe69.png">
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/13504205/200963627-6821ce22-9fb2-4ddc-95b5-22df748788f4.png">


