### PR TITLE
Fixed logging empty events

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Better handling of end chat in case of multitab scenarios
 - Prevent new chat creation failure after Proactive chat in Popout mode
 - Fixed post chat having gap in popout mode
+- Fixed logging empty events
 
 ## [1.0.2] - 2023-4-6
 

--- a/chat-widget/src/common/telemetry/TelemetryManager.ts
+++ b/chat-widget/src/common/telemetry/TelemetryManager.ts
@@ -77,7 +77,10 @@ export const RegisterLoggers = () => {
             const scenarioType = (telemetryEvent as ITelemetryEvent).payload?.scenarioType ?? ScenarioType.UNDEFINED;
             const telemetryInput = parseInput(telemetryEvent?.payload, scenarioType);
             telemetryInput.telemetryInfo = { telemetryInfo: TelemetryHelper.buildTelemetryEvent(logLevel, telemetryInput) };
-            logger.log(logLevel, telemetryInput);
+            //Do not log empty events without an Event Name
+            if (telemetryInput?.payload?.Event) {
+                logger.log(logLevel, telemetryInput);
+            }
         });
     };
     return registerLoggers();

--- a/chat-widget/src/common/telemetry/TelemetryManager.ts
+++ b/chat-widget/src/common/telemetry/TelemetryManager.ts
@@ -77,7 +77,7 @@ export const RegisterLoggers = () => {
             const scenarioType = (telemetryEvent as ITelemetryEvent).payload?.scenarioType ?? ScenarioType.UNDEFINED;
             const telemetryInput = parseInput(telemetryEvent?.payload, scenarioType);
             telemetryInput.telemetryInfo = { telemetryInfo: TelemetryHelper.buildTelemetryEvent(logLevel, telemetryInput) };
-            //Do not log empty events without an Event Name
+            //Do not log events without an Event Name
             if (telemetryInput?.payload?.Event) {
                 logger.log(logLevel, telemetryInput);
             }


### PR DESCRIPTION
Do not log events to loggers without an event name

Current issue:
![image](https://user-images.githubusercontent.com/45749980/233402318-a1ff84b1-32bb-4dc2-b362-4c40082f0ae4.png)

After fix:
![image](https://user-images.githubusercontent.com/45749980/233406112-51d6029f-39ce-4f5e-b237-4f38b80a2d27.png)

Test Script: https://sacadlcw001.blob.core.windows.net/lcwtpc/Test/TelemetryIssue/v2scripts/LiveChatBootstrapper.js