### PR TITLE
missing logic to handle unknown images by type

### DIFF
--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachmentMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachmentMiddleware.tsx
@@ -188,8 +188,9 @@ const createAttachmentMiddleware = (enableInlinePlaying: boolean | undefined) =>
                 />
             );
         }
-    
-        if (fileExtension === "txt") {
+
+        const isUnknownImageObject = contentType.toLowerCase().includes("image") && !imageExtension;    
+        if (fileExtension === "txt" || isUnknownImageObject) {
             return (
                 <Attachment
                     iconData={iconData}


### PR DESCRIPTION

Adding missing code for feature parity : 

- images that are not supported by AMS should be using the endpoint to be uploaded as objects
-  only images that are supported by AMS will be using the endpoint for upload as image

#PR of reference -> https://dynamicscrm.visualstudio.com/OneCRM/_git/CRM.OmniChannel.LiveChatWidget/commit/554266e77dd7bc03b1002a5e457bda9a048962bd?refName=refs/heads/images-handling-fix&tab=details

#Evidence

![image](https://user-images.githubusercontent.com/981914/212215900-653ea242-c89a-4d85-89ff-6621e8ac507d.png)
