### PR TITLE
Post chat survey is not rendered in reconnect scenarios

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed an issue where hideStartChatButton is true, and customer tries to reconnect from a new browser or InPrivate browser
+- Fixed post chat survey not rendered for reconnect scnearios
 
 ## [1.0.4] - 2023-5-8
 

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -53,7 +53,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
 
         // Initiate post chat render
         if (state?.domainStates?.postChatContext) {
-            await initiatePostChat(props, conversationDetails, state, dispatch);
+            await initiatePostChat(props, conversationDetails, state, dispatch, postchatContext);
             return;
         }
     }

--- a/chat-widget/src/components/livechatwidget/common/renderSurveyHelpers.ts
+++ b/chat-widget/src/components/livechatwidget/common/renderSurveyHelpers.ts
@@ -77,9 +77,10 @@ const embedModePostChatWorkflow = async (state: ILiveChatWidgetContext, dispatch
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const initiatePostChat = async (props: ILiveChatWidgetProps, conversationDetailsParam: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>) => {
+const initiatePostChat = async (props: ILiveChatWidgetProps, conversationDetailsParam: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, postchatContext: any) => {
     conversationDetails = conversationDetailsParam;
-    await setSurveyMode(props, conversationDetails?.participantType, state, dispatch);
+    const participantType = conversationDetails?.participantType ?? postchatContext.participantType;
+    await setSurveyMode(props, participantType, state, dispatch);
 
     await renderSurvey(state, dispatch);
 };


### PR DESCRIPTION
Issue: Post chat survey is not rendered for reconnect scenarios when agent ends conversation

Root cause: The service design is such that during reconnect scenario is the conversation is in Closed state, the service doesn't return anything. As LCW is dependent on participant type from `chatSDK.getConversationDetails()`, returning undefined on this case causes post chat to not load.

Fix: Adding if `conversationDetails.participantType` is undefined, then consider the value from `postChatContext.participantType`

Screenshots:

![post chat survey pane](https://github.com/microsoft/omnichannel-chat-widget/assets/104658006/36535683-525f-402e-8754-a23da89ae063)
![reconnect pane](https://github.com/microsoft/omnichannel-chat-widget/assets/104658006/111969e8-d4d0-4722-974f-6a456663071a)

Bot Ends chat

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/30007388/8b8d6c48-f3f5-48e2-8b07-337ad5b2a26f)

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/30007388/1d798e91-cd06-4bd1-a02c-0535fc433a55)
