### PR TITLE
Fix custom context in popout mode

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixed custom context not showing for popout chat
+
 ## [1.0.3] - 2023-4-24
 
 ### Added

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -129,6 +129,9 @@ export class Constants {
 
     // Visibility timeout for conversation details
     public static readonly LWICheckOnVisibilityTimeout = 3 * 60 * 1000; // 3 minute
+
+    // Popup mode custom context response event message name
+    public static readonly InitContextParamsResponse = "initContextParamsResponse";
 }
 
 export const Regex = class {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -269,8 +269,7 @@ const setCustomContextParams = async (props?: ILiveChatWidgetProps) => {
         optionalParams = Object.assign({}, optionalParams, {
             customContext: persistedState?.domainStates?.customContext
         });
-    } else
-    {
+    } else {
         const customContextFromParent = await getInitContextParamsForPopout();
         if (!isUndefinedOrEmpty(customContextFromParent?.contextVariables)) {
             optionalParams = Object.assign({}, optionalParams, {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -1,5 +1,5 @@
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
-import { ChatSDKError, LiveWorkItemState } from "../../../common/Constants";
+import { ChatSDKError, Constants, LiveWorkItemState } from "../../../common/Constants";
 import { createTimer, getStateFromCache, getWidgetCacheIdfromProps, isNullOrEmptyString, isUndefinedOrEmpty } from "../../../common/utils";
 import { getAuthClientFunction, handleAuthentication } from "./authHelper";
 
@@ -118,7 +118,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
 
         try {
             // Set custom context params
-            setCustomContextParams(props);
+            await setCustomContextParams(props);
             const defaultOptionalParams: StartChatOptionalParams = {
                 sendDefaultInitContext: true,
                 isProactiveChat: !!params?.isProactiveChat,
@@ -246,7 +246,7 @@ const canConnectToExistingChat = async (props: ILiveChatWidgetProps, chatSDK: an
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const setCustomContextParams = (props?: ILiveChatWidgetProps) => {
+const setCustomContextParams = async (props?: ILiveChatWidgetProps) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = (props?.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
     //Should not set custom context for auth chat
@@ -263,12 +263,20 @@ const setCustomContextParams = (props?: ILiveChatWidgetProps) => {
     if (!isUndefinedOrEmpty(persistedState?.domainStates?.customContext)) {
         TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
             Event: TelemetryEvent.SetCustomContext,
-            Description: "Setting custom context for unauthenicated chat"
+            Description: "Setting custom context for unauthenticated chat"
         });
 
         optionalParams = Object.assign({}, optionalParams, {
             customContext: persistedState?.domainStates?.customContext
         });
+    } else
+    {
+        const customContextFromParent = await getInitContextParamsForPopout();
+        if (!isUndefinedOrEmpty(customContextFromParent?.contextVariables)) {
+            optionalParams = Object.assign({}, optionalParams, {
+                customContext: customContextFromParent.contextVariables
+            });
+        }
     }
 };
 
@@ -332,5 +340,34 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
         chatSDK.requestId = currentRequestId;
         return false;
     }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getInitContextParamsForPopout = async (): Promise<any> => {
+    return window.opener ? await getInitContextParamForPopoutFromOuterScope(window.opener) : null;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const getInitContextParamForPopoutFromOuterScope = async (scope: any): Promise<any> =>  {
+    let payload;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let waitPromiseResolve: any;
+    const waitPromise = new Promise((res, rej) => {
+        waitPromiseResolve = res;
+        setTimeout(() => rej("Failed to find method in outer scope"), 5000);
+    }).catch((rej) => console.warn(rej));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getInitContextParamsFromParent = (e: any) => {
+        if (e.data && e.data.messageName == Constants.InitContextParamsResponse) {
+            payload = e.data.payload;
+            waitPromiseResolve();
+        }
+    };
+
+    window.addEventListener("message", getInitContextParamsFromParent, false);
+    scope.postMessage({ messageName: Constants.InitContextParamsResponse }, "*");
+    await waitPromise;
+    window.removeEventListener("message", getInitContextParamsFromParent, false);
+    return payload;
 };
 export { prepareStartChat, initStartChat, setPreChatAndInitiateChat, checkIfConversationStillValid };


### PR DESCRIPTION
Fixing the custom context data is not setup in V2 for popout mode (Unauthenticated).

Un-Auth Poput Mode V2 

![image](https://user-images.githubusercontent.com/49963796/234135773-9ff7db0a-1425-499b-ad5d-def87b2b2c94.png)

![image](https://user-images.githubusercontent.com/49963796/234135893-db9760d7-3eed-4af8-8720-d9741cb1d26c.png)

Authenticated Popout V2. Context being passed using JWT & SDK method. The JWT context shows up while the SDK method is not (expected behavior)

![image](https://user-images.githubusercontent.com/49963796/234136779-e1073fe6-ff5f-48e3-a0da-5849b895efb8.png)

![image](https://user-images.githubusercontent.com/49963796/234136893-310a758b-55ee-4d92-aa5b-0e2155c8c338.png)


Un-Auth - Embedded Mode V2
<img width="953" alt="image" src="https://user-images.githubusercontent.com/49963796/234112985-2936e51a-ae79-4ba5-ad79-f2fd845fba8c.png">

![image](https://user-images.githubusercontent.com/49963796/234113081-8d7d2b5e-21f1-48bb-a575-6ec688884431.png)

Authenticated Embedded V2 Context being passed using JWT & SDK method. The JWT context shows up while the SDK method is not (expected behavior)

![image](https://user-images.githubusercontent.com/49963796/234124562-43512add-7d49-4677-9413-1fa7cb4ff66c.png)

![image](https://user-images.githubusercontent.com/49963796/234124622-b7b2338a-f845-411c-8231-d89abb659b05.png)
