### PR TITLE
3211120 : adding new style for pop-out post survey

### DIFF
--- a/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
@@ -14,12 +14,23 @@ import useChatContextStore from "../../hooks/useChatContextStore";
 import { PostChatSurveyMode } from "./enums/PostChatSurveyMode";
 import { IPostChatSurveyPaneStatefulProps } from "./interfaces/IPostChatSurveyPaneStatefulProps";
 import { CustomerVoiceEvents } from "./enums/CustomerVoiceEvents";
+import { defaultPopOutGeneralPostChatSurveyPaneStyleProps } from "./common/defaultStyleProps/defaultPopOutgeneralPostChatSurveyPaneStyleProps";
 
 export const PostChatSurveyPaneStateful = (props: IPostChatSurveyPaneStatefulProps) => {
     const [state]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
     const postChatSurveyMode = state.domainStates.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_postconversationsurveymode;
-    const generalStyleProps: IStyle = Object.assign({}, defaultGeneralPostChatSurveyPaneStyleProps, props.styleProps?.generalStyleProps,
+   
+    const chooseGeneralStylePropsToBeLoaded = () => {
+        if (state.appStates.hideStartChatButton){
+            return defaultPopOutGeneralPostChatSurveyPaneStyleProps;
+        }
+        return defaultGeneralPostChatSurveyPaneStyleProps;
+    };
+
+    const generalStyleProps: IStyle = Object.assign({}, chooseGeneralStylePropsToBeLoaded(), props.styleProps?.generalStyleProps,
         {display: state.appStates.isMinimized ? "none" : ""});
+
+   
     let surveyInviteLink = "";
     if (state.domainStates.postChatContext.surveyInviteLink) {
         surveyInviteLink = state.domainStates.postChatContext.surveyInviteLink + "&embed=" + (postChatSurveyMode === PostChatSurveyMode.Embed).toString() + 

--- a/chat-widget/src/components/postchatsurveypanestateful/common/defaultStyleProps/defaultPopOutgeneralPostChatSurveyPaneStyleProps.ts
+++ b/chat-widget/src/components/postchatsurveypanestateful/common/defaultStyleProps/defaultPopOutgeneralPostChatSurveyPaneStyleProps.ts
@@ -1,0 +1,12 @@
+import { IStyle } from "@fluentui/react";
+
+export const defaultPopOutGeneralPostChatSurveyPaneStyleProps: IStyle = {
+    position: "initial",
+    height: "100%",
+    width: "100%",
+    left: "0%",
+    top: "0%",
+    borderRadius: "0 0 4px 4px",
+    borderWidth: "0px",
+    maxHeight: "calc(100% - 20px)"
+};


### PR DESCRIPTION
### Description
White space gap at the top of the post-survey , this was due to the max-height value 

### Solution

adding default properties just for pop-out to setup max-height for pop-out which eliminates the white space gap

### Test evidence

### Pop out window
![image](https://user-images.githubusercontent.com/981914/225135329-ed9a8dcb-3b06-4b49-a63a-1e04e74ef243.png)

### Normal window
![image](https://user-images.githubusercontent.com/981914/225135718-961f4e9f-a300-4386-ab61-e227549f39ef.png)

