### PR TITLE
Aria Logger Fix

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed custom context not showing for popout chat
 - Fix `ariaTelemetryLogger` not updating `collectorUri`
+- Update `environmentVersion` to be `prod` by default in `defaultInternalTelemetryData`
 
 ## [1.0.3] - 2023-4-24
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ## Fixed
 
 - Fixed custom context not showing for popout chat
+- Fix `ariaTelemetryLogger` not updating `collectorUri`
 
 ## [1.0.3] - 2023-4-24
 

--- a/chat-widget/src/common/telemetry/defaultConfigs/defaultTelemetryInternalData.ts
+++ b/chat-widget/src/common/telemetry/defaultConfigs/defaultTelemetryInternalData.ts
@@ -1,7 +1,7 @@
 import { IInternalTelemetryData } from "../interfaces/IInternalTelemetryData";
 
 export const defaultInternalTelemetryData: IInternalTelemetryData = {
-    environmentVersion: "test",
+    environmentVersion: "prod",
     chatWidgetLocaleLCID: "1033",
     channelId: "lcw2.0",
 };


### PR DESCRIPTION
- Fix `AriaTelemetryLogger` to be initialized to pick the proper `collectorUI` on every logging event
- Update `environmentVersion` to be `prod` by default in `defaultInternalTelemetryData`