### PR TITLE
 BUG 3238689 : [V2] Enable Different PostChat Survey for Bot vs Agent Fix

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -84,6 +84,7 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAdapter: an
             WebChatStoreLoader.store = null;
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
             dispatch({ type: LiveChatWidgetActionType.SET_POST_CHAT_WORKFLOW_IN_PROGRESS, payload: false });
+            dispatch({ type: LiveChatWidgetActionType.SET_SHOULD_USE_BOT_SURVEY, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_ENDED_BY_AGENT_EVENT_RECEIVED, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_ENDED_BY, payload: undefined });
             dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });

--- a/chat-widget/src/components/livechatwidget/common/setPostChatContextAndLoadSurvey.ts
+++ b/chat-widget/src/components/livechatwidget/common/setPostChatContextAndLoadSurvey.ts
@@ -55,6 +55,7 @@ const initiatePostChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAd
     // Check if Postchat already in progress and handle case where chat is ended by customer
     if (state.appStates.postChatWorkflowInProgress && state.appStates.conversationEndedBy === ConversationEndEntity.Customer) {
         await endChat(props, chatSDK, setAdapter, setWebChatStyles, dispatch, adapter, false, false, true);
+        return;
     }
 
     // Conversation Details call required by customer as well as agent 
@@ -80,6 +81,8 @@ const initiatePostChat = async (props: ILiveChatWidgetProps, chatSDK: any, setAd
             throw new Error(error);
         }
     } else if (conversationDetails?.participantType === Constants.botParticipantTypeTag) {
+        // Set Use bot survey to true
+        dispatch({ type: LiveChatWidgetActionType.SET_SHOULD_USE_BOT_SURVEY, payload: true });
         if (state.appStates.conversationEndedBy === ConversationEndEntity.Customer) {
             // Set use bot settings to true
             await postChatInitiatedByCustomer(props, chatSDK, setAdapter, setWebChatStyles, dispatch, adapter, state, conversationDetails, true);

--- a/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
@@ -21,7 +21,10 @@ export const PostChatSurveyPaneStateful = (props: IPostChatSurveyPaneStatefulPro
     const generalStyleProps: IStyle = Object.assign({}, defaultGeneralPostChatSurveyPaneStyleProps, props.styleProps?.generalStyleProps,
         {display: state.appStates.isMinimized ? "none" : ""});
     let surveyInviteLink = "";
-    if (state.domainStates.postChatContext.surveyInviteLink) {
+    if (state.appStates.shouldUseBotSurvey && state.domainStates.postChatContext.botSurveyInviteLink) {
+        surveyInviteLink = state.domainStates.postChatContext.botSurveyInviteLink + "&embed=" + (postChatSurveyMode === PostChatSurveyMode.Embed).toString() + 
+        "&compact=" + (props.isCustomerVoiceSurveyCompact ?? true).toString() + "&lang=" + (state.domainStates.postChatContext.formsProLocale ?? "en") + "&showmultilingual=false";
+    } else {
         surveyInviteLink = state.domainStates.postChatContext.surveyInviteLink + "&embed=" + (postChatSurveyMode === PostChatSurveyMode.Embed).toString() + 
         "&compact=" + (props.isCustomerVoiceSurveyCompact ?? true).toString() + "&lang=" + (state.domainStates.postChatContext.formsProLocale ?? "en") + "&showmultilingual=false";
     }

--- a/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
@@ -47,6 +47,7 @@ export interface ILiveChatWidgetContext {
         conversationEndedByAgentEventReceived: boolean; // true when agent end conversation or timeout event is received
         conversationEndedBy: ConversationEndEntity | undefined; // The entity that ends conversation
         postChatWorkflowInProgress: boolean; // true when customer ends conversation and postChat workflow has initiated
+        shouldUseBotSurvey: boolean; // true when bot configured survey needs to be used
     };
     uiStates: {
         showConfirmationPane: boolean; // true if the confirmation pane should show

--- a/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
@@ -236,5 +236,11 @@ export enum LiveChatWidgetActionType {
         Parameters:
         true/false: Checks if Postchat workflow is already initiated
     */
-    SET_POST_CHAT_WORKFLOW_IN_PROGRESS
+    SET_POST_CHAT_WORKFLOW_IN_PROGRESS,
+
+    /*
+        Parameters:
+        true/false: To check if bot configured survey needs to be used
+    */
+    SET_SHOULD_USE_BOT_SURVEY
 }

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -55,7 +55,8 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
             unreadMessageCount: 0,
             conversationEndedByAgentEventReceived: false,
             conversationEndedBy: undefined,
-            postChatWorkflowInProgress: false
+            postChatWorkflowInProgress: false,
+            shouldUseBotSurvey: false
         },
         uiStates: {
             showConfirmationPane: false,

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -346,6 +346,16 @@ export const createReducer = () => {
                     }
                 };
 
+            case LiveChatWidgetActionType.SET_SHOULD_USE_BOT_SURVEY:
+                return {
+                    ...state,
+                    appStates: {
+                        ...state.appStates,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        shouldUseBotSurvey: action.payload as boolean
+                    }
+                };
+
             default:
                 return state;
         }


### PR DESCRIPTION
This PR will provide fix for the below bugs:

- [Bug 3247988](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3247988): [V2] Bot Embed Survey + Agent Embed Survey Different Pop-Out - Bot Survey Not Rendered
- [Bug 3238689](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3238689): [V2] Enable Different PostChat Survey for Bot vs Agent

Provided details of testing here : [Bug 3247988](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3247988): [V2] Bot Embed Survey + Agent Embed Survey Different Pop-Out - Bot Survey Not Rendered

Testsuites : https://dynamicscrm.visualstudio.com/OneCRM/_testPlans/define?planId=1102798&suiteId=2763540

![image](https://user-images.githubusercontent.com/30007388/225973620-17fef52e-0332-4970-a2c3-120cf54cdb7f.png)
