### PR TITLE
Re-use slack markdown code

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Code refactor for event listening for custom context in pop-out mode
 - Fixed texts in adaptive cards having same color with background
 - Validations to avoid empty telemetry data.
+- Used slack-markdown-it package for v1 parity
 
 ### Changed
 

--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -1,7 +1,8 @@
+import { Constants } from "../../../common/Constants";
 import MarkdownIt from "markdown-it";
 import MarkdownItForInline from "markdown-it-for-inline";
+import MarkdownSlack from "slack-markdown-it";
 import { defaultMarkdownLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMarkdownLocalizedTexts";
-import { Constants } from "../../../common/Constants";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disableNewLineMarkdownSupport: boolean) => {
@@ -16,8 +17,7 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
                 breaks: (!disableNewLineMarkdownSupport)
             }
         );
-        // ToDo: Commenting below usage of plugin until deferred bug is resolved: https://github.com/mayashavin/markdown-it-slack/issues/1
-        // markdown.use(MarkdownSlack);
+        markdown.use(MarkdownSlack);
     } else {
         markdown = new MarkdownIt(
             Constants.Zero,


### PR DESCRIPTION
[Bug 3462510](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3462510): [PPE][LCW 6.4] While sending message in bold from customer side it is showing in italic but at agent side it is showing in bold.

Related bug has been fixed.

After:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/4429fc0f-7d0b-4216-8660-4da73a168036)

Regression check:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/4a9a5265-e239-427d-bff7-d7e0ed03f172)
