### PR TITLE
LCW [V2] - Fixed font family issue with pre-chat survey pane

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed font family issue with pre-chat survey pane
+
 ## [1.1.0] - 2023-6-8
 
 ### Added

--- a/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
+++ b/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
@@ -85,20 +85,23 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
             }
             .ac-input.ac-textInput {
                 font-size: ${props.styleProps?.customTextInputStyleProps?.fontSize};
+                font-family: ${props.styleProps?.customTextInputStyleProps?.fontFamily ?? defaultPreChatSurveyPaneStyles.customTextInputStyleProps?.fontFamily};
                 height: ${props.styleProps?.customTextInputStyleProps?.height ?? defaultPreChatSurveyPaneStyles.customTextInputStyleProps?.height};
                 padding: 8px;
             }
             .ac-input.ac-textInput.ac-multiline {
                 font-size: ${props.styleProps?.customMultilineTextInputStyleProps?.fontSize};
+                font-family: ${props.styleProps?.customMultilineTextInputStyleProps?.fontFamily ?? defaultPreChatSurveyPaneStyles.customMultilineTextInputStyleProps?.fontFamily};
                 height: ${props.styleProps?.customMultilineTextInputStyleProps?.height ?? defaultPreChatSurveyPaneStyles.customMultilineTextInputStyleProps?.height};
                 resize: none;
             }
             .ac-input.ac-multichoiceInput {
                 font-size: ${props.styleProps?.customMultichoiceInputStyleProps?.fontSize};
+                font-family: ${props.styleProps?.customMultichoiceInputStyleProps?.fontFamily ?? defaultPreChatSurveyPaneStyles.customMultichoiceInputStyleProps?.fontFamily};
                 padding: 3px;
                 padding-top: 7px;
                 padding-bottom: 7px;
-            } 
+            }
             .ac-pushButton { 
                 border: 1px solid #00000000;
                 margin: 2px;

--- a/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultStyles/defaultPreChatSurveyPaneMultichoiceInputStyles.ts
+++ b/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultStyles/defaultPreChatSurveyPaneMultichoiceInputStyles.ts
@@ -1,6 +1,5 @@
 import { IPreChatSurveyPaneElementStyles } from "../../../interfaces/IPreChatSurveyPaneElementStyles";
 
-export const defaultPreChatSurveyPaneTextInputStyles: IPreChatSurveyPaneElementStyles = {
-    height: "20px",
+export const defaultPreChatSurveyPaneMultichoiceInputStyles: IPreChatSurveyPaneElementStyles = {
     fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
 };

--- a/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultStyles/defaultPreChatSurveyPaneMultilineTextInputStyles.ts
+++ b/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultStyles/defaultPreChatSurveyPaneMultilineTextInputStyles.ts
@@ -1,5 +1,6 @@
 import { IPreChatSurveyPaneElementStyles } from "../../../interfaces/IPreChatSurveyPaneElementStyles";
 
 export const defaultPreChatSurveyPaneMultilineTextInputStyles: IPreChatSurveyPaneElementStyles = {
-    height: "52px"
+    height: "52px",
+    fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
 };

--- a/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultStyles/defaultPreChatSurveyPaneStyles.ts
+++ b/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultStyles/defaultPreChatSurveyPaneStyles.ts
@@ -4,11 +4,13 @@ import { defaultPreChatSurveyPaneButtonStyles } from "./defaultPreChatSurveyPane
 import { defaultPreChatSurveyPaneGeneralStyles } from "./defaultPreChatSurveyPaneGeneralStyles";
 import { defaultPreChatSurveyPaneMultilineTextInputStyles } from "./defaultPreChatSurveyPaneMultilineTextInputStyles";
 import { defaultPreChatSurveyPaneTextInputStyles } from "./defaultPreChatSurveyPaneTextInputStyles";
+import { defaultPreChatSurveyPaneMultichoiceInputStyles } from "./defaultPreChatSurveyPaneMultichoiceInputStyles";
 
 export const defaultPreChatSurveyPaneStyles: IPreChatSurveyPaneStyleProps = {
     generalStyleProps: defaultPreChatSurveyPaneGeneralStyles,
     customButtonStyleProps: defaultPreChatSurveyPaneButtonStyles,
     adaptiveCardContainerStyleProps: defaultPreChatSurveyPaneACContainerStyles,
     customTextInputStyleProps: defaultPreChatSurveyPaneTextInputStyles,
-    customMultilineTextInputStyleProps: defaultPreChatSurveyPaneMultilineTextInputStyles
+    customMultilineTextInputStyleProps: defaultPreChatSurveyPaneMultilineTextInputStyles,
+    customMultichoiceInputStyleProps: defaultPreChatSurveyPaneMultichoiceInputStyles
 };

--- a/chat-components/src/components/prechatsurveypane/interfaces/IPreChatSurveyPaneElementStyles.ts
+++ b/chat-components/src/components/prechatsurveypane/interfaces/IPreChatSurveyPaneElementStyles.ts
@@ -1,5 +1,6 @@
 export interface IPreChatSurveyPaneElementStyles {
     fontSize?: string;
+    fontFamily?: string;
     height?: string;
     paddingTop?: string;
 }

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -1195,15 +1195,10 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
                 margin: "3%"
             },
             customTextInputStyleProps: {
-                height: "20px",
-                fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
+                height: "20px"
             },
             customMultilineTextInputStyleProps: {
-                height: "52px",
-                fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
-            },
-            customMultichoiceInputStyleProps: {
-                fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
+                height: "52px"
             }
         }
     },

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -1195,10 +1195,15 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
                 margin: "3%"
             },
             customTextInputStyleProps: {
-                height: "20px"
+                height: "20px",
+                fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
             },
             customMultilineTextInputStyleProps: {
-                height: "52px"
+                height: "52px",
+                fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
+            },
+            customMultichoiceInputStyleProps: {
+                fontFamily: "Segoe UI, Helvetica Neue, sans-serif"
             }
         }
     },


### PR DESCRIPTION
Fixed font family issue with pre-chat survey pane.

For multiline elements in the pre-chat, we are not setting the font family as for other elements

**With Default font family** 
**SingleLine**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/4523ccb3-515c-49cf-9efb-94e9b5703b15)

**Multiline**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/26dd350b-ccb3-4e3f-a489-944867303da5)

**Multichoice**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/1b63c832-1464-4053-b479-7961af3ce603)

**With Customization**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/ade9a502-ef92-4c26-8049-797d15f740b1)

**SingleLine**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/7eb99057-bc6c-475e-a465-39c2d7fe380c)

**Multiline**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/ad7cb4f1-5646-4d46-a43a-c6b921ba487b)

**Multichoice**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/251080a0-fb31-4b78-adc9-9ca598baa3ec)


