### PR TITLE
Fix Bug 3211120: [V2] [Popout] Empty spaces around widget in post chat survey

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed popout chat is not showing Out of office pane
 - Fixed popout chat is showing blank screen
 - Better handling of end chat in case of multitab scenarios
+- Fixed post chat having gap in popout mode
 
 ## [1.0.2] - 2023-4-6
 

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -1143,7 +1143,13 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
                 borderRadius: "0 0 4px 4px",
                 borderWidth: "3px",
                 backgroundColor: "#FFFFFF",
-                borderColor: "#F1F1F1"
+                borderColor: "#F1F1F1",
+                position: "initial",
+                height: "100%",
+                width: "100%",
+                left: "0%",
+                top: "0%",
+                display: "contents"
             }
         },
         isCustomerVoiceSurveyCompact: undefined

--- a/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
@@ -1,20 +1,20 @@
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
 
+import { ConversationEndEntity } from "../../common/Constants";
+import { CustomerVoiceEvents } from "./enums/CustomerVoiceEvents";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
 import { ILiveChatWidgetContext } from "../../contexts/common/ILiveChatWidgetContext";
 import { IPostChatSurveyPaneControlProps } from "@microsoft/omnichannel-chat-components/lib/types/components/postchatsurveypane/interfaces/IPostChatSurveyPaneControlProps";
+import { IPostChatSurveyPaneStatefulProps } from "./interfaces/IPostChatSurveyPaneStatefulProps";
 import { IPostChatSurveyPaneStyleProps } from "@microsoft/omnichannel-chat-components/lib/types/components/postchatsurveypane/interfaces/IPostChatSurveyPaneStyleProps";
 import { IStyle } from "@fluentui/react";
+import { PostChatSurveyMode } from "./enums/PostChatSurveyMode";
 import { PostChatSurveyPane } from "@microsoft/omnichannel-chat-components";
 import { TelemetryHelper } from "../../common/telemetry/TelemetryHelper";
 import { defaultGeneralPostChatSurveyPaneStyleProps } from "./common/defaultStyleProps/defaultgeneralPostChatSurveyPaneStyleProps";
 import { findAllFocusableElement } from "../../common/utils";
 import useChatContextStore from "../../hooks/useChatContextStore";
-import { PostChatSurveyMode } from "./enums/PostChatSurveyMode";
-import { IPostChatSurveyPaneStatefulProps } from "./interfaces/IPostChatSurveyPaneStatefulProps";
-import { CustomerVoiceEvents } from "./enums/CustomerVoiceEvents";
-import { ConversationEndEntity } from "../../common/Constants";
 
 const generateSurveyInviteLink = (surveyInviteLink: string, isEmbed: boolean, locale: string, compact: boolean, showMultiLingual = false) => {
     const surveyLink = `${surveyInviteLink}
@@ -29,7 +29,7 @@ export const PostChatSurveyPaneStateful = (props: IPostChatSurveyPaneStatefulPro
     const [state]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
 
     const generalStyleProps: IStyle = Object.assign({}, defaultGeneralPostChatSurveyPaneStyleProps, props.styleProps?.generalStyleProps,
-        { display: state.appStates.isMinimized ? "none" : "" });
+        { display: state.appStates.isMinimized ? "none" : "contents" });
 
     let surveyInviteLink = "";
     const surveyMode = (state?.appStates?.selectedSurveyMode === PostChatSurveyMode.Embed);

--- a/chat-widget/src/components/postchatsurveypanestateful/common/defaultStyleProps/defaultgeneralPostChatSurveyPaneStyleProps.ts
+++ b/chat-widget/src/components/postchatsurveypanestateful/common/defaultStyleProps/defaultgeneralPostChatSurveyPaneStyleProps.ts
@@ -8,5 +8,5 @@ export const defaultGeneralPostChatSurveyPaneStyleProps: IStyle = {
     top: "0%",
     borderRadius: "0 0 4px 4px",
     borderWidth: "0px",
-    maxHeight: "calc(100% - 80px)"
+    display: "contents"
 };

--- a/chat-widget/src/components/postchatsurveypanestateful/common/defaultStyleProps/defaultgeneralPostChatSurveyPaneStyleProps.ts
+++ b/chat-widget/src/components/postchatsurveypanestateful/common/defaultStyleProps/defaultgeneralPostChatSurveyPaneStyleProps.ts
@@ -7,6 +7,5 @@ export const defaultGeneralPostChatSurveyPaneStyleProps: IStyle = {
     left: "0%",
     top: "0%",
     borderRadius: "0 0 4px 4px",
-    borderWidth: "0px",
-    display: "contents"
+    borderWidth: "0px"
 };


### PR DESCRIPTION
Embed:
![image](https://user-images.githubusercontent.com/14852927/232171563-1229b8fe-2686-41d6-b194-8e7e5bc68635.png)

Popout:
![image](https://user-images.githubusercontent.com/14852927/232171709-69aba71d-fcaf-4611-8822-9186aae510bd.png)

