### PR TITLE
Limit attachment size under 20MB in LiveChatWidget and Telemetry for V2

### DIFF
--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -186,9 +186,9 @@ export class WebChatMiddlewareConstants {
 }
 
 export class AMSConstants {
-    public static readonly supportedImagesMimeTypes = ["image/jpeg", "image/png", "image/gif", "image/heic", "image/webp"]; //using same MIME types as AMSClient
-    public static readonly maxSupportedImageSize = 20; //AMS max size for images is 20MB
-    public static readonly maxSupportedFileSize = 300; //AMS max size limit is 300MB but Dynamics limit is 128MB this gets overwritten on AttachmentUploadValidatorMiddleware.ts line 78
+    public static readonly supportedImagesMimeTypes = ["image/jpeg", "image/png", "image/gif", "image/heic", "image/webp"];
+    public static readonly maxSupportedImageSize = 20; // AMS max file limit outside of supported Images MIME Types.
+    public static readonly maxSupportedFileSize = 300; // AMS max size limit is 300MB.
 }
 
 export class MimeTypes {

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -182,6 +182,12 @@ export class WebChatMiddlewareConstants {
     public static readonly adaptiveCard = "AdaptiveCard";
 }
 
+export class AMSConstants {
+    public static readonly supportedImagesMimeTypes = ["image/jpeg", "image/png", "image/gif", "image/heic", "image/webp"]; //using same MIME types as AMSClient
+    public static readonly maxSupportedImageSize = 20; //AMS max size for images is 20MB
+    public static readonly maxSupportedFileSize = 300; //AMS max size limit is 300MB but Dynamics limit is 128MB this gets overwritten on AttachmentUploadValidatorMiddleware.ts line 78
+}
+
 export class MimeTypes {
     public static readonly UnknownFileType = "application/octet-stream";
 }

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -188,7 +188,7 @@ export class WebChatMiddlewareConstants {
 export class AMSConstants {
     public static readonly supportedImagesMimeTypes = ["image/jpeg", "image/png", "image/gif", "image/heic", "image/webp"];
     public static readonly maxSupportedImageSize = 20; // AMS max file limit outside of supported Images MIME Types.
-    public static readonly maxSupportedFileSize = 300; // AMS max size limit is 300MB.
+    public static readonly maxSupportedFileSize = 300; // AMS max size limit.
 }
 
 export class MimeTypes {

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -156,6 +156,7 @@ export enum TelemetryEvent {
     ProcessingHTMLTextMiddlewareFailed = "ProcessingHTMLTextMiddlewareFailed",
     ProcessingSanitizationMiddlewareFailed = "ProcessingSanitizationMiddlewareFailed",
     FormatTagsMiddlewareJSONStringifyFailed = "FormatTagsMiddlewareJSONStringifyFailed",
+    AttachmentUploadValidatorMiddlewareFailed = "AttachmentUploadValidatorMiddlewareFailed",
     QueuePositionMessageRecieved = "QueuePositionMessageRecieved",
     AverageWaitTimeMessageRecieved = "AverageWaitTimeMessageRecieved",
     DataMaskingRuleApplied = "DataMaskingRuleApplied",

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
@@ -68,9 +68,9 @@ const validateFileSize = (attachmentSize: string, maxUploadFileSize: number): bo
 
 const getMaxUploadFileSize = (maxFileSizeSupportedByDynamicsStr: string, contentType: string): number => {
     const maxFileSizeSupportedByDynamics = maxFileSizeSupportedByDynamicsStr && parseInt(maxFileSizeSupportedByDynamicsStr) ? parseInt(maxFileSizeSupportedByDynamicsStr) : AMSConstants.maxSupportedFileSize;
-    const amsAttachmentSizeLimit = isImage(contentType)? AMSConstants.maxSupportedImageSize: AMSConstants.maxSupportedFileSize;
+    const amsAttachmentSizeLimit = isImage(contentType) ? AMSConstants.maxSupportedImageSize : AMSConstants.maxSupportedFileSize;
     // Takes the smallest max file size configure betteween AMS and Dynamics Config
-    return maxFileSizeSupportedByDynamics < amsAttachmentSizeLimit? maxFileSizeSupportedByDynamics: amsAttachmentSizeLimit;
+    return maxFileSizeSupportedByDynamics < amsAttachmentSizeLimit ? maxFileSizeSupportedByDynamics : amsAttachmentSizeLimit;
 };
 
 const isImage = (contentType: string): boolean => {
@@ -105,7 +105,7 @@ const buildErrorMessage = (fileName: string, supportedFileExtension: boolean, su
         TelemetryHelper.logActionEvent(LogLevel.ERROR, {
             Event: TelemetryEvent.AttachmentUploadValidatorMiddlewareFailed,
             Description: "Attachment validation failed",
-            ExceptionDetails: { ErrorDetails:  `Unexpected error: supportedFileExtension=${supportedFileExtension} supportedFileSize=${supportedFileSize} fileIsEmpty=${!fileIsEmpty}`}
+            ExceptionDetails: { ErrorDetails: `Unexpected error: supportedFileExtension=${supportedFileExtension} supportedFileSize=${supportedFileSize} fileIsEmpty=${!fileIsEmpty}` }
         });
         errorMessage = localizedTexts.MIDDLEWARE_BANNER_ERROR_MESSAGE ?? "";
     }
@@ -129,7 +129,7 @@ const getFileSizeAndFileExtensionErrorMessage = (fileName: string, maxUploadFile
     TelemetryHelper.logActionEvent(LogLevel.ERROR, {
         Event: TelemetryEvent.AttachmentUploadValidatorMiddlewareFailed,
         Description: "Attachment validation failed",
-        ExceptionDetails: { ErrorDetails: `${exceptionDetails} Dynamics file size limit=${maxFileSizeSupportedByDynamics} AMS image size limit=${AMSConstants.maxSupportedImageSize } AMS file size limit=${AMSConstants.maxSupportedFileSize}`}
+        ExceptionDetails: { ErrorDetails: `${exceptionDetails} Dynamics file size limit=${maxFileSizeSupportedByDynamics} AMS image size limit=${AMSConstants.maxSupportedImageSize} AMS file size limit=${AMSConstants.maxSupportedFileSize}` }
     });
     return errorMessage ? (errorMessage.includes("{0}") ? errorMessage.replace("{0}", maxUploadFileSize) : errorMessage) : "";
 };
@@ -159,7 +159,7 @@ const getFileSizeErrorMessage = (maxUploadFileSize: string, maxFileSizeSupported
     TelemetryHelper.logActionEvent(LogLevel.ERROR, {
         Event: TelemetryEvent.AttachmentUploadValidatorMiddlewareFailed,
         Description: "Attachment validation failed",
-        ExceptionDetails: { ErrorDetails: `File exceeds the allowed limit of ${maxUploadFileSize}MB. Dynamics file size limit=${maxFileSizeSupportedByDynamics} AMS image size limit=${AMSConstants.maxSupportedImageSize} AMS file size limit=${AMSConstants.maxSupportedFileSize}`}
+        ExceptionDetails: { ErrorDetails: `File exceeds the allowed limit of ${maxUploadFileSize}MB. Dynamics file size limit=${maxFileSizeSupportedByDynamics} AMS image size limit=${AMSConstants.maxSupportedImageSize} AMS file size limit=${AMSConstants.maxSupportedFileSize}` }
     });
     const errorMessage = localizedTexts.MIDDLEWARE_BANNER_FILE_SIZE_ERROR;
     return errorMessage ? (errorMessage.includes("{0}") ? errorMessage.replace("{0}", maxUploadFileSize) : errorMessage) : "";

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
@@ -64,9 +64,9 @@ const validateFileSize = (attachmentSize: string, maxUploadFileSize: number): bo
     return (maxUploadFileSize * MBtoBRatio) > parseInt(attachmentSize);
 };
 
-const getmaxUploadFileSize = (maxFileSizeByDynamics:string, contentType: string): number => {
+const getmaxUploadFileSize = (maxFileSizeSupportedByDynamicsStr:string, contentType: string): number => {
     const isFileImage = isImage(contentType);
-    const maxFileSizeSupportedByDynamics = maxFileSizeByDynamics && parseInt(maxFileSizeByDynamics) ? parseInt(maxFileSizeByDynamics) : AMSConstants.maxSupportedFileSize;
+    const maxFileSizeSupportedByDynamics = maxFileSizeSupportedByDynamicsStr && parseInt(maxFileSizeSupportedByDynamicsStr) ? parseInt(maxFileSizeSupportedByDynamicsStr) : AMSConstants.maxSupportedFileSize;
 
     // Takes the smallest max file size configure betteween AMS and Dynamics Config
     if (isFileImage){
@@ -133,7 +133,7 @@ const getFileSizeErrorMessage = (maxUploadFileSize: string, localizedTexts: ILiv
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-const createAttachmentUploadValidatorMiddleware = (allowedFileExtensions: string, maxUploadFileSize: string, localizedTexts: ILiveChatWidgetLocalizedTexts) => ({ dispatch }: { dispatch: any }) => (next: any) => (action: IWebChatAction) => {
+const createAttachmentUploadValidatorMiddleware = (allowedFileExtensions: string, maxFileSizeSupportedByDynamics: string, localizedTexts: ILiveChatWidgetLocalizedTexts) => ({ dispatch }: { dispatch: any }) => (next: any) => (action: IWebChatAction) => {
     if (action.type === WebChatActionType.DIRECT_LINE_POST_ACTIVITY) {
         const {
             payload
@@ -141,7 +141,7 @@ const createAttachmentUploadValidatorMiddleware = (allowedFileExtensions: string
 
         if (payload?.activity?.attachments && payload?.activity?.channelData?.attachmentSizes &&
             payload?.activity?.attachments?.length === payload?.activity?.channelData?.attachmentSizes?.length) {
-            return next(validateAttachment(action, allowedFileExtensions, maxUploadFileSize, localizedTexts));
+            return next(validateAttachment(action, allowedFileExtensions, maxFileSizeSupportedByDynamics, localizedTexts));
         }
     }
     return next(action);

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
@@ -105,7 +105,7 @@ const buildErrorMessage = (fileName: string, supportedFileExtension: boolean, su
         TelemetryHelper.logActionEvent(LogLevel.ERROR, {
             Event: TelemetryEvent.AttachmentUploadValidatorMiddlewareFailed,
             Description: "Attachment validation failed",
-            ExceptionDetails: { ErrorDetails: "Unexpected error: supportedFileExtension=" + supportedFileExtension + " supportedFileSize=" + supportedFileSize + " fileIsEmpty=" + !fileIsEmpty }
+            ExceptionDetails: { ErrorDetails:  `Unexpected error: supportedFileExtension=${supportedFileExtension} supportedFileSize=${supportedFileSize} fileIsEmpty=${!fileIsEmpty}`}
         });
         errorMessage = localizedTexts.MIDDLEWARE_BANNER_ERROR_MESSAGE ?? "";
     }
@@ -117,11 +117,11 @@ const getFileSizeAndFileExtensionErrorMessage = (fileName: string, maxUploadFile
     let errorMessage, exceptionDetails: string;
     if (index < 0) {
         errorMessage = localizedTexts.MIDDLEWARE_BANNER_FILE_SIZE_WITHOUT_EXTENSION_ERROR;
-        exceptionDetails = "File exceeded the allowed limit of " + maxUploadFileSize + " MB and File provided without file extension";
+        exceptionDetails = `File exceeded the allowed limit of ${maxUploadFileSize} MB and File provided without file extension`;
     } else {
         const fileExtension = fileName.substring(index);
         errorMessage = localizedTexts.MIDDLEWARE_BANNER_FILE_SIZE_EXTENSION_ERROR;
-        exceptionDetails = "File exceeds the allowed limit of " + maxUploadFileSize + " MB and " + fileExtension + " files are not supported";
+        exceptionDetails = `File exceeds the allowed limit of ${maxUploadFileSize} MB and ${fileExtension} files are not supported`;
         if (errorMessage?.includes("{1}")) {
             errorMessage = errorMessage.replace("{1}", fileExtension);
         }
@@ -129,7 +129,7 @@ const getFileSizeAndFileExtensionErrorMessage = (fileName: string, maxUploadFile
     TelemetryHelper.logActionEvent(LogLevel.ERROR, {
         Event: TelemetryEvent.AttachmentUploadValidatorMiddlewareFailed,
         Description: "Attachment validation failed",
-        ExceptionDetails: { ErrorDetails: exceptionDetails + " Dynamics file size limit=" + maxFileSizeSupportedByDynamics + " AMS image size limit=" + AMSConstants.maxSupportedImageSize + " AMS file size limit=" + AMSConstants.maxSupportedFileSize }
+        ExceptionDetails: { ErrorDetails: `${exceptionDetails} Dynamics file size limit=${maxFileSizeSupportedByDynamics} AMS image size limit=${AMSConstants.maxSupportedImageSize } AMS file size limit=${AMSConstants.maxSupportedFileSize}`}
     });
     return errorMessage ? (errorMessage.includes("{0}") ? errorMessage.replace("{0}", maxUploadFileSize) : errorMessage) : "";
 };
@@ -148,7 +148,7 @@ const getFileExtensionErrorMessage = (fileName: string, localizedTexts: ILiveCha
         TelemetryHelper.logActionEvent(LogLevel.ERROR, {
             Event: TelemetryEvent.AttachmentUploadValidatorMiddlewareFailed,
             Description: "Attachment validation failed",
-            ExceptionDetails: { ErrorDetails: fileExtension + " files are not supported." }
+            ExceptionDetails: { ErrorDetails: `${fileExtension} files extension is not supported.` }
         });
         const errorMessage = localizedTexts.MIDDLEWARE_BANNER_FILE_EXTENSION_ERROR;
         return errorMessage ? (errorMessage.includes("{0}") ? errorMessage.replace("{0}", fileExtension) : errorMessage) : "";
@@ -159,7 +159,7 @@ const getFileSizeErrorMessage = (maxUploadFileSize: string, maxFileSizeSupported
     TelemetryHelper.logActionEvent(LogLevel.ERROR, {
         Event: TelemetryEvent.AttachmentUploadValidatorMiddlewareFailed,
         Description: "Attachment validation failed",
-        ExceptionDetails: { ErrorDetails: "File exceeds the allowed limit of " + maxUploadFileSize + " MB. Dynamics file size limit=" + maxFileSizeSupportedByDynamics + " AMS image size limit=" + AMSConstants.maxSupportedImageSize + " AMS file size limit=" + AMSConstants.maxSupportedFileSize }
+        ExceptionDetails: { ErrorDetails: `File exceeds the allowed limit of ${maxUploadFileSize}MB. Dynamics file size limit=${maxFileSizeSupportedByDynamics} AMS image size limit=${AMSConstants.maxSupportedImageSize} AMS file size limit=${AMSConstants.maxSupportedFileSize}`}
     });
     const errorMessage = localizedTexts.MIDDLEWARE_BANNER_FILE_SIZE_ERROR;
     return errorMessage ? (errorMessage.includes("{0}") ? errorMessage.replace("{0}", maxUploadFileSize) : errorMessage) : "";


### PR DESCRIPTION
**Description**
As AMSClient file size restriction 20Mb for images, 300Mb for other files
we need to the sizes of the file,
to prevent failures before to upload the file.

**Solution Proposed**
Adding an extra validation on AttachmentUploadValidatorMiddleware.ts that checks both Dynamics and AMSClient file restrictions and validates the file before submitting it

**Acceptance criteria**
validation for images is up to 20MB
validation for any other attachment 300MB
error should be displayed in the UI

**Test cases and evidence**

1. Image of 10Mb, Files of 50Mb and 100Mb tested
![image](https://user-images.githubusercontent.com/62082252/225487883-bf47e8b8-b64c-4ef4-b8a4-8cdb2fc2ead0.png)

2. Failure message after trying to upload a 30Mb image
![image](https://user-images.githubusercontent.com/62082252/225487909-b674e313-0584-4f29-9ab2-aee1e7ae439d.png)

3. Failure after trying to upload 200Mb file
![image](https://user-images.githubusercontent.com/62082252/225487928-70370dba-be59-415b-88bc-c4bdef481f80.png)

Files used
![image](https://user-images.githubusercontent.com/62082252/225487943-0e4218b8-1159-46cd-b3c1-de23f9e3a9a7.png)

### Telemetry section
**Description**
Adding telemetry to attachment Upload Validator Middleware when the validation has an exception

**Solution Proposed**
Adding logs to telemetry for the differnt cases that there could be an exception while validating a file

**Acceptance criteria**
Logs for different case scenarios should be logged in Kusto

**Test cases and evidence**
After trying to upload image over 30Mb, file over 128Mb I got the following logs in telemetry
https://josue.blob.core.windows.net/telemetry/indexv2.html
![image](https://user-images.githubusercontent.com/62082252/226062519-fdf4883c-4320-40ad-9d7d-8e533d950c32.png)
![image](https://user-images.githubusercontent.com/62082252/226062554-41789704-2ea2-4009-80ec-9c9e84419aa7.png)


**Query**
union lcw_*
| where OrganizationId == '27ff8a63-815a-49f6-b180-b248f806b867'
| where Event == "AttachmentUploadValidatorMiddlewareFailed"