### PR TITLE
Use participant type to decide which survey to load

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed an issue where C2 voice/video feed does not end despite C2 ending the chat
 - Added workaround to render all adaptive card texts properly
+- Fixed an issue where agent post chat survey is used when customer closes the chat with only bot engagement
 
 ## [1.3.0] - 2023-09-18
 

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -1,4 +1,4 @@
-import { ConfirmationState, Constants, ConversationEndEntity } from "../../../common/Constants";
+import { ConfirmationState, Constants, ConversationEndEntity, ParticipantType } from "../../../common/Constants";
 import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { getAuthClientFunction, handleAuthentication } from "./authHelper";
 import { getConversationDetailsCall, getWidgetEndChatEventName, isNullOrEmptyString } from "../../../common/utils";
@@ -31,6 +31,11 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
             }
             // Use Case: If ended by Agent, stay chat in InActive state
             return;
+        }
+
+        // Register post chat participant type
+        if (conversationDetails?.participantType === ParticipantType.Bot || conversationDetails?.participantType === ParticipantType.User) {
+            dispatch({ type: LiveChatWidgetActionType.SET_POST_CHAT_PARTICIPANT_TYPE, payload: conversationDetails?.participantType });
         }
 
         // Use Case: Can render post chat scenarios

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -66,6 +66,10 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_ENDED_BY, payload: ConversationEndEntity.Agent });
             }
 
+            if (conversationDetails?.participantType === ParticipantType.Bot || conversationDetails?.participantType === ParticipantType.User) {
+                dispatch({ type: LiveChatWidgetActionType.SET_POST_CHAT_PARTICIPANT_TYPE, payload: conversationDetails?.participantType });
+            }
+
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.ConversationEndedThreadEventReceived,
                 Description: "Conversation end by agent side or by timeout event received."

--- a/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
@@ -1,7 +1,7 @@
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
 
-import { ConversationEndEntity } from "../../common/Constants";
+import { ParticipantType } from "../../common/Constants";
 import { CustomerVoiceEvents } from "./enums/CustomerVoiceEvents";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
 import { ILiveChatWidgetContext } from "../../contexts/common/ILiveChatWidgetContext";
@@ -34,7 +34,8 @@ export const PostChatSurveyPaneStateful = (props: IPostChatSurveyPaneStatefulPro
     let surveyInviteLink = "";
     const surveyMode = (state?.appStates?.selectedSurveyMode === PostChatSurveyMode.Embed);
 
-    if (state?.appStates?.conversationEndedBy === ConversationEndEntity.Bot && state.domainStates.postChatContext.botSurveyInviteLink) {
+    if (state.domainStates.postChatContext.botSurveyInviteLink && // Bot survey enabled
+        state.appStates.postChatParticipantType === ParticipantType.Bot) { // Only Bot has engaged
         surveyInviteLink = generateSurveyInviteLink(
             state.domainStates.postChatContext.botSurveyInviteLink,
             surveyMode,

--- a/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
@@ -3,7 +3,7 @@ import { ConversationState } from "./ConversationState";
 import { IInternalTelemetryData } from "../../common/telemetry/interfaces/IInternalTelemetryData";
 import { ILiveChatWidgetLocalizedTexts } from "./ILiveChatWidgetLocalizedTexts";
 import { IRenderingMiddlewareProps } from "../../components/webchatcontainerstateful/interfaces/IRenderingMiddlewareProps";
-import { ConfirmationState, ConversationEndEntity } from "../../common/Constants";
+import { ConfirmationState, ConversationEndEntity, ParticipantType } from "../../common/Constants";
 
 export interface ILiveChatWidgetContext {
     domainStates: {
@@ -51,6 +51,7 @@ export interface ILiveChatWidgetContext {
         conversationEndedBy: ConversationEndEntity; // The entity that ends conversation
         chatDisconnectEventReceived: boolean; // true when customer disconnect event is received
         selectedSurveyMode: string | null; // selected survey mode
+        postChatParticipantType: undefined | ParticipantType; // participant type to render post chat survey
     };
     uiStates: {
         showConfirmationPane: boolean; // true if the confirmation pane should show

--- a/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
@@ -263,8 +263,14 @@ export enum LiveChatWidgetActionType {
     SET_SURVEY_MODE,
 
     /*
-    Parameters:
-    ConfirmationState: Set confirmation state(OK/Cancel/NotSet)
+        Parameters:
+        ConfirmationState: Set confirmation state(OK/Cancel/NotSet)
     */
-    SET_CONFIRMATION_STATE
+    SET_CONFIRMATION_STATE,
+
+    /*
+        Parameters:
+        ParticipantType: Set participant type when rendering post chat survey
+    */
+    SET_POST_CHAT_PARTICIPANT_TYPE
 }

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -58,7 +58,8 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
             unreadMessageCount: 0,
             conversationEndedBy: ConversationEndEntity.NotSet,
             chatDisconnectEventReceived: false,
-            selectedSurveyMode: null
+            selectedSurveyMode: null,
+            postChatParticipantType: undefined
         },
         uiStates: {
             showConfirmationPane: false,

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -7,7 +7,7 @@ import { ILiveChatWidgetContext } from "./common/ILiveChatWidgetContext";
 import { ILiveChatWidgetLocalizedTexts } from "./common/ILiveChatWidgetLocalizedTexts";
 import { IRenderingMiddlewareProps } from "../components/webchatcontainerstateful/interfaces/IRenderingMiddlewareProps";
 import { LiveChatWidgetActionType } from "./common/LiveChatWidgetActionType";
-import { ConfirmationState, ConversationEndEntity } from "../common/Constants";
+import { ConfirmationState, ConversationEndEntity, ParticipantType } from "../common/Constants";
 import { PostChatSurveyMode } from "../components/postchatsurveypanestateful/enums/PostChatSurveyMode";
 
 export const createReducer = () => {
@@ -360,6 +360,15 @@ export const createReducer = () => {
                     domainStates: {
                         ...state.domainStates,
                         confirmationState: action.payload as ConfirmationState
+                    }
+                };
+
+            case LiveChatWidgetActionType.SET_POST_CHAT_PARTICIPANT_TYPE:
+                return {
+                    ...state,
+                    appStates: {
+                        ...state.appStates,
+                        postChatParticipantType: action.payload as ParticipantType
                     }
                 };
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3643817](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3643817): CRI - LCW V2 - When bot and agent separate surveys are configured, only agent survey is shown

### Description
_Include a description of the problem to be solved_
When bot and agent separate surveys are configured, only agent survey is shown when customer ends the chat with only bot engaged

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
Add a new state variable for participantType that updates every time conversationDetail is called

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
When bot and agent separate surveys are configured, bot survey is shown when customer ends the chat with only bot engaged

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

[Test Case 2694593](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/2694593): [LCW OOB] [Post Chat] Verify Customer should be able to get different embed surveys for agent and bot as configured when customer ends conversation
Bot only + Customer ends:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/fd714f6c-7c56-488b-9f0c-bb86c181279a)

Agent + Customer ends:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/79a44b3a-ca89-4723-95c3-3a9399c1a043)

Agent + Agent ends:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/169d476c-b831-472a-9ca6-df0ec3329e53)

Popout + Agent ends:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/5084a07c-d010-4b0a-8b69-472ce4d14a1d)

Post Chat Disabled for Bot:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/86291720-39dd-4909-9ce5-97ac60f3ab9f)
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/28538e34-b38f-4de9-8ef9-1e77f4786916)

Same survey:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/049bc70d-1c87-4b2d-9d59-4b2e3f9cae7f)
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/8d53e04b-dea2-48bf-9cf1-ade8443007cc)

Different survey types:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/9513150f-9c41-4888-a844-f5232131036a)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__