### PR TITLE
throwing errors for empty telemetry values

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - Code refactor for event listening for custom context in pop-out mode
 - Fixed texts in adaptive cards having same color with background
+- Validations to avoid empty telemetry data.
 
 ### Changed
 

--- a/chat-widget/automation_tests/configuration/testsettings.json
+++ b/chat-widget/automation_tests/configuration/testsettings.json
@@ -1,7 +1,7 @@
 {
-  "OrgUrl": "",
-  "OrgId": "",
-  "AppId": "",
+  "OrgUrl": "DEFAULT-VISUAL-TEST-ORG-URL",
+  "OrgId": "DEFAULT-VISUAL-TEST-ORG-ID",
+  "AppId": "DEFAULT-VISUAL-TEST-APP-ID",
   "browsers": ["chromium"],
   "devices": [],
   "launchBrowserSettings": {

--- a/chat-widget/src/common/telemetry/TelemetryHelper.ts
+++ b/chat-widget/src/common/telemetry/TelemetryHelper.ts
@@ -204,15 +204,15 @@ export class TelemetryHelper {
     public static addWidgetDataToTelemetry(telemetryConfig: ITelemetryConfig, telemetryInternalData: IInternalTelemetryData): IInternalTelemetryData {
         const telemetryDataLocal: IInternalTelemetryData = telemetryInternalData;
 
-        if (!telemetryConfig?.appId) {
+        if (!telemetryConfig?.appId || telemetryConfig?.appId.trim() === "") {
             throw new Error("TelemetryConfig.appId is not set");
         }
 
-        if (!telemetryConfig?.orgId) {
+        if (!telemetryConfig?.orgId || telemetryConfig?.orgId.trim() === "") {
             throw new Error("TelemetryConfig.orgId is not set");
         }
 
-        if (!telemetryConfig?.orgUrl) {
+        if (!telemetryConfig?.orgUrl || telemetryConfig?.orgUrl.trim() === "") {
             throw new Error("TelemetryConfig.orgUrl is not set");
         }
         

--- a/chat-widget/src/common/telemetry/TelemetryHelper.ts
+++ b/chat-widget/src/common/telemetry/TelemetryHelper.ts
@@ -203,6 +203,19 @@ export class TelemetryHelper {
 
     public static addWidgetDataToTelemetry(telemetryConfig: ITelemetryConfig, telemetryInternalData: IInternalTelemetryData): IInternalTelemetryData {
         const telemetryDataLocal: IInternalTelemetryData = telemetryInternalData;
+
+        if (!telemetryConfig?.appId) {
+            throw new Error("TelemetryConfig.appId is not set");
+        }
+
+        if (!telemetryConfig?.orgId) {
+            throw new Error("TelemetryConfig.orgId is not set");
+        }
+
+        if (!telemetryConfig?.orgUrl) {
+            throw new Error("TelemetryConfig.orgUrl is not set");
+        }
+        
         telemetryDataLocal.widgetId = telemetryConfig?.appId;
         telemetryDataLocal.orgId = telemetryConfig?.orgId;
         telemetryDataLocal.orgUrl = telemetryConfig?.orgUrl;

--- a/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
+++ b/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
@@ -23,13 +23,9 @@ export const registerTelemetryLoggers = (props: ILiveChatWidgetProps, dispatch: 
             ariaConfig: Object.assign({}, defaultAriaConfig, telemetryConfig?.ariaConfigurations)
         };
 
-
-
         if (props.chatConfig) {
             telemetryData = TelemetryHelper.addChatConfigDataToTelemetry(props?.chatConfig, telemetryData);
         }
-
-        console.log("ELOPEZANAYA : telemetryConfig", JSON.stringify(telemetryConfig));
 
         if (!props.chatSDK?.omnichannelConfig?.orgId || props.chatSDK?.omnichannelConfig?.orgId.trim().length === 0 ) {
             throw new Error("orgId is undefined in ChatSDK");

--- a/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
+++ b/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
@@ -25,6 +25,19 @@ export const registerTelemetryLoggers = (props: ILiveChatWidgetProps, dispatch: 
         if (props.chatConfig) {
             telemetryData = TelemetryHelper.addChatConfigDataToTelemetry(props?.chatConfig, telemetryData);
         }
+
+        if (!props.chatSDK?.omnichannelConfig?.orgId) {
+            throw new Error("orgId is undefined");
+        }
+
+        if (!props.chatSDK?.omnichannelConfig?.widgetId) {
+            throw new Error("widgetId is undefined");
+        }
+
+        if (!props.chatSDK?.omnichannelConfig?.orgUrl) {
+            throw new Error("orgUrl is undefined");
+        }
+
         telemetryData = TelemetryHelper.addWidgetDataToTelemetry(telemetryConfig, telemetryData);
         telemetryData.OCChatSDKVersion = telemetryConfig.OCChatSDKVersion ?? "0.0.0-0";
         telemetryData.chatComponentVersion = telemetryConfig.chatComponentVersion ?? "0.0.0-0";

--- a/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
+++ b/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
@@ -10,6 +10,7 @@ import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { defaultAriaConfig } from "../../../common/telemetry/defaultConfigs/defaultAriaConfig";
 import { defaultInternalTelemetryData } from "../../../common/telemetry/defaultConfigs/defaultTelemetryInternalData";
 import { defaultTelemetryConfiguration } from "../../../common/telemetry/defaultConfigs/defaultTelemetryConfiguration";
+import { newGuid } from "../../../common/utils";
 
 export const registerTelemetryLoggers = (props: ILiveChatWidgetProps, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     const telemetryConfig: ITelemetryConfig = { ...defaultTelemetryConfiguration, ...props.telemetryConfig };
@@ -22,29 +23,34 @@ export const registerTelemetryLoggers = (props: ILiveChatWidgetProps, dispatch: 
             ariaConfig: Object.assign({}, defaultAriaConfig, telemetryConfig?.ariaConfigurations)
         };
 
+
+
         if (props.chatConfig) {
             telemetryData = TelemetryHelper.addChatConfigDataToTelemetry(props?.chatConfig, telemetryData);
         }
 
+        console.log("ELOPEZANAYA : telemetryConfig", JSON.stringify(telemetryConfig));
+
         if (!props.chatSDK?.omnichannelConfig?.orgId || props.chatSDK?.omnichannelConfig?.orgId.trim().length === 0 ) {
-            throw new Error("orgId is undefined");
+            throw new Error("orgId is undefined in ChatSDK");
         }
 
         if (!props.chatSDK?.omnichannelConfig?.widgetId || props.chatSDK?.omnichannelConfig?.widgetId.trim().length === 0 ) {
-            throw new Error("widgetId is undefined");
+            throw new Error("widgetId is undefined in ChatSDK");
         }
 
         if (!props.chatSDK?.omnichannelConfig?.orgUrl || props.chatSDK?.omnichannelConfig?.orgUrl.trim().length === 0  ) {
-            throw new Error("orgUrl is undefined");
+            throw new Error("orgUrl is undefined in ChatSDK");
         }
 
-        telemetryData = TelemetryHelper.addWidgetDataToTelemetry(telemetryConfig, telemetryData);
         telemetryData.OCChatSDKVersion = telemetryConfig.OCChatSDKVersion ?? "0.0.0-0";
         telemetryData.chatComponentVersion = telemetryConfig.chatComponentVersion ?? "0.0.0-0";
         telemetryData.chatWidgetVersion = telemetryConfig.chatWidgetVersion ?? "0.0.0-0";
         telemetryData.orgId = props.chatSDK?.omnichannelConfig?.orgId;
         telemetryData.widgetId = props.chatSDK?.omnichannelConfig?.widgetId;
         telemetryData.orgUrl = props.chatSDK?.omnichannelConfig?.orgUrl;
+        telemetryData.lcwRuntimeId = telemetryConfig.LCWRuntimeId ?? newGuid();
+
         TelemetryManager.InternalTelemetryData = telemetryData;
 
         dispatch({ type: LiveChatWidgetActionType.SET_TELEMETRY_DATA, payload: telemetryData });

--- a/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
+++ b/chat-widget/src/components/livechatwidget/common/registerTelemetryLoggers.ts
@@ -26,15 +26,15 @@ export const registerTelemetryLoggers = (props: ILiveChatWidgetProps, dispatch: 
             telemetryData = TelemetryHelper.addChatConfigDataToTelemetry(props?.chatConfig, telemetryData);
         }
 
-        if (!props.chatSDK?.omnichannelConfig?.orgId) {
+        if (!props.chatSDK?.omnichannelConfig?.orgId || props.chatSDK?.omnichannelConfig?.orgId.trim().length === 0 ) {
             throw new Error("orgId is undefined");
         }
 
-        if (!props.chatSDK?.omnichannelConfig?.widgetId) {
+        if (!props.chatSDK?.omnichannelConfig?.widgetId || props.chatSDK?.omnichannelConfig?.widgetId.trim().length === 0 ) {
             throw new Error("widgetId is undefined");
         }
 
-        if (!props.chatSDK?.omnichannelConfig?.orgUrl) {
+        if (!props.chatSDK?.omnichannelConfig?.orgUrl || props.chatSDK?.omnichannelConfig?.orgUrl.trim().length === 0  ) {
             throw new Error("orgUrl is undefined");
         }
 

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
@@ -7,6 +7,11 @@ export class MockChatSDK {
 
     public isMockModeOn = true;
 
+    public omnichannelConfig = {
+        widgetId: "00000000-0000-0000-0000-000000000000",
+        orgId: "00000000-0000-0000-0000-000000000000",
+        orgUrl: "https://contoso.crm.dynamics.com",
+    }
     public async startChat() {
         await this.sleep(1000);
     }

--- a/chat-widget/stories/OmniChannelLiveChatWidget.stories.tsx
+++ b/chat-widget/stories/OmniChannelLiveChatWidget.stories.tsx
@@ -20,6 +20,17 @@ const LiveChatWidgetTemplate: Story<ILiveChatWidgetProps> = (args) => <LiveChatW
 
 export const Default = LiveChatWidgetTemplate.bind({});
 
+const telemetryConfigGlobal = {
+
+    appId: "00000000-0000-0000-0000-000000000000",
+    orgId: "00000000-0000-0000-0000-000000000000",
+    orgUrl: "https://contoso.crm.dynamics.com",
+    telemetryDisabled:true,
+    chatComponentVersion : "111111",
+    OCChatSDKVersion : "222222",
+    chatWidgetVersion : "333333",
+};
+
 const liveChatWidgetDefaultProps: ILiveChatWidgetProps = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     chatSDK: new MockChatSDK() as any,
@@ -31,7 +42,7 @@ const liveChatWidgetDefaultProps: ILiveChatWidgetProps = {
             left: "20px"
         }
     },
-    telemetryConfig: undefined
+    telemetryConfig: telemetryConfigGlobal
 };
 
 Default.args = liveChatWidgetDefaultProps;
@@ -110,7 +121,7 @@ const liveChatWidgetDefaultWithSurveyProps: ILiveChatWidgetProps = {
             }
         }
     },
-    telemetryConfig: undefined
+    telemetryConfig: telemetryConfigGlobal
 };
 
 DefaultWithSurvey.args = liveChatWidgetDefaultWithSurveyProps;
@@ -348,7 +359,7 @@ const liveChatWidgetCustom: ILiveChatWidgetProps = {
             }
         }
     },
-    telemetryConfig: undefined
+    telemetryConfig: telemetryConfigGlobal
 };
 
 Custom.args = liveChatWidgetCustom;

--- a/chat-widget/stories/OmniChannelLiveChatWidget.stories.tsx
+++ b/chat-widget/stories/OmniChannelLiveChatWidget.stories.tsx
@@ -21,14 +21,13 @@ const LiveChatWidgetTemplate: Story<ILiveChatWidgetProps> = (args) => <LiveChatW
 export const Default = LiveChatWidgetTemplate.bind({});
 
 const telemetryConfigGlobal = {
-
     appId: "00000000-0000-0000-0000-000000000000",
     orgId: "00000000-0000-0000-0000-000000000000",
     orgUrl: "https://contoso.crm.dynamics.com",
-    telemetryDisabled:true,
-    chatComponentVersion : "111111",
-    OCChatSDKVersion : "222222",
-    chatWidgetVersion : "333333",
+    telemetryDisabled: true,
+    chatComponentVersion: "111111",
+    OCChatSDKVersion: "222222",
+    chatWidgetVersion: "333333",
 };
 
 const liveChatWidgetDefaultProps: ILiveChatWidgetProps = {


### PR DESCRIPTION
we have detected in telemetry several entries without values for OrgId, WidgetId and OrgUrl.

currently use optionals for those values, allowing empty telemtry values

in this PR I'm addressing that issue

- add validation for values of the required properties
- add missing values for mocks and tests, causing telemetry to aggregate empty values in kusto
