### PR TITLE
Ensure end voice and video call before ending chat

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 - Added customContext option in `StartChat` BroadcastEvent to pass in custom context variables synchronously
 
+### Fixed
+- Fixed an issue where C2 voice/video feed does not end despite C2 ending the chat
+
 ## [1.3.0] - 2023-09-18
 
 ### Added

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -17,14 +17,6 @@ import { defaultWebChatContainerStatefulProps } from "../../webchatcontainerstat
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, setWebChatStyles: any, adapter: any, uwid: string) => {
-    // const resetCallingStates = () => {
-    //     dispatch({ type: LiveChatWidgetActionType.SHOW_CALLING_CONTAINER, payload: false });
-    //     dispatch({ type: LiveChatWidgetActionType.SET_INCOMING_CALL, payload: true });
-    //     dispatch({ type: LiveChatWidgetActionType.DISABLE_VIDEO_CALL, payload: true });
-    //     dispatch({ type: LiveChatWidgetActionType.DISABLE_LOCAL_VIDEO, payload: true });
-    //     dispatch({ type: LiveChatWidgetActionType.DISABLE_REMOTE_VIDEO, payload: true });
-    // };
-
     try {
         // Use Case: If call is ongoing, end the call by simulating end call button click
         const voiceVideoCallingSdk = await chatSDK.getVoiceVideoCalling();

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
@@ -1,5 +1,6 @@
 import { ParticipantType } from "../../../common/Constants";
 import MockAdapter from "./mockadapter";
+import { MockVoiceVideoCallingSDK } from "./mockvoicevideocallingsdk";
 
 export class MockChatSDK {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,5 +58,9 @@ export class MockChatSDK {
         return {
             reconnectId: "123"
         };
+    }
+
+    public getVoiceVideoCalling() {
+        return null;
     }
 }

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
@@ -1,6 +1,5 @@
 import { ParticipantType } from "../../../common/Constants";
 import MockAdapter from "./mockadapter";
-import { MockVoiceVideoCallingSDK } from "./mockvoicevideocallingsdk";
 
 export class MockChatSDK {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

[Bug 3603600](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3603600): [LCW] [V2] Agent can still see C2 video despite C2 ending the chat

### Description
When C2 ends chat without ending a voice/video call, agent can still see C2's video call despite C2's chat widget being closed.

## Solution Proposed
Add voice/video call cleanup during the `prepareEndChat` stage, to simulate End Call button click if C2 ends chat without ending the video call.

### Acceptance criteria
C2's video call data is no longer visible to the agent after ending a chat (without ending the call) -> can confirm that video feed icon in browser is no longer active. Ensure all scenarios of C2 ending chat are successful, such as 1) C2 hitting "X" end chat button and 2) C2 running closeChat() OC SDK call.

## Test cases and evidence
1) C2 hitting "X" end chat button
<img width="627" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/38c09adf-4393-47d4-89f8-0a78cea254f6">
<img width="259" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/fcb228b7-454d-4819-9a8e-9450030d3412">
<img width="543" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/be7848be-b10d-4891-8c0f-721ef7dc7bd0">
<img width="268" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/03c33523-21de-4107-9f8b-5ec5db485c03">

2) closeChat SDK call:
<img width="765" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/a804041c-33c2-4ae7-babd-70424e69c2a0">
<img width="766" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/c1ba1d53-b402-4b6f-b696-8d5cef407860">
<img width="253" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/35b714d3-f657-4da4-a6fe-3a6a65d2f630">


### Sanity Tests
-   [x] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__