### PR TITLE
custom context not being passed in initial custom context

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - Better handling of end chat in case of multitab scenarios
 - Prevent new chat creation failure after Proactive chat in Popout mode
 - Fixed post chat having gap in popout mode
+- Fixed initial custom context not being passed to OC
+- Adding additional check for auth chats not to set custom context
 
 ## [1.0.2] - 2023-4-6
 

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -100,7 +100,7 @@ export enum TelemetryEvent {
     ChatVisibilityChanged = "ChatVisibilityChanged",
     EndChatSucceeded = "EndChatSucceeded",
     EndChatFailed = "EndChatFailed",
-
+    SetCustomContext = "SetCustomContext",
     WebChatLoaded = "WebChatLoaded",
     LCWChatButtonClicked = "LCWChatButtonClicked",
     LCWChatButtonShow = "LCWChatButtonShow",

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -261,16 +261,6 @@ const setCustomContextParams = (props?: ILiveChatWidgetProps) => {
     const persistedState = getStateFromCache(widgetInstanceId);
 
     if (!isUndefinedOrEmpty(persistedState?.domainStates?.customContext)) {
-        if (persistedState?.domainStates.liveChatConfig?.LiveChatConfigAuthSettings) {
-            const errorMessage = "Use of custom context with authenticated chat is deprecated. The chat would not go through.";
-            TelemetryHelper.logSDKEvent(LogLevel.WARN, {
-                Event: TelemetryEvent.StartChatMethodException,
-                ExceptionDetails: {
-                    exception: errorMessage
-                }
-            });
-            throw new Error(errorMessage);
-        }
         optionalParams = Object.assign({}, optionalParams, {
             customContext: persistedState?.domainStates?.customContext
         });

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -261,6 +261,11 @@ const setCustomContextParams = (props?: ILiveChatWidgetProps) => {
     const persistedState = getStateFromCache(widgetInstanceId);
 
     if (!isUndefinedOrEmpty(persistedState?.domainStates?.customContext)) {
+        TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
+            Event: TelemetryEvent.SetCustomContext,
+            Description: "Setting custom context for unauthenicated chat"
+        });
+
         optionalParams = Object.assign({}, optionalParams, {
             customContext: persistedState?.domainStates?.customContext
         });

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -118,7 +118,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
 
         try {
             // Set custom context params
-            setCustomContextParams();
+            setCustomContextParams(props);
             const defaultOptionalParams: StartChatOptionalParams = {
                 sendDefaultInitContext: true,
                 isProactiveChat: !!params?.isProactiveChat,
@@ -246,7 +246,17 @@ const canConnectToExistingChat = async (props: ILiveChatWidgetProps, chatSDK: an
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setCustomContextParams = () => {
+const setCustomContextParams = (props?: ILiveChatWidgetProps) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const isAuthenticatedChat = (props?.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
+    //Should not set custom context for auth chat
+    if (isAuthenticatedChat) {
+        return;
+    }
+
+    if (isNullOrEmptyString(widgetInstanceId)) {
+        widgetInstanceId = getWidgetCacheIdfromProps(props);
+    }
     // Add custom context only for unauthenticated chat
     const persistedState = getStateFromCache(widgetInstanceId);
 


### PR DESCRIPTION
Initial custom context is not passed to OC for unauth chats

Setting custom context:
![image](https://user-images.githubusercontent.com/45749980/233415095-f72e6e28-4c5d-416a-bda8-f88690d71b30.png)


Before Fix: (There is no other/additional detail tab)
![image](https://user-images.githubusercontent.com/45749980/233416812-926adda3-e807-46de-a7c7-bec94121970f.png)

After Fix:
![image](https://user-images.githubusercontent.com/45749980/233414809-90b590c0-a2ca-49c9-a33d-a7765b210d7b.png)
