### PR TITLE
Added customContext option in `StartChat` BroadcastEvent

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added customContext option in `StartChat` BroadcastEvent to pass in custom context variables synchronously
+
 ## [1.3.0] - 2023-09-18
 
 ### Added

--- a/chat-widget/samples/javascript-sample/SampleWidget.js
+++ b/chat-widget/samples/javascript-sample/SampleWidget.js
@@ -67,6 +67,16 @@ const main = async () => {
         BroadcastService.postMessage(setCustomContextEvent);
     };
 
+    const startChat = (context) => {
+        const setCustomContextEvent = {
+            eventName: "StartChat",
+            payload: {
+                customContext: context
+            }
+        };
+        BroadcastService.postMessage(setCustomContextEvent);
+    };
+
     const startProactiveChat = (notificationUIConfig, showPrechat, inNewWindow) => {
         const startProactiveChatEvent = {
             eventName: "StartProactiveChat",
@@ -81,6 +91,7 @@ const main = async () => {
 
     window["switchConfig"] = switchConfig;
     window["startProactiveChat"] = startProactiveChat;
+    window["startChat"] = startChat;
     window["setCustomContext"] = setCustomContext;
     switchConfig(await getCustomizationJson());
 };

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -56,7 +56,7 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
     const isPreChatEnabledInProactiveChat = state.appStates.proactiveChatStates.proactiveChatEnablePrechat;
 
     //Setting PreChat and intiate chat
-    await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, isProactiveChat, isPreChatEnabledInProactiveChat, undefined, props);
+    await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, isProactiveChat, isPreChatEnabledInProactiveChat, state, props);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -299,7 +299,23 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         });
 
         // Start chat from SDK Event
-        BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe(() => {
+        BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
+            let stateWithUpdatedContext: ILiveChatWidgetContext = state;
+            if (msg?.payload?.customContext) {
+                TelemetryHelper.logActionEvent(LogLevel.INFO, {
+                    Event: TelemetryEvent.CustomContextReceived,
+                    Description: "CustomContext received through startChat event."
+                });
+                dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: msg?.payload?.customContext });
+                stateWithUpdatedContext = {
+                    ...state,
+                    domainStates: {
+                        ...state.domainStates,
+                        customContext: msg?.payload?.customContext
+                    }
+                };
+            }
+            
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.StartChatEventRecevied,
                 Description: "Start chat event received."
@@ -313,7 +329,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.ChatInitiated
                 });
-                prepareStartChat(props, chatSDK, state, dispatch, setAdapter);
+                prepareStartChat(props, chatSDK, stateWithUpdatedContext, dispatch, setAdapter);
                 return;
             }
 
@@ -326,7 +342,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                     BroadcastService.postMessage({
                         eventName: BroadcastEvent.ChatInitiated
                     });
-                    prepareStartChat(props, chatSDK, state, dispatch, setAdapter);
+                    prepareStartChat(props, chatSDK, stateWithUpdatedContext, dispatch, setAdapter);
                     return;
                 }
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Task 3582642](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3582642): Add new parameter in startChat to take in customContext variables

### Description
Today, the OOB SDKs including`Microsoft.Omnichannel.LiveChatWidget.SDK.setContextProvider` and `Microsoft.Omnichannel.LiveChatWidget.SDK.startChat` are async calls due to the nature of iframe message sending. As a result, the below scenario will fail:

1. Customer calls `Microsoft.Omnichannel.LiveChatWidget.SDK.setContextProvider`
2. Customer wants to star the chat as soon as chat script is loaded, so the SDK `Microsoft.Omnichannel.LiveChatWidget.SDK.startChat` is immediately called. 
3. Because the 2 calls are async, the custom context is not populated yet by the time `ChatSDK.startChat` is initiated, and in turn the context is not passed to the agent. Subsequent startChat will have the context

## Solution Proposed
Because the `Microsoft.Omnichannel.LiveChatWidget.SDK.startChat` SDk method relies on the `StartChat` Broadcast event, we add a extra parameter in the CustomEvent - `customContext`. In chat-widget code, we synchronously set the context first, then start the chat. One caveat is that the state variable will not update in the same render, so the in the startChat sequence we need to to pass a deep cloned copy of the same state object. In the next `StartChat` call (next render occurred), the state will be correctly populated by the dispatch call.

On OOB side, we introduce another parameter inside .startChat() - `Microsoft.Omnichannel.LiveChatWidget.SDK.startChat({inNewWindow, customContext})`. If customContext is set, we pass the context into the startChat event, and also set the default contextProvider variable, as if the customer has called .setContextProvider SDK explicitly. This is in the cases of popout chat, {inNewWindow: true} scenarios, and if the following calls don't include any context variables (in this case we use the previous context variables).

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__