### PR TITLE
Exposing new prop to avoid automatically starting a new chat if already expired

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,9 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- allowStartNewChatIfExpired to ILiveChatWidgetProps
+
 ## Fixed
 
 - Fixed custom context not showing for popout chat
+- Fixed reconnect chat pane not showing, when hideStartChatButton is true
 
 ## [1.0.3] - 2023-4-24
 

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -55,7 +55,8 @@ export enum BroadcastEvent {
     InitiateStartChatInPopoutMode = "InitiateStartChatInPopoutMode",
     HideChatVisibilityChangeEvent = "hideChatVisibilityChangeEvent",
     UpdateSessionDataForTelemetry = "UpdateSessionDataForTelemetry",
-    UpdateConversationDataForTelemetry = "UpdateConversationDataForTelemetry"
+    UpdateConversationDataForTelemetry = "UpdateConversationDataForTelemetry",
+    ReconnectChatExpired = "ReconnectChatExpired"
 }
 
 // Events being logged

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -1743,5 +1743,6 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
     },
     telemetryConfig: undefined as unknown as ITelemetryConfig,
     getAuthToken: undefined,
-    initialCustomContext: undefined
+    initialCustomContext: undefined,
+    allowStartNewChatIfExpired: true
 };

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -243,7 +243,6 @@ const canConnectToExistingChat = async (props: ILiveChatWidgetProps, chatSDK: an
     if (persistedState &&
         !isUndefinedOrEmpty(persistedState?.domainStates?.liveChatContext) &&
         persistedState?.appStates?.conversationState === ConversationState.Active) {
-        console.log("test-refresh");
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
         const optionalParams = { liveChatContext: persistedState?.domainStates?.liveChatContext };
         await initStartChat(chatSDK, dispatch, setAdapter, props, optionalParams, persistedState);

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -51,6 +51,13 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
         return;
     }
 
+    if (props?.allowStartNewChatIfExpired === false) {
+        BroadcastService.postMessage({
+            eventName: BroadcastEvent.ReconnectChatExpired
+        });
+        return;
+    }
+    
     // Setting Proactive chat settings
     const isProactiveChat = state.appStates.conversationState === ConversationState.ProactiveChat;
     const isPreChatEnabledInProactiveChat = state.appStates.proactiveChatStates.proactiveChatEnablePrechat;
@@ -236,6 +243,7 @@ const canConnectToExistingChat = async (props: ILiveChatWidgetProps, chatSDK: an
     if (persistedState &&
         !isUndefinedOrEmpty(persistedState?.domainStates?.liveChatContext) &&
         persistedState?.appStates?.conversationState === ConversationState.Active) {
+        console.log("test-refresh");
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
         const optionalParams = { liveChatContext: persistedState?.domainStates?.liveChatContext };
         await initStartChat(chatSDK, dispatch, setAdapter, props, optionalParams, persistedState);

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
@@ -64,4 +64,5 @@ export interface ILiveChatWidgetProps {
     allowSdkChatSupport?: boolean; // to avoid any performance impact
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     initialCustomContext?: any;
+    allowStartNewChatIfExpired?: boolean;
 }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -155,6 +155,20 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         if (isChatValid === false) {
             if (localState) {
+                // adding the reconnect logic for the case when they try to reconnect from a new browser or InPrivate browser
+                if (isReconnectEnabled(props.chatConfig) === true) {
+                    await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+                    // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
+                    if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
+                        return;
+                    }
+                }
+                if (props?.allowStartNewChatIfExpired === false) {
+                    BroadcastService.postMessage({
+                        eventName: BroadcastEvent.ReconnectChatExpired
+                    });
+                    return;
+                }
                 await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, undefined, undefined, localState, props);
                 return;
             } else {

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -139,6 +139,7 @@ Refer to the below table to understand different broadcast events raised during 
 | `RaiseErrorEvent`                 | On raising error events |
 | `UpdateSessionDataForTelemetry`         | On Chat Id and Request Id being populated for telemetry|
 | `UpdateConversationDataForTelemetry`    | On Conversation (LiveWorkItem) Id being populated for telemetry |
+| `ReconnectChatExpired`    | On reconnect chat expired |
 
 ### Telemetry Events
 


### PR DESCRIPTION
1) Adding allowStartNewChatIfExpired to ILiveChatWidgetProps.

Do not start chat automatically when when allowStartNewChatIfExpired is false, but send a broadcast event instead. 

Below is the UI:

**Embed**:
![allowStartNewChatIfExpiredEmbed](https://user-images.githubusercontent.com/104658006/235373778-f1b7d841-8d66-443d-9935-ff8483392fbf.png)


**hideStartChatButton**:
![allowStartNewChatIfExpiredHideChatButton](https://user-images.githubusercontent.com/104658006/235373788-6f2b6df0-4767-4e65-a320-f4cfec1f116b.png)


**Popout**:
![allowStartNewChatIfExpiredPopout](https://user-images.githubusercontent.com/104658006/235373791-6698bed9-ab60-4453-8391-d1cfd854dcc2.png)


2) Fixing reconnect chat pane, when hideStartChatButton is true. Without this fix, if hideStartChatButton is true and we try to reconnect in a different browser, or InPrivate browser, reconnect pane doesn't show.

The following bootstrapper link includes the changes:
https://nisrastorageaccount.blob.core.windows.net/lcw2testing/dist/v2scripts/LiveChatBootstrapper.js