### PR TITLE
3297996 c2 xss

### DIFF
--- a/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
+++ b/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
@@ -4,6 +4,7 @@ import { NotificationHandler } from "../../webchatcontainerstateful/webchatcontr
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
+import DOMPurify from "dompurify";
 
 const processDisplayName = (displayName: string): string => {
     // if displayname matches "teamsvisitor:<some alphanumeric string>", we replace it with "Customer"
@@ -61,7 +62,10 @@ const processContent = (transcriptContent: string, isAgentChat: boolean, renderM
     }
     if (renderMarkDown) {
         transcriptContent = renderMarkDown(transcriptContent);
+    }else{
+        transcriptContent = DOMPurify.sanitize(transcriptContent);
     }
+    
     return transcriptContent;
 };
 

--- a/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
+++ b/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
@@ -62,10 +62,10 @@ const processContent = (transcriptContent: string, isAgentChat: boolean, renderM
     }
     if (renderMarkDown) {
         transcriptContent = renderMarkDown(transcriptContent);
-    }else{
+    } else {
         transcriptContent = DOMPurify.sanitize(transcriptContent);
     }
-    
+
     return transcriptContent;
 };
 

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -37,7 +37,6 @@ import { getConversationDetails } from "./endChat";
 import HyperlinkTextOverrideRenderer from "../../webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer";
 import DOMPurify from "dompurify";
 
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, chatSDK: any) => {
     const localizedTexts = {

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -104,7 +104,8 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
         markdownRenderers.forEach((renderer) => {
             text = renderer.render(text);
         });
-
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        text = (window as any).DOMPurify.sanitize(text);
         return text;
     };
 

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -35,6 +35,8 @@ import createMessageTimeStampMiddleware from "../../webchatcontainerstateful/web
 import { ConversationEndEntity, ParticipantType } from "../../../common/Constants";
 import { getConversationDetails } from "./endChat";
 import HyperlinkTextOverrideRenderer from "../../webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer";
+import DOMPurify from "dompurify";
+
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, chatSDK: any) => {
@@ -105,7 +107,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
             text = renderer.render(text);
         });
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        text = (window as any).DOMPurify.sanitize(text);
+        text = DOMPurify.sanitize(text);
         return text;
     };
 


### PR DESCRIPTION


### Description
_Include a description of the problem to be solved_

When passing messages with potential XSS included as part of an image tag definition , the code is executed  on C2 side .

another side effect is that after the message is included, is no longer possible to send attachments after that.
sample message : 
<img src='#' onerror=alert(1) />

## Solution Proposed
_Detail what is the solution proposed, including links to the design document if required or any other document required to support the solution_

After research, it was found a problem in the markdown render component, the idea is to sanitize the content when rendering.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

-  when passing <img src='#' onerror=alert(1) /> , should not execute onerror call
- markdown should not be affected
- attachment should not be affected

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

![Recording-20230419_122743](https://user-images.githubusercontent.com/981914/233180454-1b4149e4-a3c2-430b-8da2-aa865a3bb283.gif)


