### PR TITLE
Bug: Reconnect pane not appearing when reconnect is configured 

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -104,4 +104,4 @@ All notable changes to this project will be documented in this file.## [Unreleas
 - Fixed Postchat loading twice issue
 - Adding an event listener in case the chat window is hidden for notifications
 - Adding support for bot survey
-- Fixing reconnect pane not appearing
+- Changing precedence of reconnect feature over local cache when reconnect is enabled

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -107,10 +107,12 @@ const redirectPage = (redirectURL: string, redirectInSameWindow: boolean) => {
     }
 };
 
-const isReconnectEnabled = (chatConfig: ChatConfig) => {
-    return chatConfig &&
-        chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_enablechatreconnect &&
-        (chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect === "true" || chatConfig.LiveWSAndLiveChatEngJoin.msdyn_enablechatreconnect === true);
+const isReconnectEnabled = (chatConfig?: ChatConfig): boolean => {
+    if (chatConfig) {
+        const reconnectEnabled = (chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_enablechatreconnect?.toLowerCase() === "true");
+        return reconnectEnabled;
+    }
+    return false;
 };
 
 const hasReconnectId = (reconnectAvailabilityResponse: IReconnectChatContext) => {

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -109,7 +109,7 @@ const redirectPage = (redirectURL: string, redirectInSameWindow: boolean) => {
 
 const isReconnectEnabled = (chatConfig?: ChatConfig): boolean => {
     if (chatConfig) {
-        const reconnectEnabled = (chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_enablechatreconnect?.toLowerCase() === "true");
+        const reconnectEnabled = chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_enablechatreconnect?.toLowerCase() === "true";
         return reconnectEnabled;
     }
     return false;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -275,7 +275,7 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
     let conversationDetails: any = undefined;
 
     //Preserve old requestId
-    const oldRequestId = chatSDK.requestId;
+    const oldRequestId = chatSDK.requestId ?? "";
     dispatch({ type: LiveChatWidgetActionType.SET_INITIAL_CHAT_SDK_REQUEST_ID, payload: oldRequestId });
 
     try {

--- a/chat-widget/src/components/reconnectchatpanestateful/ReconnectChatPaneStateful.tsx
+++ b/chat-widget/src/components/reconnectchatpanestateful/ReconnectChatPaneStateful.tsx
@@ -27,7 +27,7 @@ export const ReconnectChatPaneStateful = (props: IReconnectChatPaneStatefulParam
             await initStartChat(optionalParams);
         } else {
             dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
-            chatSDK.requestId = state.domainStates.initialChatSdkRequestId;
+            chatSDK.requestId = state?.domainStates?.initialChatSdkRequestId;
             const parseToJson = false;
             const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
             if (preChatSurveyResponse) {

--- a/chat-widget/src/components/reconnectchatpanestateful/ReconnectChatPaneStateful.tsx
+++ b/chat-widget/src/components/reconnectchatpanestateful/ReconnectChatPaneStateful.tsx
@@ -27,6 +27,7 @@ export const ReconnectChatPaneStateful = (props: IReconnectChatPaneStatefulParam
             await initStartChat(optionalParams);
         } else {
             dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
+            chatSDK.requestId = state.domainStates.initialChatSdkRequestId;
             const parseToJson = false;
             const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
             if (preChatSurveyResponse) {

--- a/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
@@ -25,6 +25,7 @@ export interface ILiveChatWidgetContext {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         widgetSize: any;
         widgetInstanceId: string;
+        initialChatSdkRequestId: string;
     };
     appStates: {
         conversationState: ConversationState; // The state that the conversation is currently in

--- a/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
@@ -236,5 +236,11 @@ export enum LiveChatWidgetActionType {
         Parameters:
         true/false: Checks if Postchat workflow is already initiated
     */
-    SET_POST_CHAT_WORKFLOW_IN_PROGRESS
+    SET_POST_CHAT_WORKFLOW_IN_PROGRESS,
+
+    /*
+        Parameters:
+        any: Set initial chat sdk request id (for reconnect scenario when start new chat is deferred)
+    */
+    SET_INITIAL_CHAT_SDK_REQUEST_ID
 }

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -34,6 +34,7 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
             customContext: undefined,
             widgetSize: undefined,
             widgetInstanceId: "",
+            initialChatSdkRequestId: ""
         },
         appStates: {
             conversationState: ConversationState.Closed,

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -296,7 +296,7 @@ export const createReducer = () => {
                         conversationEndedByAgentEventReceived: action.payload as boolean
                     }
                 };
-                
+
             case LiveChatWidgetActionType.SET_CONVERSATION_ENDED_BY:
                 return {
                     ...state,
@@ -325,7 +325,7 @@ export const createReducer = () => {
                         widgetInstanceId: action.payload as string
                     }
                 };
-            
+
             case LiveChatWidgetActionType.SET_LIVE_CHAT_CONFIG:
                 return {
                     ...state,
@@ -346,6 +346,15 @@ export const createReducer = () => {
                     }
                 };
 
+            case LiveChatWidgetActionType.SET_INITIAL_CHAT_SDK_REQUEST_ID:
+                return {
+                    ...state,
+                    domainStates: {
+                        ...state.domainStates,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        initialChatSdkRequestId: action.payload as string
+                    }
+                };
             default:
                 return state;
         }

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -351,7 +351,6 @@ export const createReducer = () => {
                     ...state,
                     domainStates: {
                         ...state.domainStates,
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         initialChatSdkRequestId: action.payload as string
                     }
                 };


### PR DESCRIPTION
- Fixing reconnect pane is not appearing in chat widget even when reconnect is configured. 
- Fixing customer conversation forcefully ended after reconnect time due to first issue.

Screenshots:
**Auth chat (with reconnect prompt)**
   _Previous session detected:_
![image](https://user-images.githubusercontent.com/45749980/226489692-da60f919-4fed-4706-b01b-ae19ea897819.png)

  _Continue Conversation:_
![image](https://user-images.githubusercontent.com/45749980/226490010-b3231e5b-4f82-432a-9e89-c3eeb65dd167.png)

  _Start new conversation:_
![image](https://user-images.githubusercontent.com/45749980/226490107-24933156-f9a7-4f46-89e4-47a63c857782.png)

 _Customer chat not forcefully ended by OC:_
![image](https://user-images.githubusercontent.com/45749980/226490272-89634144-2acf-45d6-9101-a14f94f31213.png)

**Auth chat (with reconnect id)**
![image](https://user-images.githubusercontent.com/45749980/226490518-42e04ee2-2b82-40b3-8838-1ef19263a87e.png)

**Unauth Chat (with reconnect id)**
![image](https://user-images.githubusercontent.com/45749980/226490703-0dc65dfb-767d-41fe-909b-41e5b7b715f0.png)
  
  _Customer chat not ended forcefully:_
![image](https://user-images.githubusercontent.com/45749980/226490809-e82409ca-0990-4cbc-9bad-86d666e45aea.png)


Sample html to test: 
Unauth: https://sacadlcw001.blob.core.windows.net/lcwtpc/test2_reconnect_unauth.html
Auth: https://sacadlcw001.blob.core.windows.net/lcwtpc/test2_reconnect_auth.html
Script: https://sacadlcw001.blob.core.windows.net/lcwtpc/reconnectpane/v2scripts/LiveChatBootstrapper.js


