### PR TITLE
Support text spacing for chat button

### DIFF
--- a/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonGeneralStyles.ts
+++ b/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonGeneralStyles.ts
@@ -23,5 +23,5 @@ export const defaultChatButtonGeneralStyles: IStyle = {
             outline: "dotted 2px #000"
         }
     },
-    width: "180px"
+    minWidth: "180px"
 };

--- a/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonSubTitleStyles.ts
+++ b/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonSubTitleStyles.ts
@@ -13,5 +13,6 @@ export const defaultChatButtonSubTitleStyles: IStyle = {
     padding: "0px",
     textOverflow: "ellipsis !important",
     whiteSpace: "nowrap",
-    minWidth: "90px"
+    minWidth: "90px",
+    maxWidth: "105px"
 };

--- a/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonSubTitleStyles.ts
+++ b/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonSubTitleStyles.ts
@@ -13,5 +13,5 @@ export const defaultChatButtonSubTitleStyles: IStyle = {
     padding: "0px",
     textOverflow: "ellipsis !important",
     whiteSpace: "nowrap",
-    width: "90px"
+    minWidth: "90px"
 };

--- a/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonTitleStyles.ts
+++ b/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonTitleStyles.ts
@@ -14,5 +14,5 @@ export const defaultChatButtonTitleStyles: IStyle = {
     padding: "0px",
     textOverflow: "ellipsis !important",
     whiteSpace: "nowrap",
-    width: "90px"
+    minWidth: "90px"
 };

--- a/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonTitleStyles.ts
+++ b/chat-components/src/components/chatbutton/common/defaultStyles/defaultChatButtonTitleStyles.ts
@@ -14,5 +14,6 @@ export const defaultChatButtonTitleStyles: IStyle = {
     padding: "0px",
     textOverflow: "ellipsis !important",
     whiteSpace: "nowrap",
-    minWidth: "90px"
+    minWidth: "90px",
+    maxWidth: "105px"
 };


### PR DESCRIPTION

after consulting A11Y  help desk :  

- we are obligated to support our base case (Let's chat) for text spacing within the limits of the rule

1. Line height (line spacing) to at least 1.5 times the font size; 
2. Spacing following paragraphs to at least 2 times the font size; 
3. Letter spacing (tracking) to at least 0.12 times the font size; 
4. Word spacing to at least 0.16 times the font size. 

For custom text, defined by the customer, we are not obligated to scale the button to accommodate such text.
 
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/8c66d1f0-6f81-422a-9350-faedab468010)
