### PR TITLE
close chat widget in all cases

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Better handling of end chat in case of multitab scenarios
 - Prevent new chat creation failure after Proactive chat in Popout mode
 - Fixed post chat having gap in popout mode
+- Fixing reconnect message is appearing even after end chat
 
 ## [1.0.2] - 2023-4-6
 

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -100,7 +100,7 @@ export enum TelemetryEvent {
     ChatVisibilityChanged = "ChatVisibilityChanged",
     EndChatSucceeded = "EndChatSucceeded",
     EndChatFailed = "EndChatFailed",
-    SetCustomContext = "SetCustomContext",
+    SettingCustomContext = "SettingCustomContext",
     WebChatLoaded = "WebChatLoaded",
     LCWChatButtonClicked = "LCWChatButtonClicked",
     LCWChatButtonShow = "LCWChatButtonShow",

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -120,9 +120,7 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
         } finally {
             dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
             // Always allow to close the chat for embedded mode irrespective of end chat errors
-            // Removed the hideStartChatButton check here as it leaves to webchat container open and poll messages, impacting reconnect
-            // There should be a confirmation screen for popout chat like a thank you page instead of just showing blank page, which could confuse customer
-            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
+            await closeChatWidget(dispatch, props, state);
         }
     }
 
@@ -158,6 +156,20 @@ const closeChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) 
             proactiveChatInNewWindow: false
         }
     });
+};
+
+const closeChatWidget = async (dispatch: Dispatch<ILiveChatWidgetAction>, props: ILiveChatWidgetProps, state: ILiveChatWidgetContext) => {
+    if (state?.appStates?.hideStartChatButton) {
+        // Only close chat if header is enabled for popout
+        // TODO : This condition needs to be removed eventually when the filler UX is ready for popout, removing this condition would show a blank screen for OOB Widget
+        if (props?.controlProps?.hideHeader === undefined || props?.controlProps?.hideHeader === false) {
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
+        }
+        return;
+    }
+
+    // Embedded chat
+    dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -120,7 +120,7 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
         } finally {
             dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
             // Always allow to close the chat for embedded mode irrespective of end chat errors
-            await closeChatWidget(dispatch, props, state);
+            closeChatWidget(dispatch, props, state);
         }
     }
 
@@ -135,7 +135,6 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
 
 const endChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
     // Need to clear these states immediately when chat ended from OC.
-    dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: false });
@@ -158,7 +157,7 @@ const closeChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) 
     });
 };
 
-const closeChatWidget = async (dispatch: Dispatch<ILiveChatWidgetAction>, props: ILiveChatWidgetProps, state: ILiveChatWidgetContext) => {
+const closeChatWidget = (dispatch: Dispatch<ILiveChatWidgetAction>, props: ILiveChatWidgetProps, state: ILiveChatWidgetContext) => {
     if (state?.appStates?.hideStartChatButton) {
         // Only close chat if header is enabled for popout
         // TODO : This condition needs to be removed eventually when the filler UX is ready for popout, removing this condition would show a blank screen for OOB Widget

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -119,10 +119,10 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
             });
         } finally {
             dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
-            //Always allow to close the chat for embedded mode irrespective of end chat errors
-            if (!state?.appStates?.hideStartChatButton) {
-                dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
-            }
+            // Always allow to close the chat for embedded mode irrespective of end chat errors
+            // Removed the hideStartChatButton check here as it leaves to webchat container open and poll messages, impacting reconnect
+            // There should be a confirmation screen for popout chat like a thank you page instead of just showing blank page, which could confuse customer
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
         }
     }
 

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -259,15 +259,15 @@ const setCustomContextParams = (props?: ILiveChatWidgetProps) => {
     }
     // Add custom context only for unauthenticated chat
     const persistedState = getStateFromCache(widgetInstanceId);
-
-    if (!isUndefinedOrEmpty(persistedState?.domainStates?.customContext)) {
+    const customContextLocal = persistedState?.domainStates?.customContext ?? props?.initialCustomContext;
+    if (customContextLocal) {
         TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
-            Event: TelemetryEvent.SetCustomContext,
+            Event: TelemetryEvent.SettingCustomContext,
             Description: "Setting custom context for unauthenicated chat"
         });
 
         optionalParams = Object.assign({}, optionalParams, {
-            customContext: persistedState?.domainStates?.customContext
+            customContext: customContextLocal
         });
     }
 };

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -230,6 +230,7 @@ Refer to the below table to understand different critical telemetry events raise
 | `ChatDisconnectThreadEventReceived` | On chat disconnected|
 | `GetConversationDetailsCallStarted` | On conversation detail api call start |
 | `GetChatReconnectContextSDKCallStarted` | On chat reconnect context api call start |
+| `SettingCustomContext` | Setting custom context |
 
 #### Calling Events
 


### PR DESCRIPTION
Chat widget is not closed when `hideStartChatButton` is `true`, causing poll reconnect messages even after end chat.

Present issue:
![image](https://user-images.githubusercontent.com/45749980/233423277-b37351fa-d60a-4a33-b700-0744445731cc.png)

After Fix:
![image](https://user-images.githubusercontent.com/45749980/233427901-8f29153d-1e76-4742-ad55-c49edb8389a2.png)

