### PR TITLE
Fix for - BUG 3079131 : PostChat Loading Screen Close button not working as expected

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -94,6 +94,7 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Allowing to accept Cache Ttl from partners
 - Adding force close to endChat if chat stuck after sessionInit
 - Removing MesssageReceived event for system messages
-- Fixed PostChat loading twice when Bot enabled
 - Adding `hideErrorUIPane` to `ILiveChatWidgetControlProps` to show/hide Error UI on start chat
 - Fix Start Chat icon disappearing due to subtitle length
+- Removed close button from PostChat Loading Screen
+- Added PostChat Context check for triggering Embedded PostChat Workflow

--- a/chat-widget/src/components/headerstateful/HeaderStateful.tsx
+++ b/chat-widget/src/components/headerstateful/HeaderStateful.tsx
@@ -51,7 +51,7 @@ export const HeaderStateful = (props: IHeaderStatefulParams) => {
         ...headerProps?.controlProps,
         hideTitle: (state.appStates.conversationState === ConversationState.Loading && !state.appStates.isStartChatFailing) || state.appStates.conversationState === ConversationState.PostchatLoading || headerProps?.controlProps?.hideTitle,
         hideIcon: (state.appStates.conversationState === ConversationState.Loading && !state.appStates.isStartChatFailing) || state.appStates.conversationState === ConversationState.PostchatLoading || headerProps?.controlProps?.hideIcon,
-        hideCloseButton: (state.appStates.conversationState === ConversationState.Loading && !state.appStates.isStartChatFailing) || state.appStates.conversationState === ConversationState.Prechat || state.appStates.conversationState === ConversationState.ReconnectChat || headerProps?.controlProps?.hideCloseButton
+        hideCloseButton: (state.appStates.conversationState === ConversationState.Loading && !state.appStates.isStartChatFailing) || state.appStates.conversationState === ConversationState.PostchatLoading || state.appStates.conversationState === ConversationState.Prechat || state.appStates.conversationState === ConversationState.ReconnectChat || headerProps?.controlProps?.hideCloseButton
     };
 
     const outOfOfficeControlProps: IHeaderControlProps = {

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -64,13 +64,18 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdap
         }
 
         if (postChatSurveyMode === PostChatSurveyMode.Embed) {
-            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.PostchatLoading });
-            await addDelayInMs(Constants.PostChatLoadingDurationInMs);
-
-            const loadPostChatEvent: ICustomEvent = {
-                eventName: BroadcastEvent.LoadPostChatSurvey,
-            };
-            BroadcastService.postMessage(loadPostChatEvent);
+            // Only start embedded Postchat workflow if postchat context is set successfully else close chat
+            if (state.domainStates.postChatContext) {
+                dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.PostchatLoading });
+                await addDelayInMs(Constants.PostChatLoadingDurationInMs);
+    
+                const loadPostChatEvent: ICustomEvent = {
+                    eventName: BroadcastEvent.LoadPostChatSurvey,
+                };
+                BroadcastService.postMessage(loadPostChatEvent);
+            } else {
+                await endChat(props, chatSDK, setAdapter, setWebChatStyles, dispatch, adapter, true, false, true);
+            }
         } else if (postChatSurveyMode === PostChatSurveyMode.Link) {
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.InActive });
 

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -64,14 +64,20 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, chatSDK: any, s
             }
             if (isPostChatEnabled === "true") {
                 if (postChatSurveyMode === PostChatSurveyMode.Embed) {
-                    WebChatStoreLoader.store = null;
-                    dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.PostchatLoading });
-                    await addDelayInMs(Constants.PostChatLoadingDurationInMs);
-
-                    const loadPostChatEvent: ICustomEvent = {
-                        eventName: BroadcastEvent.LoadPostChatSurvey,
-                    };
-                    BroadcastService.postMessage(loadPostChatEvent);
+                    // Only start embedded Postchat workflow if postchat context is set successfully else close chat
+                    if (state.domainStates.postChatContext) {
+                        WebChatStoreLoader.store = null;
+                        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.PostchatLoading });
+                        await addDelayInMs(Constants.PostChatLoadingDurationInMs);
+    
+                        const loadPostChatEvent: ICustomEvent = {
+                            eventName: BroadcastEvent.LoadPostChatSurvey,
+                        };
+                        BroadcastService.postMessage(loadPostChatEvent);
+                    } else {
+                        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.InActive });
+                        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_ENDED_BY_AGENT, payload: true });                        
+                    }
                 } else if (postChatSurveyMode === PostChatSurveyMode.Link) {
                     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.InActive });
                 }


### PR DESCRIPTION
Fixes in PR for https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3079131

Fixes are as follows: 
1. Removed close button in PostChatLoadingPane.
2. Close chat immediately (do not show PostChat loading or survey screen) if postChat context is null or undefined.

Demos in the Attachment section of 
[BUG 3079131](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3079131)