### PR TITLE
Support HTML tags inside system messages

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Fixed an issue where video card cannot be rendered
 - Fixed an issue where refreshing unauthenticated reconnect chat results in infinite loading
 - Fixed an issue where unauthenticated reconnect chat doesn't work with valid reconnect id
+- Fixed an issue where system message does not support html tags
 
 ## [1.2.2] - 2023-8-16
 

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.spec.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.spec.ts
@@ -1,0 +1,202 @@
+import { Constants } from "../../../../../common/Constants";
+import { DirectLineActivityType } from "../../enums/DirectLineActivityType";
+import { DirectLineSenderRole } from "../../enums/DirectLineSenderRole";
+import { MessageTypes } from "../../enums/MessageType";
+import { TelemetryHelper } from "../../../../../common/telemetry/TelemetryHelper";
+import { createActivityMiddleware } from "./activityMiddleware";
+
+describe("activityMiddleware test", () => {
+    it ("createActivityMiddleware() with Channel role sender should returns nothing", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const args = {
+            activity: {
+                channelData: {
+                    type: MessageTypes.Thread
+                },
+                from: {
+                    role: DirectLineSenderRole.Channel
+                }
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(results()).toEqual(false);
+        expect(TelemetryHelper.logActionEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it ("createActivityMiddleware() with Hidden tag should return nothing", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const args = {
+            activity: {
+                channelData: {
+                    tags: [Constants.hiddenTag]
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                }
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(results()).toEqual(false);
+        expect(TelemetryHelper.logActionEvent).toHaveBeenCalledTimes(0);
+    });
+
+    it ("createActivityMiddleware() with System tag should return system message", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const systemMessage = "system message";
+        const args = {
+            activity: {
+                text: systemMessage,
+                channelData: {
+                    tags: [Constants.systemMessageTag]
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                }
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(TelemetryHelper.logActionEvent).toHaveBeenCalledTimes(0);
+        expect(results().props?.dangerouslySetInnerHTML?.__html).toEqual(systemMessage);
+    });
+
+    it ("createActivityMiddleware() should escape html texts to prevent XSS attacks", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const systemMessage = "<img src='' onerror=\"alert('XSS attack')\"/>";
+        const args = {
+            activity: {
+                text: systemMessage,
+                channelData: {
+                    tags: [Constants.systemMessageTag]
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                }
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(TelemetryHelper.logActionEvent).toHaveBeenCalledTimes(0);
+        expect(results().props?.dangerouslySetInnerHTML?.__html).toEqual("&lt;img src=&#39;&#39; onerror=&quot;alert(&#39;XSS attack&#39;)&quot;&#x2F;&gt;");
+    });
+
+    it ("createActivityMiddleware() with QueuePosition tag should log QueuePosition message", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const systemMessage = "system message";
+        const args = {
+            activity: {
+                text: systemMessage,
+                channelData: {
+                    tags: [Constants.systemMessageTag, Constants.queuePositionMessageTag]
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                }
+            }
+        };
+
+        createActivityMiddleware()()(next)(args);
+        expect(TelemetryHelper.logActionEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it ("createActivityMiddleware() with same clientmessageid with next activity should return nothing", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const systemMessage = "system message";
+        const args = {
+            activity: {
+                text: systemMessage,
+                channelData: {
+                    tags: [Constants.systemMessageTag],
+                    clientmessageid: "1234"
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                }
+            },
+            nextVisibleActivity: {
+                channelData: {
+                    clientmessageid: "1234"
+                }
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(results()).toEqual(false);
+    });
+
+    it ("createActivityMiddleware() with same messageid with next activity should return nothing", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const systemMessage = "system message";
+        const args = {
+            activity: {
+                text: systemMessage,
+                channelData: {
+                    tags: [Constants.systemMessageTag]
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                },
+                messageid: "1234"
+            },
+            nextVisibleActivity: {
+                messageid: "1234"
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(results()).toEqual(false);
+    });
+
+    it ("createActivityMiddleware() should render normal user messages", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const userMessage = "Hello World";
+        const args = {
+            activity: {
+                text: userMessage,
+                channelId: "webchat",
+                channelData: {
+                    isHtmlEncoded: false
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                },
+                type: DirectLineActivityType.Message
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(results().props?.children?.activity?.text).toEqual(userMessage);
+    });
+
+    it ("createActivityMiddleware() should not render typing messages", () => {
+        spyOn(TelemetryHelper, "logActionEvent").and.callFake(() => false);
+        const next = (args: any) => () => args; // eslint-disable-line @typescript-eslint/no-explicit-any
+        const userMessage = "Hello World";
+        const args = {
+            activity: {
+                text: userMessage,
+                channelId: "webchat",
+                channelData: {
+                    isHtmlEncoded: false
+                },
+                from: {
+                    role: DirectLineSenderRole.User
+                },
+                type: DirectLineActivityType.Typing
+            }
+        };
+
+        const results = createActivityMiddleware()()(next)(args);
+        expect(results().activity?.text).toEqual(userMessage);
+    });
+});

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
@@ -46,11 +46,9 @@ const handleSystemMessage = (next: any, args: any[], card: any, systemMessageSty
         return () => false;
     }
 
-    // eslint-disable-next-line react/display-name, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line react/display-name
     return () => (
-        <div key={card.activity.id} style={systemMessageStyles} aria-hidden="true">
-            {card.activity.text}
-        </div>
+        <div key={card.activity.id} style={systemMessageStyles} aria-hidden="true" dangerouslySetInnerHTML={{ __html: card.activity.text }}/>
     );
 };
 

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
@@ -48,7 +48,7 @@ const handleSystemMessage = (next: any, args: any[], card: any, systemMessageSty
 
     // eslint-disable-next-line react/display-name
     return () => (
-        <div key={card.activity.id} style={systemMessageStyles} aria-hidden="true" dangerouslySetInnerHTML={{ __html: card.activity.text }}/>
+        <div key={card.activity.id} style={systemMessageStyles} aria-hidden="true" dangerouslySetInnerHTML={{ __html: escapeHtml("<img src='' onerror=\"alert('XSS attack')\"/>")}}/>
     );
 };
 

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
@@ -48,7 +48,7 @@ const handleSystemMessage = (next: any, args: any[], card: any, systemMessageSty
 
     // eslint-disable-next-line react/display-name
     return () => (
-        <div key={card.activity.id} style={systemMessageStyles} aria-hidden="true" dangerouslySetInnerHTML={{ __html: escapeHtml("<img src='' onerror=\"alert('XSS attack')\"/>")}}/>
+        <div key={card.activity.id} style={systemMessageStyles} aria-hidden="true" dangerouslySetInnerHTML={{ __html: escapeHtml(card.activity.text)}}/>
     );
 };
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3547532](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3547532): [V2] HTML welcome system message - Chat widget v2 no longer supports html-tags

### Description
HTML tags are not applied to system messages

## Solution Proposed
Set the text as html innerText.

Because the sanitization middleware is executed before activityMiddleware, dangerouslySetHtml is ok to use here. It is the same implementation inside webchat

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
1. html tags render correctly
2. normal texts doesn't have regression
3. No security concerns - scripts are not executed

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![proof1](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/add43725-2397-469b-9094-3f7ee4f21b44)
![proof2](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/8b906a51-a518-4f52-8b37-4f35501c5bcd)
![proof3](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/8ab3e6ce-2381-494b-b6e0-7b5d0990aee3)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__