### PR TITLE
[NOT MERGE] A11 y close dialog validation

### DIFF
--- a/chat-components/src/components/confirmationpane/ConfirmationPane.tsx
+++ b/chat-components/src/components/confirmationpane/ConfirmationPane.tsx
@@ -94,7 +94,7 @@ function ConfirmationPane(props: IConfirmationPaneProps) {
                     dir={props.controlProps?.dir || defaultConfirmationPaneControlProps.dir}
                     styles={containerStyles}
                     role="dialog"
-                    aria-describedby={elementId + "-title" +" " +elementId + "-subtitle"}
+                    aria-labelledby={elementId + "-title" +" " +elementId + "-subtitle"}
                 >
 
                     {!props.controlProps?.hideTitle && (decodeComponentString(props.componentOverrides?.title) ||

--- a/chat-components/src/components/confirmationpane/ConfirmationPane.tsx
+++ b/chat-components/src/components/confirmationpane/ConfirmationPane.tsx
@@ -94,15 +94,17 @@ function ConfirmationPane(props: IConfirmationPaneProps) {
                     dir={props.controlProps?.dir || defaultConfirmationPaneControlProps.dir}
                     styles={containerStyles}
                     role="dialog"
-                    aria-labelledby={elementId + "-title"}
-                    aria-describedby={elementId + "-subtitle"}>
+                    aria-describedby={elementId + "-title" +" " +elementId + "-subtitle"}
+                >
 
                     {!props.controlProps?.hideTitle && (decodeComponentString(props.componentOverrides?.title) ||
                         <Label
                             className={props.styleProps?.classNames?.titleClassName}
-                            styles={titleStyles}
+                            styles= {titleStyles}
                             tabIndex={-1}
-                            id={elementId + "-title"}>
+                            id={elementId +"-title"} 
+                            aria-hidden="true"
+                        >
                             {props.controlProps?.titleText || defaultConfirmationPaneControlProps.titleText}
                         </Label>)}
 
@@ -111,7 +113,9 @@ function ConfirmationPane(props: IConfirmationPaneProps) {
                             className={props.styleProps?.classNames?.subtitleClassName}
                             styles={subtitleStyles}
                             tabIndex={-1}
-                            id={elementId + "-subtitle"}>
+                            id={elementId + "-subtitle"}
+                            aria-hidden="true"
+                        >
                             {props.controlProps?.subtitleText || defaultConfirmationPaneControlProps.subtitleText}
                         </Label>)}
 


### PR DESCRIPTION
## Issue

dialog was using aria-describedby combined with aria-labeledby.

aria-describedby is "buggy" in Windows narrator, causing to not be able to describe the dialog when the screen reader is on, and in nvda causes multiple re-reading of the same elements.

## Solution

- relay only on aria-labeledby, but using multiple id's to narrate the whole text.
-  set aria-hide for labels to avoid re-reading of the elements

## Acceptance criteria and testing

BLOB FOR TESTING : https://elastorageredmond.blob.core.windows.net/elopez-dev/test/a11y/samples/javascript-sample/test.html

__note 1: for NVDA is narrating twice the dialog,  this will be consulted with A11Y helpdesk, in the meantime is ok to go with this__

__note 2 : it seems like when using a clean browser , loading the chat for first time, sometimes the narrator is a "fleaky" and doesnt detect the change of focus from close button to cancel , no idea why__

###  chrome NVDA 
dialog announced twice with full text description, is ok by now.

### chrome narrator
dialog announced with full text description

###  EDGE NVDA 
dialog announced twice with full text description, is ok by now.

### EDGE narrator
dialog announced with full text description

###  Firefox NVDA 
dialog announced twice with full text description, is ok by now.

### Firefox narrator
dialog announced with full text description




