### PR TITLE
Use old LiveChatContext for downloading transcript after endChat

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ## Fixed
 
 - Fixed custom context not showing for popout chat
+- Fixed an issue where after ending chat and downloading transcript, a new chat cannot be started
 
 ## [1.0.3] - 2023-4-24
 

--- a/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
+++ b/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
@@ -4,6 +4,7 @@ import { NotificationHandler } from "../../webchatcontainerstateful/webchatcontr
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
+import LiveChatContext from "@microsoft/omnichannel-chat-sdk/lib/core/LiveChatContext";
 
 const processDisplayName = (displayName: string): string => {
     // if displayname matches "teamsvisitor:<some alphanumeric string>", we replace it with "Customer"
@@ -162,12 +163,11 @@ const beautifyChatTranscripts = (chatTranscripts: string, renderMarkDown?: (tran
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const downloadTranscript = async (chatSDK: any, renderMarkDown?: (transcriptContent: string) => string, bannerMessageOnError?: string, attachmentMessage?: string, state?: ILiveChatWidgetContext) => {
     // Need to keep existing request id for scenarios when trnascript is downloaded after endchat
-    const existingRequestId = chatSDK.requestId;
-    chatSDK.chatToken = state?.domainStates?.chatToken;
-    chatSDK.requestId = state?.domainStates?.chatToken?.requestId;
-    let data = await chatSDK?.getLiveChatTranscript();
-    // This is used for allowing to start next chat
-    chatSDK.requestId = existingRequestId;
+    const liveChatContext: LiveChatContext = {
+        chatToken: state?.domainStates?.chatToken,
+        requestId: state?.domainStates?.chatToken?.requestId
+    };
+    let data = await chatSDK?.getLiveChatTranscript({liveChatContext});
     if (typeof (data) === Constants.String) {
         data = JSON.parse(data);
     }


### PR DESCRIPTION
[Bug 3304875](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3304875): [V2] Ending chat from bot/agent and downloading transcript then starting chat does not wotk

https://user-images.githubusercontent.com/14852927/236058229-faea5676-8253-4658-9685-bdfded525aee.mp4

