### PR TITLE
Call endchat when chat closed in inActive state

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where opening a chat right after agent ends the previous chat doesn't work
+
 ## [1.2.1] - 2023-7-24
 
 ### Changed

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -479,15 +479,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         }
 
         // If start chat failed, and C2 is trying to close chat widget
-        if (state?.appStates?.startChatFailed) {
+        if (state?.appStates?.startChatFailed || state?.appStates?.conversationState === ConversationState.Postchat) {
             endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, true, false, true, uwid.current);
             return;
         }
 
         // Scenario -> Chat was InActive and closing the chat (Refresh scenario on post chat)
-        if (state?.appStates?.conversationState === ConversationState.Postchat ||
-            state?.appStates?.conversationState === ConversationState.InActive) {
-            endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, true, false, true, uwid.current);
+        if (state?.appStates?.conversationState === ConversationState.InActive) {
+            endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, false, true, uwid.current);
             return;
         }
 


### PR DESCRIPTION
Bug: [Bug 3495812](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3495812): [V2] `ChatSDK.endChat()` is not called on customer closing the chat

Fix: Call endChat when conversation is in InActive state

Validated for no-postchat, link-postchat, embed-postchat

![proof1](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/09699c4a-f665-4474-afeb-622d57b5bb61)

![proof2](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/1029c419-d5c2-43d5-8680-455830354553)
