### PR TITLE
Fix unauth reconnect bugs

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 # Chat Widget
 
 ## [Unreleased]
+
 ### Added
+
 - Added new middleware (messageSequenceIdOverrideMiddleware) to ensure proper order of messages
 - Added handling for OriginalMessageId in transcript component to fix sorting issues.
 
@@ -16,6 +18,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed an issue where video card cannot be rendered
+- Fixed an issue where refreshing unauthenticated reconnect chat results in infinite loading
+- Fixed an issue where unauthenticated reconnect chat doesn't work with valid reconnect id
 
 ## [1.2.2] - 2023-8-16
 

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -18,9 +18,10 @@ import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidge
 import StartChatOptionalParams from "@microsoft/omnichannel-chat-sdk/lib/core/StartChatOptionalParams";
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 
+// Return value: should start normal chat flow when reconnect is enabled
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, state: ILiveChatWidgetContext): Promise<boolean | undefined> => {
-    if (!isReconnectEnabled(props.chatConfig) || isPersistentEnabled(props.chatConfig)) return;
+const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, state: ILiveChatWidgetContext): Promise<boolean> => {
+    if (!isReconnectEnabled(props.chatConfig) || isPersistentEnabled(props.chatConfig)) return false;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = (props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
@@ -31,21 +32,21 @@ const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<
     //Redirect if enabled
     if (reconnectChatContext?.redirectURL) {
         redirectPage(reconnectChatContext.redirectURL, props.reconnectChatPaneProps?.redirectInSameWindow);
-        return;
+        return false;
     }
 
     if (hasReconnectId(reconnectChatContext)) {
         //if reconnect id is provided in props, don't show reconnect pane
         if (props.reconnectChatPaneProps?.reconnectId && !isNullOrEmptyString(props.reconnectChatPaneProps?.reconnectId)) {
             await setReconnectIdAndStartChat(isAuthenticatedChat, chatSDK, state, props, dispatch, setAdapter, reconnectChatContext.reconnectId ?? "", initStartChat);
-            return;
+            return false;
         }
 
         //show reconnect pane
         state.appStates.conversationState = ConversationState.ReconnectChat;
         dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: reconnectChatContext.reconnectId ?? "" });
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.ReconnectChat });
-        return;
+        return false;
     }
 
     // If we have reached this point, it means there is no valid reconnect id or redirectUrl

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -267,9 +267,9 @@ const setCustomContextParams = async (state: ILiveChatWidgetContext | undefined,
         return;
     }
 
-    if (state?.domainStates.customContext) {
+    if (state?.domainStates?.customContext) {
         optionalParams = Object.assign({}, optionalParams, {
-            customContext: JSON.parse(JSON.stringify(state?.domainStates.customContext))
+            customContext: JSON.parse(JSON.stringify(state?.domainStates?.customContext))
         });
         return;
     }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -145,9 +145,9 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             if (isChatValid === true) {
                 //Check if reconnect enabled
                 if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
-                    await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+                    const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
                     // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
-                    if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
+                    if (!noValidReconnectId && (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat)) {
                         return;
                     }
                 }
@@ -160,9 +160,9 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             if (localState) {
                 // adding the reconnect logic for the case when customer tries to reconnect from a new browser or InPrivate browser
                 if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
-                    await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+                    const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
                     // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
-                    if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
+                    if (!noValidReconnectId && (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat)) {
                         return;
                     }
                 }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -131,6 +131,17 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const startChat = async (props: ILiveChatWidgetProps, localState?: any) => {
+        const isReconnectTriggered = async (): Promise<boolean> => {
+            if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
+                const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+                // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
+                if (!noValidReconnectId && (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
         let isChatValid = false;
         //Start a chat from cache/reconnectid
         if (activeCachedChatExist === true) {
@@ -143,15 +154,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             //Check if conversation state is not in wrapup or closed state
             isChatValid = await checkIfConversationStillValid(chatSDK, dispatch, state);
             if (isChatValid === true) {
-                //Check if reconnect enabled
-                if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
-                    const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
-                    // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
-                    if (!noValidReconnectId && (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat)) {
-                        return;
-                    }
+                const reconnectTriggered = await isReconnectTriggered();
+                if (!reconnectTriggered) {
+                    await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams);
                 }
-                await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams);
                 return;
             }
         }
@@ -159,14 +165,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         if (isChatValid === false) {
             if (localState) {
                 // adding the reconnect logic for the case when customer tries to reconnect from a new browser or InPrivate browser
-                if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
-                    const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
-                    // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
-                    if (!noValidReconnectId && (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat)) {
-                        return;
-                    }
+                const reconnectTriggered = await isReconnectTriggered();
+                if (!reconnectTriggered) {
+                    await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, undefined, undefined, localState, props);
                 }
-                await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, undefined, undefined, localState, props);
                 return;
             } else {
                 // To avoid showing blank screen in popout


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3554753](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3554753): [V2] [8.3 PPE] [LCW] [UNAUTH] After the chat gets reconnected to previous chat, the error banner like "Start Chat Failed: TypeError: Cannot read properties of undefined (reading 'customContext')" is showing in the top of blob window.
[Bug 3552329](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3552329): [V2] Refreshing an active reconnect chat places chat in forever loading state

### Description
_Include a description of the problem to be solved_
1. Refreshing unauth reconnect page results in infinite loading
2. Using reconnect id in url shows an error banner

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
1. Detect when unauth reconnect page is being refreshed without reconnect id, then go with normal chat flow
2. reconnectHandler is missing an argument when doing initStartChat. Fixed the bug

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
Passed the following test cases and Reconnect regression suite
[Test Case 3561446](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3561446): [LCW OOB] [Reconnect Chat] Verify unauthenticated customer reconnects to chat after page refresh when third party cookie is on
[Test Case 2710644](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/2710644): [LCW OOB] [Reconnect Chat] Verify unauthenticated customer reconnects to chat using reconnect url within redirection time limit

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![proof1](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/e9f3c83d-913e-4195-ad82-1b2622b20eed)


### Sanity Tests
-   [x] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__