### PR TITLE
Fixed texts in adaptive cards having same color with background

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,7 +9,6 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Code refactor for event listening for custom context in pop-out mode
-- Fixed font family issue with pre-chat survey pane
 - Fixed texts in adaptive cards having same color with background
 
 ### Changed

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 - Code refactor for event listening for custom context in pop-out mode
 - Fixed font family issue with pre-chat survey pane
+- Fixed texts in adaptive cards having same color with background
 
 ## [1.1.0] - 2023-6-8
 

--- a/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
+++ b/chat-widget/src/components/livechatwidget/common/defaultProps/dummyDefaultProps.ts
@@ -1745,7 +1745,10 @@ export const dummyDefaultProps: ILiveChatWidgetProps = {
         },
         adaptiveCardStyles: {
             background: "white",
-            color: "black"
+            color: "black",
+            anchorColor: "blue",
+            textWhiteSpace: "normal",
+            buttonWhiteSpace: "normal"
         },
         hyperlinkTextOverride: false
     },

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -125,8 +125,15 @@ export const WebChatContainerStateful = (props: IWebChatContainerStatefulProps) 
             max-width: ${props?.renderingMiddlewareProps?.systemMessageBoxStyles?.maxWidth ?? defaultSystemMessageBoxStyles?.maxWidth}
         }
 
-        div[class="ac-textBlock"]>p{color:${props?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color}; white-space:${props?.adaptiveCardStyles?.textWhiteSpace ?? defaultAdaptiveCardStyles.textWhiteSpace}}
-        
+        div[class="ac-textBlock"] *,
+        div[class="ac-input-container"] * {color:${props?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color}; white-space:${props?.adaptiveCardStyles?.textWhiteSpace ?? defaultAdaptiveCardStyles.textWhiteSpace}}
+        div[class="ac-textBlock"] a:link,
+        div[class="ac-textBlock"] a:visited,
+        div[class="ac-textBlock"] a:hover,
+        div[class="ac-textBlock"] a:active {
+            color: ${props?.adaptiveCardStyles?.anchorColor ?? defaultAdaptiveCardStyles.anchorColor};
+        } 
+
         .webchat__stacked-layout__content .ac-actionSet > .ac-pushButton > div {white-space: ${props?.adaptiveCardStyles?.buttonWhiteSpace ?? defaultAdaptiveCardStyles.buttonWhiteSpace} !important;}
 
         .ms_lcw_webchat_received_message img.webchat__markdown__external-link-icon { 

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles.ts
@@ -3,6 +3,7 @@ import { IAdaptiveCardStyles } from "../../interfaces/IAdaptiveCardStyles";
 export const defaultAdaptiveCardStyles: IAdaptiveCardStyles = {
     background: "white",
     color: "black",
+    anchorColor: "blue",
     textWhiteSpace: "normal",
     buttonWhiteSpace: "normal"
 };

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IAdaptiveCardStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IAdaptiveCardStyles.ts
@@ -1,6 +1,7 @@
 export interface IAdaptiveCardStyles {
     background?: string;
     color?: string;
+    anchorColor?: string;
     buttonWhiteSpace?: string;
     textWhiteSpace?: string;
 }


### PR DESCRIPTION
[Bug 3428503](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3428503): [V2] Adaptive Cards Markdown Content has White Font Color on a White Background Ccolor

Links are separated out

Before: 
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/33ccbaf8-9020-41cd-b2c0-960b4969841c)

After:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/125558d4-2464-4ef5-b6f5-f33ff4a7850e)

Before:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/ab27b6f1-b9e6-4666-85d0-f4f53e1abcd3)

After:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/62680b76-3840-4251-b204-648cb811942c)

