### PR TITLE
Expose `adaptiveCardsHostConfig` from webchat and force button text wrap

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `adaptiveCardsHostConfig` from webchat and force button text wrap
+
 ## [1.0.5] - 2023-5-26
 
 ### Added

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -1,25 +1,26 @@
 import { IStackStyles, Stack } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
-import { Components } from "botframework-webchat";
+
+import { BotMagicCodeStore } from "./webchatcontroller/BotMagicCodeStore";
 import { BroadcastChannel } from "broadcast-channel";
+import { Components } from "botframework-webchat";
+import { Constants } from "../../common/Constants";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
 import { ILiveChatWidgetContext } from "../../contexts/common/ILiveChatWidgetContext";
 import { IWebChatContainerStatefulProps } from "./interfaces/IWebChatContainerStatefulProps";
 import { LiveChatWidgetActionType } from "../../contexts/common/LiveChatWidgetActionType";
 import { TelemetryHelper } from "../../common/telemetry/TelemetryHelper";
+import { WebChatActionType } from "./webchatcontroller/enums/WebChatActionType";
+import { WebChatStoreLoader } from "./webchatcontroller/WebChatStoreLoader";
+import { defaultAdaptiveCardStyles } from "./common/defaultStyles/defaultAdaptiveCardStyles";
 import { defaultMiddlewareLocalizedTexts } from "./common/defaultProps/defaultMiddlewareLocalizedTexts";
+import { defaultReceivedMessageAnchorStyles } from "./webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultReceivedMessageAnchorStyles";
+import { defaultSystemMessageBoxStyles } from "./webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultSystemMessageBoxStyles";
+import { defaultUserMessageBoxStyles } from "./webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultUserMessageBoxStyles";
 import { defaultWebChatContainerStatefulProps } from "./common/defaultProps/defaultWebChatContainerStatefulProps";
 import { setFocusOnSendBox } from "../../common/utils";
 import { useChatContextStore } from "../..";
-import { WebChatActionType } from "./webchatcontroller/enums/WebChatActionType";
-import { WebChatStoreLoader } from "./webchatcontroller/WebChatStoreLoader";
-import { Constants } from "../../common/Constants";
-import { BotMagicCodeStore } from "./webchatcontroller/BotMagicCodeStore";
-import { defaultAdaptiveCardStyles } from "./common/defaultStyles/defaultAdaptiveCardStyles";
-import { defaultReceivedMessageAnchorStyles } from "./webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultReceivedMessageAnchorStyles";
-import { defaultUserMessageBoxStyles } from "./webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultUserMessageBoxStyles";
-import { defaultSystemMessageBoxStyles } from "./webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultSystemMessageBoxStyles";
 
 const broadcastChannelMessageEvent = "message";
 const postActivity = (activity: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -123,7 +124,9 @@ export const WebChatContainerStateful = (props: IWebChatContainerStatefulProps) 
             max-width: ${props?.renderingMiddlewareProps?.systemMessageBoxStyles?.maxWidth ?? defaultSystemMessageBoxStyles?.maxWidth}
         }
 
-        div[class="ac-textBlock"]>p{color:${props?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color};}
+        div[class="ac-textBlock"]>p{color:${props?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color}; white-space:${props?.adaptiveCardStyles?.textWhiteSpace ?? defaultAdaptiveCardStyles.textWhiteSpace}}
+        
+        .webchat__stacked-layout__content .ac-actionSet > .ac-pushButton > div {white-space: ${props?.adaptiveCardStyles?.buttonWhiteSpace ?? defaultAdaptiveCardStyles.buttonWhiteSpace} !important;}
 
         .ms_lcw_webchat_received_message img.webchat__markdown__external-link-icon { 
             background-image : url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIzIDMgMTggMTgiICB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik03LjI1MDEgNC41MDAxN0gxMC43NDk1QzExLjE2MzcgNC41MDAxNyAxMS40OTk1IDQuODM1OTYgMTEuNDk5NSA1LjI1MDE3QzExLjQ5OTUgNS42Mjk4NiAxMS4yMTczIDUuOTQzNjYgMTAuODUxMyA1Ljk5MzMyTDEwLjc0OTUgNi4wMDAxN0g3LjI0OTc0QzYuMDcwNzkgNS45OTk2MSA1LjEwMzQ5IDYuOTA2NTYgNS4wMDc4NiA4LjA2MTEyTDUuMDAwMjggOC4yMjAwM0w1LjAwMzEyIDE2Ljc1MDdDNS4wMDM0MyAxNy45NDE1IDUuOTI4ODUgMTguOTE2MSA3LjA5OTY2IDE4Ljk5NDlMNy4yNTM3MSAxOS4wMDAxTDE1Ljc1MTggMTguOTg4NEMxNi45NDE1IDE4Ljk4NjggMTcuOTE0NSAxOC4wNjIgMTcuOTkzNSAxNi44OTIzTDE3Ljk5ODcgMTYuNzM4NFYxMy4yMzIxQzE3Ljk5ODcgMTIuODE3OSAxOC4zMzQ1IDEyLjQ4MjEgMTguNzQ4NyAxMi40ODIxQzE5LjEyODQgMTIuNDgyMSAxOS40NDIyIDEyLjc2NDMgMTkuNDkxOCAxMy4xMzAzTDE5LjQ5ODcgMTMuMjMyMVYxNi43Mzg0QzE5LjQ5ODcgMTguNzQwNyAxNy45MjkzIDIwLjM3NjkgMTUuOTUyOCAyMC40ODI5TDE1Ljc1MzggMjAuNDg4NEw3LjI1ODI3IDIwLjUwMDFMNy4wNTQ5NSAyMC40OTQ5QzUuMTQyMzkgMjAuMzk1NCAzLjYwODk1IDE4Ljg2MjcgMy41MDgzNyAxNi45NTAyTDMuNTAzMTIgMTYuNzUxMUwzLjUwMDg5IDguMjUyN0wzLjUwNTI5IDguMDUwMkMzLjYwNTM5IDYuMTM3NDkgNS4xMzg2NyA0LjYwNDQ5IDcuMDUwOTYgNC41MDUyN0w3LjI1MDEgNC41MDAxN0gxMC43NDk1SDcuMjUwMVpNMTMuNzQ4MSAzLjAwMTQ2TDIwLjMwMTggMy4wMDE5N0wyMC40MDE0IDMuMDE1NzVMMjAuNTAyMiAzLjA0MzkzTDIwLjU1OSAzLjA2ODAzQzIwLjYxMjIgMy4wOTEyMiAyMC42NjM0IDMuMTIxNjMgMjAuNzExMSAzLjE1ODg1TDIwLjc4MDQgMy4yMjE1NkwyMC44NjQxIDMuMzIwMTRMMjAuOTE4MyAzLjQxMDI1TDIwLjk1NyAzLjUwMDU3TDIwLjk3NjIgMy41NjQ3NkwyMC45ODk4IDMuNjI4NjJMMjAuOTk5MiAzLjcyMjgyTDIwLjk5OTcgMTAuMjU1NEMyMC45OTk3IDEwLjY2OTYgMjAuNjYzOSAxMS4wMDU0IDIwLjI0OTcgMTEuMDA1NEMxOS44NyAxMS4wMDU0IDE5LjU1NjIgMTAuNzIzMiAxOS41MDY1IDEwLjM1NzFMMTkuNDk5NyAxMC4yNTU0TDE5LjQ5ODkgNS41NjE0N0wxMi4yNzk3IDEyLjc4NDdDMTIuMDEzNCAxMy4wNTEgMTEuNTk2OCAxMy4wNzUzIDExLjMwMzEgMTIuODU3NUwxMS4yMTkgMTIuNzg0OUMxMC45NTI3IDEyLjUxODcgMTAuOTI4NCAxMi4xMDIxIDExLjE0NjIgMTEuODA4NEwxMS4yMTg4IDExLjcyNDNMMTguNDM2OSA0LjUwMTQ2SDEzLjc0ODFDMTMuMzY4NCA0LjUwMTQ2IDEzLjA1NDYgNC4yMTkzMSAxMy4wMDUgMy44NTMyNEwxMi45OTgxIDMuNzUxNDZDMTIuOTk4MSAzLjM3MTc3IDEzLjI4MDMgMy4wNTc5NyAxMy42NDY0IDMuMDA4MzFMMTMuNzQ4MSAzLjAwMTQ2WiIgZmlsbD0iI0ZGRkZGRiIgLz48L3N2Zz4) !important;

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles.ts
@@ -3,6 +3,6 @@ import { IAdaptiveCardStyles } from "../../interfaces/IAdaptiveCardStyles";
 export const defaultAdaptiveCardStyles: IAdaptiveCardStyles = {
     background: "white",
     color: "black",
-    textWhiteSpace: "nowrap",
+    textWhiteSpace: "normal",
     buttonWhiteSpace: "normal"
 };

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles.ts
@@ -2,5 +2,7 @@ import { IAdaptiveCardStyles } from "../../interfaces/IAdaptiveCardStyles";
 
 export const defaultAdaptiveCardStyles: IAdaptiveCardStyles = {
     background: "white",
-    color: "black"
+    color: "black",
+    textWhiteSpace: "nowrap",
+    buttonWhiteSpace: "normal"
 };

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IAdaptiveCardStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IAdaptiveCardStyles.ts
@@ -1,4 +1,6 @@
 export interface IAdaptiveCardStyles {
     background?: string;
     color?: string;
+    buttonWhiteSpace?: string;
+    textWhiteSpace?: string;
 }

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatProps.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatProps.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { ActivityMiddleware, ActivityStatusMiddleware, AttachmentForScreenReaderMiddleware, AttachmentMiddleware, AvatarMiddleware, CardActionMiddleware, GroupActivitiesMiddleware, ScrollToEndButtonMiddleware, ToastMiddleware, TypingIndicatorMiddleware, WebSpeechPonyfillFactory } from "botframework-webchat-api";
 import { DirectLineActivity, OneOrMany } from "botframework-webchat-core";
 
@@ -7,6 +9,7 @@ export interface IWebChatProps {
     // "core" props: language-neutral, SHOULD work on React Native (if we work on that later)
     activityMiddleware?: OneOrMany<ActivityMiddleware>;
     activityStatusMiddleware?: OneOrMany<ActivityStatusMiddleware>;
+    adaptiveCardsHostConfig?: any;
     attachmentForScreenReaderMiddleware?: OneOrMany<AttachmentForScreenReaderMiddleware>;
     attachmentMiddleware?: OneOrMany<AttachmentMiddleware>;
     avatarMiddleware?: OneOrMany<AvatarMiddleware>;
@@ -15,27 +18,27 @@ export interface IWebChatProps {
     dir?: string;
     disabled?: boolean;
     downscaleImageToDataURL?: (blob: Blob, maxWidth: number, maxHeight: number, type: string, quality: number) => string;
-    grammars?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    grammars?: any;
     groupActivitiesMiddleware?: OneOrMany<GroupActivitiesMiddleware>;
     internalErrorBoxClass?: React.Component | Function; // eslint-disable-line @typescript-eslint/ban-types
-    internalRenderErrorBox?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    internalRenderErrorBox?: any;
     locale?: string;
-    onTelemetry?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    overrideLocalizedStrings?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-    renderMarkdown?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    onTelemetry?: any;
+    overrideLocalizedStrings?: any;
+    renderMarkdown?: any;
     scrollToEndButtonMiddleware?: OneOrMany<ScrollToEndButtonMiddleware>;
     selectVoice?: (voices: typeof window.SpeechSynthesisVoice[], activity: DirectLineActivity) => void;
     sendTypingIndicator?: boolean;
-    store?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    store?: any;
     toastMiddleware?: OneOrMany<ToastMiddleware>;
     typingIndicatorMiddleware?: OneOrMany<TypingIndicatorMiddleware>;
     userID?: string;
     username?: string;
 
     // "api" props: these stuff probably only works when in a web browser
-    extraStyleSet?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    extraStyleSet?: any;
     nonce?: string;
-    styleSet?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    styleSet?: any;
     suggestedActionsAccessKey?: boolean | string;
     webSpeechPonyfillFactory?: WebSpeechPonyfillFactory;
 


### PR DESCRIPTION
HostConfig is used to change background color and css is used for wrapping

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/ef2b97ed-67dc-419c-85f6-7ee06d92f81b)

[Bug 3426571](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3426571): [V2] parity on adaptive cards action text wrap
