### PR TITLE
Reconnect when hideStartChatButton is true

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where hideStartChatButton is true, and customer tries to reconnect from a new browser or InPrivate browser
+
 ## [1.0.4] - 2023-5-8
 
 ### Added

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -155,6 +155,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         if (isChatValid === false) {
             if (localState) {
+                // adding the reconnect logic for the case when customer tries to reconnect from a new browser or InPrivate browser
+                if (isReconnectEnabled(props.chatConfig) === true) {
+                    await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+                    // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
+                    if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
+                        return;
+                    }
+                }
                 await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, undefined, undefined, localState, props);
                 return;
             } else {


### PR DESCRIPTION
Reconnect logic is missing for the case where hideStartChatButton is true, and customer tries to reconnect from a new browser or InPrivate browser.