### PR TITLE
Adding support for sentMessageAnchorStyles

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Exposed `adaptiveCardsHostConfig` from webchat and force button text wrap
 - Add ability to render transcript using `WebChat`
 - Added `OrganizationUrl` as a column in default logger
+- Adding `sentMessageAnchorStyles` customization for anchors
 
 ## [1.0.5] - 2023-5-26
 

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -21,6 +21,7 @@ import { defaultUserMessageBoxStyles } from "./webchatcontroller/middlewares/ren
 import { defaultWebChatContainerStatefulProps } from "./common/defaultProps/defaultWebChatContainerStatefulProps";
 import { setFocusOnSendBox } from "../../common/utils";
 import { useChatContextStore } from "../..";
+import { defaultSentMessageAnchorStyles } from "./webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultSentMessageAnchorStyles";
 
 const broadcastChannelMessageEvent = "message";
 const postActivity = (activity: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -146,7 +147,14 @@ export const WebChatContainerStateful = (props: IWebChatContainerStatefulProps) 
         .ms_lcw_webchat_received_message a:hover,
         .ms_lcw_webchat_received_message a:active {
             color: ${props?.renderingMiddlewareProps?.receivedMessageAnchorStyles?.color ?? defaultReceivedMessageAnchorStyles?.color};
-        } `}</style>
+        } 
+        .ms_lcw_webchat_sent_message a:link,
+        .ms_lcw_webchat_sent_message a:visited,
+        .ms_lcw_webchat_sent_message a:hover,
+        .ms_lcw_webchat_sent_message a:active {
+            color: ${props?.renderingMiddlewareProps?.sentMessageAnchorStyles?.color ?? defaultSentMessageAnchorStyles?.color};
+        }
+        `}</style>
         <Stack styles={containerStyles}>
             <BasicWebChat></BasicWebChat>
         </Stack>

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IRenderingMiddlewareProps.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IRenderingMiddlewareProps.ts
@@ -33,4 +33,5 @@ export interface IRenderingMiddlewareProps {
     attachmentContentStyles?: React.CSSProperties;
     attachmentSizeStyles?: React.CSSProperties;
     receivedMessageAnchorStyles?: React.CSSProperties;
+    sentMessageAnchorStyles?: React.CSSProperties;
 }

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultSentMessageAnchorStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultSentMessageAnchorStyles.ts
@@ -1,0 +1,3 @@
+export const defaultSentMessageAnchorStyles: React.CSSProperties = {
+    color: "white"
+};

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultSentMessageAnchorStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultSentMessageAnchorStyles.ts
@@ -1,3 +1,3 @@
 export const defaultSentMessageAnchorStyles: React.CSSProperties = {
-    color: "white"
+    color: "blue"
 };


### PR DESCRIPTION
**Issue :** 
Anchor controls are causing accessibility issue for user sent messages, please refer below bug for more details
https://github.com/microsoft/omnichannel-chat-widget/issues/294

**Solution:**
Added a new prop to expose customizations for anchor styles in user sent messages

**Screenshots**
_Existing:_
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/45749980/fd12db59-6ba7-4d9c-afe8-c68c23880c24)

_Post Fix:_
  With theme:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/45749980/6b6682cc-02e6-4383-91f1-03734b5e9f13)

  Without customization:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/45749980/299b4198-819e-459b-adb4-8bb47074f62b)
