### PR TITLE
Fetch custom context from OOB layer if cache expired

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,11 +11,13 @@ All notable changes to this project will be documented in this file.
 - Uptake [@microsoft/omnichannel-chat-sdk@1.4.5](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.4.5)
 - Added parity to NewMessage event payload, and renamed `HistoryMessageReceived` to `RehydrateMessageReceived` to avoid conflict with the same BroadcastEvent
 - Added Pull Request Template
+
 ### Fixed
 
 - Fixed an issue where opening a chat right after agent ends the previous chat doesn't work
 - Fixed an issue where opening/refreshing a persistent chat shows the Reconnect Pane
-- Fix SSO magic code due to incompatibility of broadcast channel
+- Fixed SSO magic code due to incompatibility of broadcast channel
+- Fixed an issue where custom context disappears after state cache expires
 
 ## [1.2.1] - 2023-7-24
 

--- a/chat-widget/samples/javascript-sample/SampleWidget.js
+++ b/chat-widget/samples/javascript-sample/SampleWidget.js
@@ -40,9 +40,6 @@ const main = async () => {
         liveChatWidgetProps = config;
         liveChatWidgetProps = {
             ...liveChatWidgetProps,
-            getAuthToken: async () => {
-                return "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI2MzdmY2M5Zi00YTliLTRhYWEtODcxMy1hMmEzY2ZkYTE1MDUiLCJpYXQiOjE1ODc1OTU5MzksIm5iZiI6MTU4NzU5NTkzOSwiZXhwIjoxNjk4NjkyMzM5LCJzdWIiOiIzOTFkNGFhZS1hZTU4LTQ2MGUtOTkzMS1hZGVlM2Q3NTk4MGUiLCJvaWQiOiIzOTFkNGFhZS1hZTU4LTQ2MGUtOTkzMS1hZGVlM2Q3NTk4MGUiLCJ0aWQiOiJjZDFiN2M2Yy04ZGZkLTQyMjQtOWZhNi0yOTkxZDM1OTYzODIiLCJ1cG4iOiJjcm1hZG1pbkBzZzQzOXRlbmFudDQ1Mi5jY3NjdHAubmV0IiwiRmlyc3ROYW1lIjoiQ3JtYWRtaW4iLCJMYXN0TmFtZSI6ImFkbWluIiwibHdpY29udGV4dHMiOnsiQ2FzZU51bWJlciI6eyJ2YWx1ZSI6IjIwMDQxNTAwMTAwMDEyNDUiLCJpc0Rpc3BsYXlhYmxlIjp0cnVlfSwiQ2FzZVRpdGxlIjp7InZhbHVlIjoiVEVzdCIsImlzRGlzcGxheWFibGUiOnRydWV9LCJBY3RpdmVTeXN0ZW0iOnsidmFsdWUiOiJEeW5hbWljcyIsImlzRGlzcGxheWFibGUiOnRydWV9LCJGaXJzdE5hbWUiOnsidmFsdWUiOiJDcm1hZG1pbiIsImlzRGlzcGxheWFibGUiOnRydWV9LCJMYXN0TmFtZSI6eyJ2YWx1ZSI6ImFkbWluIiwiaXNEaXNwbGF5YWJsZSI6dHJ1ZX0sIkN1cnJlbnRVc2VyRW1haWwiOnsidmFsdWUiOiJjcm1hZG1pbkBzZzQzOXRlbmFudDQ1Mi5jY3NjdHAubmV0IiwiaXNEaXNwbGF5YWJsZSI6dHJ1ZX0sIkNhc2VPd25lckVtYWlsIjp7InZhbHVlIjoiYUBiLmMiLCJpc0Rpc3BsYXlhYmxlIjpmYWxzZX0sIlByb2R1Y3ROYW1lIjp7InZhbHVlIjoiUG93ZXIgQXV0b21hdGUiLCJpc0Rpc3BsYXlhYmxlIjp0cnVlfSwiQ2F0ZWdvcnkiOnsidmFsdWUiOiJBcHByb3ZhbHMiLCJpc0Rpc3BsYXlhYmxlIjp0cnVlfSwiU3ViQ2F0ZWdvcnkiOnsidmFsdWUiOiJXb3JraW5nIHdpdGggYXBwcm92YWwgZmxvd3MiLCJpc0Rpc3BsYXlhYmxlIjp0cnVlfSwiU2V2ZXJpdHkiOnsidmFsdWUiOiJTZXZlcml0eUMiLCJpc0Rpc3BsYXlhYmxlIjp0cnVlfSwiU2VydmljZUxldmVsIjp7InZhbHVlIjoiUHJvZmVzc2lvbmFsIiwiaXNEaXNwbGF5YWJsZSI6dHJ1ZX0sIkxhbmd1YWdlIjp7InZhbHVlIjoiZW4tVVMiLCJpc0Rpc3BsYXlhYmxlIjp0cnVlfSwiTG9jYXRpb24iOnsidmFsdWUiOiJVUyIsImlzRGlzcGxheWFibGUiOnRydWV9fX0.ddgAh8-t7ZJiUPpPgR29x6sMBG-iN_5o0I68AYldRYhguWY9M_Uy0jYU1kHhnRpeLxZjaXpPq2C9Inl6kIbdSJEFQ06oEA9W5ML85E5NZMJkO55c9UPB5v4UmNIeMpkXAZTc7gK607bUSuSYrBVNW0hBUeW_rAGvYyK3Jm80HTeA-R1t72I_6_EjOsrY5YoXdLwMhhBArTQU_6NUrhO_RizCj9NAhuwNVulxbpbFAWmPywH4yWenBSe_eaOEK8wV62iZk1Rc3zEyJZSm_-q5GB764zLjcWqohqj6gArJeZNf1QEPH3FKRhuKwBI_EiVRGudaGldtrsOch5axTA318A";
-            },
             chatSDK: chatSDK,
             chatConfig: chatConfig,
             telemetryConfig: {
@@ -56,7 +53,9 @@ const main = async () => {
             <LiveChatWidget {...liveChatWidgetProps} />,
             document.getElementById("oc-lcw-container")
         );
+    };
 
+    const setCustomContext = () => {
         const setCustomContextEvent = {
             eventName: "SetCustomContext",
             payload: {
@@ -67,6 +66,7 @@ const main = async () => {
         };
         BroadcastService.postMessage(setCustomContextEvent);
     };
+
     const startProactiveChat = (notificationUIConfig, showPrechat, inNewWindow) => {
         const startProactiveChatEvent = {
             eventName: "StartProactiveChat",
@@ -81,6 +81,7 @@ const main = async () => {
 
     window["switchConfig"] = switchConfig;
     window["startProactiveChat"] = startProactiveChat;
+    window["setCustomContext"] = setCustomContext;
     switchConfig(await getCustomizationJson());
 };
 

--- a/chat-widget/samples/javascript-sample/test.html
+++ b/chat-widget/samples/javascript-sample/test.html
@@ -12,9 +12,6 @@
   <script>
     function lcw() {
       return {
-        controlProps: {
-          cacheTtlInMins: 0.1
-        },
         styleProps: {
           generalStyles: {
             width: "360px",
@@ -70,9 +67,8 @@
     }
   </script>
   <div id="oc-lcw-container" style="width: 370px; height: 100%; position: fixed; right: 0; bottom: 0"></div>
-  <script id="oc-lcw-script" src="../../dist/out.js" data-customization-callback="lcw" data-org-id="1ced8f4f-9f9f-4d24-9939-c2f24d6ea8f8"
-  data-org-url="https://1ced8f4f9f9f4d249939c2f24d6ea8f8-crm.omnichannelengagementhub.com"
-  data-app-id="561b0880-f454-426a-8f68-76e01b2b745c"></script>
+  <script id="oc-lcw-script" src="../../dist/out.js" data-customization-callback="lcw" data-org-id="" data-app-id=""
+    data-org-url=""></script>
 </body>
 
 </html>

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -151,7 +151,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                         return;
                     }
                 }
-                await initStartChat(chatSDK, dispatch, setAdapter, props, optionalParams);
+                await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams);
                 return;
             }
         }
@@ -561,7 +561,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const endChatRelay = (adapter: any, skipEndChatSDK: any, skipCloseChat: any, postMessageToOtherTab?: boolean) => endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, skipEndChatSDK, skipCloseChat, postMessageToOtherTab, uwid.current);
     const prepareStartChatRelay = () => prepareStartChat(props, chatSDK, state, dispatch, setAdapter);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const initStartChatRelay = (optionalParams?: any, persistedState?: any) => initStartChat(chatSDK, dispatch, setAdapter, props, optionalParams, persistedState);
+    const initStartChatRelay = (optionalParams?: any, persistedState?: any) => initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams, persistedState);
     const confirmationPaneProps = initConfirmationPropsComposer(props);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const prepareEndChatRelay = () => prepareEndChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, uwid.current);


### PR DESCRIPTION
Go Live blocker for BPost [Bug 3437196](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3437196): [V2][BPost][GoLiveBlocker] : Custom context data is not persisted for more than 15 minutes.