### PR TITLE
Added `enablePrechat` in `ProactiveChatStartPopoutChat` broadcast event

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `enablePrechat` in `ProactiveChatStartPopoutChat` broadcast event
+- If `hidePreChatSurveyPane` is set, skip rendering prechat
+
 ### Fixed
 
 - Fixed an issue where hideStartChatButton is true, and customer tries to reconnect from a new browser or InPrivate browser

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -66,7 +66,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
-    const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : preChatSurveyResponse;
+    const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
 
     if (showPrechat) {
         dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });

--- a/chat-widget/src/components/proactivechatpanestateful/ProactiveChatPaneStateful.tsx
+++ b/chat-widget/src/components/proactivechatpanestateful/ProactiveChatPaneStateful.tsx
@@ -54,6 +54,9 @@ export const ProactiveChatPaneStateful = (props: any) => {
                 // TODO: BroadcastService: replace with the sdk broadcast service, when in place
                 const startPopoutChatEvent: ICustomEvent = {
                     eventName: BroadcastEvent.ProactiveChatStartPopoutChat,
+                    payload: {
+                        enablePrechat: state?.appStates?.proactiveChatStates?.proactiveChatEnablePrechat === true
+                    }
                 };
                 BroadcastService.postMessage(startPopoutChatEvent);
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });


### PR DESCRIPTION
Bug: [Bug 3262457](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3262457): [V2] Microsoft.Omnichannel.LiveChatWidget.SDK.startProactiveChat({}, false, {inNewWindow: true}) still shows prechat pane on popout

| | PreChat | No PreChat |
| --- | --- | --- |
| Popout |  ![pro-pre-popout](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/ce45ad2c-c944-42f7-9a83-f5b8a22c8ae5) |  ![pro-nopre-popout](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/b70363bd-2c9e-47bc-8b3e-09ec34ecc41b)|
| Embed | ![pro-pre-embed](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/27ba0300-8be7-496d-832c-021b3b68127a) | ![pro-nopre-embed](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/55eb2964-56e1-4f87-bbc1-a96deb9bf024) |

