### PR TITLE
Update data masking logic to break loop on empty string rule

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixed an issue where data masking rule matching empty strings will cause infitnite loop
+
 ## [1.0.2] - 2023-4-6
 
 ### Added

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
@@ -77,11 +77,6 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
                 });
             }
         }
-
-        // Exit if rule matched
-        if (isRuleMatched === true) {
-            break;
-        }
     }
 
     action.payload.text = text;

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
@@ -27,7 +27,6 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
         return action;
     }
 
-    let isRuleMatched = false;
     for (const ruleId of Object.keys(regexCollection)) {
         const item = regexCollection[ruleId];
         if (item) {
@@ -48,7 +47,6 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
                     
                     ruleApplied = true;
                     text = modifiedText;
-                    isRuleMatched = true;
                 }
             } catch (err) {
                 TelemetryHelper.logActionEvent(LogLevel.ERROR, {

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware.ts
@@ -37,7 +37,13 @@ const applyDataMasking = (action: IWebChatAction, regexCollection: IDataMaskingR
                 // eslint-disable-next-line no-cond-assign
                 while (match = regex.exec(text)) {
                     const replaceStr = match[0].replace(/./gi, maskedChar);
-                    text = text.replace(match[0], replaceStr);
+                    const modifiedText = text.replace(match[0], replaceStr);
+                    if (modifiedText == text) {
+                        console.warn(`The data masking rule ${item} is ignored because it matches empty strings. Please modify this rule.`);
+                        break;
+                    } 
+                    
+                    text = modifiedText;
                     TelemetryHelper.logActionEvent(LogLevel.INFO, {
                         Event: TelemetryEvent.DataMaskingRuleApplied,
                         Description: `Data Masking Rule Id: ${ruleId} applied.`


### PR DESCRIPTION
[Bug 3298417](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3298417): [V2] When a data masking rule matches empty string, it should not hang the chat

## Description
When a data masking rule matches empty strings, the while loop will go on forever

## Solution Proposed
Break the loop if the modified string is the same as the original string

## Acceptance criteria
Chat does not hang when trying to send a message with a data masking rule matching empty strings

## Test cases and evidence
https://lcwstorageaccountdev.blob.core.windows.net/charlwan/test/nam.html 