### PR TITLE
Do not show reconnect pane in persistent chat

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed an issue where opening a chat right after agent ends the previous chat doesn't work
+- Fixed an issue where opening/refreshing a persistent chat shows the Reconnect Pane
 
 ## [1.2.1] - 2023-7-24
 

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -234,6 +234,11 @@ export enum E2VVOptions {
     VoiceOnly = "192350002"
 }
 
+export enum ConversationMode {
+    Regular = "192350000",
+    Persistent = "192350001"
+}
+
 export enum LiveWorkItemState {
     Active = "Active",
     Closed = "Closed",

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -6,6 +6,7 @@ import { handleAuthentication, removeAuthTokenProvider } from "./authHelper";
 
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import ChatConfig from "@microsoft/omnichannel-chat-sdk/lib/core/ChatConfig";
+import { ConversationMode } from "../../../common/Constants";
 import { ConversationState } from "../../../contexts/common/ConversationState";
 import { Dispatch } from "react";
 import { ICustomEvent } from "@microsoft/omnichannel-chat-components/lib/types/interfaces/ICustomEvent";
@@ -19,8 +20,7 @@ import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, state: ILiveChatWidgetContext) => {
-
-    if (!isReconnectEnabled(props.chatConfig)) return;
+    if (!isReconnectEnabled(props.chatConfig) || isPersistentEnabled(props.chatConfig)) return;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = (props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
@@ -120,8 +120,16 @@ const isReconnectEnabled = (chatConfig?: ChatConfig): boolean => {
     return false;
 };
 
+const isPersistentEnabled = (chatConfig?: ChatConfig): boolean => {
+    if (chatConfig) {
+        const persistentEnabled = chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode?.toLowerCase() === ConversationMode.Persistent;
+        return persistentEnabled;
+    }
+    return false;
+};
+
 const hasReconnectId = (reconnectAvailabilityResponse: IReconnectChatContext) => {
     return reconnectAvailabilityResponse && !isNullOrUndefined(reconnectAvailabilityResponse.reconnectId);
 };
 
-export { handleChatReconnect, isReconnectEnabled, getChatReconnectContext };
+export { handleChatReconnect, isReconnectEnabled, isPersistentEnabled, getChatReconnectContext };

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../../common/utils";
 import { defaultClientDataStoreProvider, isCookieAllowed } from "../../../common/storage/default/defaultClientDataStoreProvider";
 import { endChat, prepareEndChat } from "../common/endChat";
-import { handleChatReconnect, isReconnectEnabled } from "../common/reconnectChatHelper";
+import { handleChatReconnect, isPersistentEnabled, isReconnectEnabled } from "../common/reconnectChatHelper";
 import {
     shouldShowCallingContainer,
     shouldShowChatButton,
@@ -144,7 +144,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             isChatValid = await checkIfConversationStillValid(chatSDK, dispatch, state);
             if (isChatValid === true) {
                 //Check if reconnect enabled
-                if (isReconnectEnabled(props.chatConfig) === true) {
+                if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
                     await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
                     // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
                     if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
@@ -159,7 +159,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         if (isChatValid === false) {
             if (localState) {
                 // adding the reconnect logic for the case when customer tries to reconnect from a new browser or InPrivate browser
-                if (isReconnectEnabled(props.chatConfig) === true) {
+                if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
                     await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
                     // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
                     if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {


### PR DESCRIPTION
[Bug 3499443](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3499443): Persistent chat should not show Reconnect chat options

Fix is to check persistent chat logic before showing reconnect pane