### PR TITLE
Adding hideErrorUIPane to show/hide Error UI on start chat (#13)

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -95,4 +95,5 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Adding force close to endChat if chat stuck after sessionInit
 - Removing MesssageReceived event for system messages
 - Fixed PostChat loading twice when Bot enabled
-- Fixed Narrator/Ndva in PreChat Survey Pane 
+- Fixed Narrator/Ndva in PreChat Survey Pane
+- Adding `hideErrorUIPane` to `ILiveChatWidgetControlProps` to show/hide Error UI on start chat

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -111,6 +111,7 @@ export enum TelemetryEvent {
     DownloadTranscriptResponseNullOrUndefined = "DownloadTranscriptResponseNullOrUndefined",
     EmailTranscriptSent = "EmailTranscriptSent",
     EmailTranscriptFailed = "EmailTranscriptFailed",
+    ErrorUIPaneLoaded = "ErrorUIPaneLoaded",
     DownloadTranscriptFailed = "DownloadTranscriptFailed",
     StartChatFailed = "StartChatFailed",
     IC3ThreadUpdateEventReceived = "IC3ThreadUpdateEventReceived",

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -554,6 +554,7 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
         hideCallingContainer: false,
         hideChatButton: false,
         hideConfirmationPane: false,
+        hideErrorUIPane: false,
         hideFooter: false,
         hideHeader: false,
         hideLoadingPane: false,

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -91,7 +91,7 @@ const setReconnectIdAndStartChat = async (isAuthenticatedChat: boolean, chatSDK:
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: reconnectId });
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
 
-    await initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams);
+    await initStartChat(chatSDK, dispatch, setAdapter, props, optionalParams);
 };
 
 const redirectPage = (redirectURL: string, redirectInSameWindow: boolean) => {

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetControlProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetControlProps.ts
@@ -4,6 +4,7 @@ export interface ILiveChatWidgetControlProps {
     hideCallingContainer?: boolean;
     hideChatButton?: boolean;
     hideConfirmationPane?: boolean;
+    hideErrorUIPane?: boolean;
     hideFooter?: boolean;
     hideHeader?: boolean;
     hideLoadingPane?: boolean;

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -112,7 +112,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const startChat = async (props: any, localState?: any) => {
+    const startChat = async (props: ILiveChatWidgetProps, localState?: any) => {
         let isChatValid = false;
 
         //Start a chat from cache/reconnectid
@@ -125,7 +125,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             //Check if conversation state is not in wrapup or closed state
             isChatValid = await checkIfConversationStillValid(chatSDK, props, state.domainStates?.liveChatContext?.requestId, dispatch);
             if (isChatValid === true) {
-                await initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams);
+                await initStartChat(chatSDK, dispatch, setAdapter, props, optionalParams);
                 return;
             }
         }
@@ -440,7 +440,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const prepareEndChatRelay = (adapter: any, state: ILiveChatWidgetContext) => prepareEndChat(props, chatSDK, setAdapter, setWebChatStyles, dispatch, adapter, state);
     const prepareStartChatRelay = () => prepareStartChat(props, chatSDK, state, dispatch, setAdapter);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const initStartChatRelay = (optionalParams?: any, persistedState?: any) => initStartChat(chatSDK, props.chatConfig, props.getAuthToken, dispatch, setAdapter, optionalParams, persistedState);
+    const initStartChatRelay = (optionalParams?: any, persistedState?: any) => initStartChat(chatSDK, dispatch, setAdapter, props, optionalParams, persistedState);
     const confirmationPaneProps = initConfirmationPropsComposer(props);
 
     return (


### PR DESCRIPTION
By default flag is set to false

Have to be explicitly set to true to hide error UI
