### PR TITLE
Fix SSO magic code to use Web browser's version of BroadcastChannel

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed an issue where opening a chat right after agent ends the previous chat doesn't work
 - Fixed an issue where opening/refreshing a persistent chat shows the Reconnect Pane
+- Fix SSO magic code due to incompatibility of broadcast channel
 
 ## [1.2.1] - 2023-7-24
 

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -3,9 +3,7 @@
 import { IStackStyles, Stack } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
-
 import { BotMagicCodeStore } from "./webchatcontroller/BotMagicCodeStore";
-import { BroadcastChannel } from "broadcast-channel";
 import { Components } from "botframework-webchat";
 import { Constants } from "../../common/Constants";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
@@ -54,8 +52,8 @@ const createMagicCodeSuccessResponse = (signin: string) => {
 export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
     const { BasicWebChat } = Components;
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
-    const magicCodeBroadcastChannel = new BroadcastChannel(Constants.magicCodeBroadcastChannel);
-    const magicCodeResponseBroadcastChannel = new BroadcastChannel(Constants.magicCodeResponseBroadcastChannel);
+    const magicCodeBroadcastChannel = new (window as any).BroadcastChannel(Constants.magicCodeBroadcastChannel); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const magicCodeResponseBroadcastChannel = new (window as any).BroadcastChannel(Constants.magicCodeResponseBroadcastChannel); // eslint-disable-line @typescript-eslint/no-explicit-any
     const {webChatContainerProps, contextDataStore} = props;
 
     const containerStyles: IStackStyles = {


### PR DESCRIPTION
- Replace usage of BroadcastChannel node package with browser's supported BroadcastChannel library for SSO magic code feature

### Test Scenarios
- SSO Magic code should be suppressed
- Magic Code page should not be opened
- Magic Code should be sent behind the scenes
- Magic Code should not appear in the chat widget


https://github.com/microsoft/omnichannel-chat-widget/assets/8888565/4d22f393-567d-4518-9e3d-e637166e059f

