### PR TITLE
Fix Bug 3293775: [V2] Pre-chat doesn't show hyperlinks

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed custom context not showing for embed chat
+- Fixed hyperlink not working in prechat pane
 
 ## [1.0.1] - 2023-3-23
 

--- a/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
@@ -1,6 +1,7 @@
 import { HtmlAttributeNames, Regex } from "../../common/Constants";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
+import MarkdownIt from "markdown-it";
 import { extractPreChatSurveyResponseValues, findAllFocusableElement, getStateFromCache, isUndefinedOrEmpty, parseAdaptiveCardPayload } from "../../common/utils";
 
 import { ConversationState } from "../../contexts/common/ConversationState";
@@ -20,6 +21,8 @@ import useChatContextStore from "../../hooks/useChatContextStore";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const PreChatSurveyPaneStateful = (props: IPreChatSurveyPaneStatefulParams) => {
+    // Set MarkDown global variable to be used for prechat adaptive cards
+    window["markdownit"] = MarkdownIt;
 
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
     const { surveyProps, initStartChat } = props;


### PR DESCRIPTION
Fixed [Bug 3293775](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3293775): [V2] Pre-chat doesn't show hyperlinks

Before:
![image](https://user-images.githubusercontent.com/14852927/229932341-afa8698a-7b5f-4478-8617-f33ff4a5b304.png)

After:
![image](https://user-images.githubusercontent.com/14852927/229932478-fac0be33-8ed7-4f40-9c79-196009a227c2.png)

