### PR TITLE
allow to pass chat token in props to avoid duplicate chats

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Fixed an issue where sending "InitiateEndChat" event doesn't end chat when no post chat is configured
 - Fixed logging empty events
 - Fixing reconnect message is appearing even after end chat
+- Adding capability to pass chat token through props to avoid duplicate chats between browsers
 
 ## [1.0.2] - 2023-4-6
 

--- a/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
+++ b/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
@@ -13,28 +13,24 @@ import { defaultTelemetryConfiguration } from "../../../common/telemetry/default
 
 export const registerTelemetryLoggers = (props: ILiveChatWidgetProps, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     const telemetryConfig: ITelemetryConfig = { ...defaultTelemetryConfiguration, ...props.telemetryConfig };
-    if (props.liveChatContextFromCache?.domainStates?.telemetryInternalData) {
-        TelemetryManager.InternalTelemetryData = props.liveChatContextFromCache?.domainStates?.telemetryInternalData;
-    } else {
-        let telemetryData: IInternalTelemetryData = {
-            ...defaultInternalTelemetryData,
-            telemetryConfig: Object.assign({}, defaultTelemetryConfiguration, telemetryConfig),
-            ariaConfig: Object.assign({}, defaultAriaConfig, telemetryConfig?.ariaConfigurations)
-        };
+    let telemetryData: IInternalTelemetryData = {
+        ...defaultInternalTelemetryData,
+        telemetryConfig: Object.assign({}, defaultTelemetryConfiguration, telemetryConfig),
+        ariaConfig: Object.assign({}, defaultAriaConfig, telemetryConfig?.ariaConfigurations)
+    };
 
-        if (props.chatConfig) {
-            telemetryData = TelemetryHelper.addChatConfigDataToTelemetry(props?.chatConfig, telemetryData);
-        }
-        telemetryData = TelemetryHelper.addWidgetDataToTelemetry(telemetryConfig, telemetryData);
-        telemetryData.OCChatSDKVersion = telemetryConfig.OCChatSDKVersion ?? "0.0.0-0";
-        telemetryData.chatComponentVersion = telemetryConfig.chatComponentVersion ?? "0.0.0-0";
-        telemetryData.chatWidgetVersion = telemetryConfig.chatWidgetVersion ?? "0.0.0-0";
-        telemetryData.orgId = props.chatSDK?.omnichannelConfig?.orgId;
-        telemetryData.widgetId = props.chatSDK?.omnichannelConfig?.widgetId;
-        telemetryData.orgUrl = props.chatSDK?.omnichannelConfig?.orgUrl;
-        TelemetryManager.InternalTelemetryData = telemetryData;
-
-        dispatch({ type: LiveChatWidgetActionType.SET_TELEMETRY_DATA, payload: telemetryData });
+    if (props.chatConfig) {
+        telemetryData = TelemetryHelper.addChatConfigDataToTelemetry(props?.chatConfig, telemetryData);
     }
+    telemetryData = TelemetryHelper.addWidgetDataToTelemetry(telemetryConfig, telemetryData);
+    telemetryData.OCChatSDKVersion = telemetryConfig.OCChatSDKVersion ?? "0.0.0-0";
+    telemetryData.chatComponentVersion = telemetryConfig.chatComponentVersion ?? "0.0.0-0";
+    telemetryData.chatWidgetVersion = telemetryConfig.chatWidgetVersion ?? "0.0.0-0";
+    telemetryData.orgId = props.chatSDK?.omnichannelConfig?.orgId;
+    telemetryData.widgetId = props.chatSDK?.omnichannelConfig?.widgetId;
+    telemetryData.orgUrl = props.chatSDK?.omnichannelConfig?.orgUrl;
+    TelemetryManager.InternalTelemetryData = telemetryData;
+
+    dispatch({ type: LiveChatWidgetActionType.SET_TELEMETRY_DATA, payload: telemetryData });
     RegisterLoggers();
 };

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -304,13 +304,13 @@ const canStartPopoutChat = async (props: ILiveChatWidgetProps) => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, state: ILiveChatWidgetContext, props: ILiveChatWidgetProps): Promise<boolean> => {
-    let requestIdFromCache = state.domainStates?.liveChatContext?.requestId ?? undefined;
+    let requestIdFromCache = props?.liveChatContextFromCache?.requestId ?? undefined;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let conversationDetails: any = undefined;
 
-    // localStorage has more precedence, if its null check if requestid passed in props
     if (isNullOrUndefined(requestIdFromCache)) {
-        requestIdFromCache = props?.liveChatContextFromCache?.requestId ?? undefined;
+        requestIdFromCache = state.domainStates?.liveChatContext?.requestId ?? undefined;
     }
 
     // There is no cached request id, so no existing conversation to check

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
@@ -23,6 +23,7 @@ import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidget
 import { IContextDataStore } from "../../../common/interfaces/IContextDataStore";
 import { IPostChatSurveyPaneStatefulProps } from "../../postchatsurveypanestateful/interfaces/IPostChatSurveyPaneStatefulProps";
 import { IScrollBarProps } from "./IScrollBarProps";
+import LiveChatContext from "@microsoft/omnichannel-chat-sdk/lib/core/LiveChatContext";
 
 export interface ILiveChatWidgetProps {
     audioNotificationProps?: IAudioNotificationProps;
@@ -56,7 +57,7 @@ export interface ILiveChatWidgetProps {
     styleProps?: ILiveChatWidgetStyleProps;
     telemetryConfig: ITelemetryConfig;
     webChatContainerProps?: IWebChatContainerStatefulProps;
-    liveChatContextFromCache?: ILiveChatWidgetContext;
+    liveChatContextFromCache?: LiveChatContext;
     contextDataStore?: IContextDataStore;
     getAuthToken?: (authClientFunction?: string) => Promise<string | null>;
     scrollBarProps?: IScrollBarProps;

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
@@ -19,7 +19,6 @@ import { IStartChatErrorPaneProps } from "../../loadingpanestateful/interfaces/I
 import { ITelemetryConfig } from "../../../common/telemetry/interfaces/ITelemetryConfig";
 import { IWebChatContainerStatefulProps } from "../../webchatcontainerstateful/interfaces/IWebChatContainerStatefulProps";
 import { OmnichannelChatSDK } from "@microsoft/omnichannel-chat-sdk";
-import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 import { IContextDataStore } from "../../../common/interfaces/IContextDataStore";
 import { IPostChatSurveyPaneStatefulProps } from "../../postchatsurveypanestateful/interfaces/IPostChatSurveyPaneStatefulProps";
 import { IScrollBarProps } from "./IScrollBarProps";

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -141,7 +141,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
 
             //Check if conversation state is not in wrapup or closed state
-            isChatValid = await checkIfConversationStillValid(chatSDK, dispatch, state);
+            isChatValid = await checkIfConversationStillValid(chatSDK, dispatch, state, props);
             if (isChatValid === true) {
                 //Check if reconnect enabled
                 if (isReconnectEnabled(props.chatConfig) === true) {

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -120,6 +120,9 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             state?.appStates?.conversationState === ConversationState.Active) {
             activeCachedChatExist = true;
             optionalParams = { liveChatContext: state?.domainStates?.liveChatContext };
+        } else if (!isUndefinedOrEmpty(props?.liveChatContextFromCache)) {
+            activeCachedChatExist = true;
+            optionalParams = { liveChatContext: props?.liveChatContextFromCache };
         } else {
             activeCachedChatExist = false;
             optionalParams = {};


### PR DESCRIPTION
Problem: Partners reported issues that if same chat url is used in two or more different browser or cleared cache, customers can start multiple chats for same chat url.

Root cause: Chat widget depends on the `localStorage` cache. When the users are copying same chat url to a different browsers, there are no localStorage available and causing to start new chat.

Fix: Allows partners to store the chat token in their own storage and pass that in to chat widget through props. If the chat token is recognized and valid customers can use same chat, otherwise start a new chat.