### PR TITLE
Fix chat button UI issues

### DIFF
--- a/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonSubTitleStyles.ts
+++ b/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonSubTitleStyles.ts
@@ -10,6 +10,7 @@ export const defaultChatButtonSubTitleStyles: IStyle = {
     fontWeight:"200",
     margin: "0px 14px 0px 14px",
     overflow: "hidden",
+    padding: "0px",
     textOverflow: "ellipsis !important",
     width: "max-content"
 };

--- a/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonTitleStyles.ts
+++ b/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonTitleStyles.ts
@@ -11,6 +11,7 @@ export const defaultChatButtonTitleStyles: IStyle = {
     height: "22px",
     margin: "0px 14px 0px 14px",
     overflow: "hidden",
+    padding: "0px",
     textOverflow: "ellipsis !important",
     whiteSpace: "nowrap",
     width: "90px"


### PR DESCRIPTION
Fixed 2 bugs on chat button customization

[Bug 3119870](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3119870): [V2] Chat button title default height is not enough
[Bug 3119873](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3119873): [V2] Chat button title position is off when hideChatSubtitle is true