### PR TITLE
removing region landmarks from footer and header

### DIFF
--- a/chat-components/src/components/footer/Footer.tsx
+++ b/chat-components/src/components/footer/Footer.tsx
@@ -52,9 +52,9 @@ function Footer(props: IFooterProps) {
         props.styleProps?.footerItemFocusStyleProps);
 
     return (
-        <Stack id={footerId} horizontal className={props.className} horizontalAlign="space-between"
+        <Stack as="article" id={footerId} horizontal className={props.className} horizontalAlign="space-between"
             verticalAlign="center" styles={stackStyles}
-            dir={props.controlProps?.dir ?? "ltr"} role="region">
+            dir={props.controlProps?.dir ?? "ltr"}>
             <Stack horizontal id={Ids.FooterLeftGroupId} verticalAlign="center">
                 {!props.controlProps?.hideDownloadTranscriptButton && (decodeComponentString(props.componentOverrides?.DownloadTranscriptButton) ||
                     <DownloadTranscriptButton

--- a/chat-components/src/components/header/Header.tsx
+++ b/chat-components/src/components/header/Header.tsx
@@ -60,9 +60,9 @@ function Header(props: IHeaderProps) {
 
     return (
 
-        <Stack id={headerId} horizontal className={props.className} horizontalAlign="space-between"
+        <Stack as="article" id={headerId} horizontal className={props.className} horizontalAlign="space-between"
             styles={stackStyles}
-            dir={props.controlProps?.dir ?? "ltr"} role="region">
+            dir={props.controlProps?.dir ?? "ltr"}>
             <Stack horizontal id={Ids.HeaderLeftGroupId} verticalAlign="center">
                 <Stack horizontal verticalAlign="center">
                     {processCustomComponents(props.controlProps?.leftGroup?.children)}


### PR DESCRIPTION
we are removing unnecessary Landmarks and switching from using div to the article.

We can control only for Header and Footer.


issue created for webchat : https://github.com/microsoft/BotFramework-WebChat/issues/4733


<img width="312" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/3983fa95-e7fe-4ea1-8e64-3c372485bbf2">


