### PR TITLE
Fixed PreChatPane not showing full text for toggle input text

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -160,6 +160,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed PreChatPane not showing full text for toggle input text
+
 ## [1.0.5] - 2023-7-20
 
 ### Added

--- a/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
+++ b/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
@@ -1,11 +1,11 @@
 import * as AdaptiveCards from "adaptivecards";
 
+import { ElementType, EventNames } from "../../common/Constants";
 import { IStackStyles, Stack } from "@fluentui/react";
 import React, { useCallback } from "react";
 import { addNoreferrerNoopenerTag, broadcastError, getInputValuesFromAdaptiveCard } from "../../common/utils";
 
 import { BroadcastService } from "../../services/BroadcastService";
-import { ElementType, EventNames } from "../../common/Constants";
 import { ICustomEvent } from "../../interfaces/ICustomEvent";
 import { IPreChatSurveyPaneProps } from "./interfaces/IPreChatSurveyPaneProps";
 import { defaultPreChatSurveyPaneACContainerStyles } from "./common/defaultProps/defaultStyles/defaultPreChatSurveyPaneACContainerStyles";
@@ -75,6 +75,8 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
                 font-size: ${props.styleProps?.customTextStyleProps?.fontSize} !important;
                 height: ${props.styleProps?.customTextStyleProps?.height};
                 padding-top: ${props.styleProps?.customTextStyleProps?.paddingTop};
+                overflow-wrap: break-word;
+                white-space: normal !important;
             }
             .ac-textRun {
                 font-size: ${props.styleProps?.customTextStyleProps?.fontSize} !important;


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3546392](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3546392): [V2][ICM] Prechat with long lenght texts is not presented properly

### Description
PreChatPane not showing full text for toggle input text
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/2a805993-2d67-4211-8840-449e77b526fb)

### Solution Proposed
Added required styles to all ac-textBlock to show full text

### Acceptance criteria
Toggle input showing full text

### Test cases and evidence
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/405a8bd0-40ef-4863-8bc7-bed5f65845bc)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


### A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__
