### PR TITLE
[Bug 3178278] - [V2] Showing unread messages number after ending chat

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -110,6 +110,7 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdapter: an
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
+    dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
 
     if (!skipCloseChat) {
         try {
@@ -121,7 +122,6 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdapter: an
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_ENDED_BY_AGENT, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
             dispatch({ type: LiveChatWidgetActionType.SET_AUDIO_NOTIFICATION, payload: null });
-            dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
             dispatch({
                 type: LiveChatWidgetActionType.SET_PROACTIVE_CHAT_PARAMS, payload: {
                     proactiveChatBodyTitle: "",

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -144,7 +144,7 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdapter: an
                     exception: `Failed to endChat: ${error}`
                 }
             });
-        }finally {
+        } finally {
             dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
         }
     }

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -110,7 +110,6 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdapter: an
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
-    dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
 
     if (!skipCloseChat) {
         try {
@@ -145,6 +144,8 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdapter: an
                     exception: `Failed to endChat: ${error}`
                 }
             });
+        }finally {
+            dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
         }
     }
 };


### PR DESCRIPTION
Fixing [bug 3178278](https://dynamicscrm.visualstudio.com/OneCRM/_sprints/backlog/CCA%20-%20Customer%20Interaction%20Tools/OneCRM/Train/2023/2302?workitem=3178278)

After doing some reserach I saw that if closeChat fails for any reason (specifically if JWT token doesn't exist anymore) the message count doesn't dissapear 
Moving the reset count independtly of any error on closing chat
![image](https://user-images.githubusercontent.com/62082252/220811065-b5b1afde-cc33-43a3-b3e4-ada6ecd22847.png)

![image](https://user-images.githubusercontent.com/62082252/220811085-89223228-3cfe-41d8-89d4-5ef618094147.png)

