### PR TITLE
Restore parity on NewMessage event payload

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Uptake [@microsoft/omnichannel-chat-sdk@1.4.5](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.4.5)
+- Added parity to NewMessage event payload, and renamed `HistoryMessageReceived` to `RehydrateMessageReceived` to avoid conflict with the same BroadcastEvent
 
 ### Fixed
 

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -192,7 +192,7 @@ export enum TelemetryEvent {
     MessageSent = "MessageSent",
     MessageReceived = "MessageReceived",
     SystemMessageReceived = "SystemMessageReceived",
-    HistoryMessageReceived = "HistoryMessageReceived",
+    RehydrateMessageReceived = "RehydrateMessageReceived",
 
     CustomContextReceived = "CustomContextReceived",
 

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -217,7 +217,7 @@ Refer to the below table to understand different critical telemetry events raise
 | `GetAuthTokenFailed` | On getting auth token failed |
 | `ReceivedNullOrEmptyToken` | On receiving null or empty auth token |
 | `SystemMessageReceived` | On system message received |
-| `HistoryMessageReceived` | On history message received (called only once) |
+| `RehydrateMessageReceived` | On history message received (called only once) |
 | `ChatVisibilityChanged` | On minimizing the chat window |
 | `SigninCardReceived` | On sign-in adaptive card received from bot |
 | `BotAuthActivityEmptySasUrl` | On detecting a sign-in adaptive card with no SAS Url |


### PR DESCRIPTION
[Bug 3514952](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3514952): [LCW][V2] Multiple issues found with LCW telemetry parity

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/47a4788f-db9f-468e-b81c-35f17718029b)
