### PR TITLE
If StartChat event has a runtimeId included in payload, only start chat for that one tab

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where invoking `StartChat` event will create different chats across all tabs
+
 ### Changed
 - Uptake [@microsoft/omnichannel-chat-sdk@1.5.2](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.5.2)
 

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -1,7 +1,7 @@
 import { ConfirmationState, Constants, ConversationEndEntity, ParticipantType } from "../../../common/Constants";
 import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { getAuthClientFunction, handleAuthentication } from "./authHelper";
-import { getConversationDetailsCall, getWidgetEndChatEventName, isNullOrEmptyString } from "../../../common/utils";
+import { getConversationDetailsCall, getWidgetEndChatEventName } from "../../../common/utils";
 import { getPostChatContext, initiatePostChat } from "./renderSurveyHelpers";
 
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
@@ -14,9 +14,10 @@ import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidge
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { WebChatStoreLoader } from "../../webchatcontainerstateful/webchatcontroller/WebChatStoreLoader";
 import { defaultWebChatContainerStatefulProps } from "../../webchatcontainerstateful/common/defaultProps/defaultWebChatContainerStatefulProps";
+import { TelemetryManager } from "../../../common/telemetry/TelemetryManager";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, setWebChatStyles: any, adapter: any, uwid: string) => {
+const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, setWebChatStyles: any, adapter: any) => {
     try {
         // Use Case: If call is ongoing, end the call by simulating end call button click
         endVoiceVideoCallIfOngoing(chatSDK, dispatch);
@@ -27,7 +28,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
         if (conversationDetails?.canRenderPostChat?.toLowerCase() === Constants.false) {
             // If ended by customer, just close chat
             if (state?.appStates?.conversationEndedBy === ConversationEndEntity.Customer) {
-                await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, false, true, uwid);
+                await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, false, true);
             }
             // Use Case: If ended by Agent, stay chat in InActive state
             return;
@@ -47,7 +48,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
         if (postchatContext === undefined) {
             // For Customer intiated conversations, just close chat widget
             if (state?.appStates?.conversationEndedBy === ConversationEndEntity.Customer) {
-                await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, false, true, uwid);
+                await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, false, true);
                 return;
             }
 
@@ -56,7 +57,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
             return;
         }
 
-        endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, true, true, uwid);
+        endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, true, true);
 
         // Initiate post chat render
         if (state?.domainStates?.postChatContext) {
@@ -74,7 +75,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
 
         //Close chat widget for any failure in embedded to allow to show start chat button
         if (props.controlProps?.hideStartChatButton === false) {
-            await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, false, true, uwid);
+            await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, false, true);
         }
     }
     finally {
@@ -85,7 +86,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, setWebChatStyles: any, adapter: any,
-    skipEndChatSDK?: boolean, skipCloseChat?: boolean, postMessageToOtherTab?: boolean, uwid = "") => {
+    skipEndChatSDK?: boolean, skipCloseChat?: boolean, postMessageToOtherTab?: boolean) => {
     if (!skipEndChatSDK && chatSDK.conversation) {
         try {
             TelemetryHelper.logSDKEvent(LogLevel.INFO, {
@@ -132,16 +133,18 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
         }
     }
 
-    if (postMessageToOtherTab && !isNullOrEmptyString(uwid)) {
+    if (postMessageToOtherTab) {
         const endChatEventName = await getEndChatEventName(chatSDK, props);
         BroadcastService.postMessage({
             eventName: endChatEventName,
-            payload: uwid
+            payload: {
+                runtimeId: TelemetryManager.InternalTelemetryData.lcwRuntimeId
+            }
         });
     }
 };
 
-const callingStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
+export const callingStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
     dispatch({ type: LiveChatWidgetActionType.SHOW_CALLING_CONTAINER, payload: false });
     dispatch({ type: LiveChatWidgetActionType.SET_INCOMING_CALL, payload: true });
     dispatch({ type: LiveChatWidgetActionType.DISABLE_VIDEO_CALL, payload: true });
@@ -149,14 +152,14 @@ const callingStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) =>
     dispatch({ type: LiveChatWidgetActionType.DISABLE_REMOTE_VIDEO, payload: true });
 };
 
-const endChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
+export const endChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
     // Need to clear these states immediately when chat ended from OC.
     dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: false });
 };
 
-const closeChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
+export const closeChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: undefined });
     // dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -14,6 +14,7 @@ import {
     getWidgetCacheIdfromProps,
     getWidgetEndChatEventName,
     isNullOrEmptyString,
+    isNullOrUndefined,
     isUndefinedOrEmpty,
     newGuid
 } from "../../../common/utils";
@@ -62,7 +63,7 @@ import ProactiveChatPaneStateful from "../../proactivechatpanestateful/Proactive
 import ReconnectChatPaneStateful from "../../reconnectchatpanestateful/ReconnectChatPaneStateful";
 import StartChatOptionalParams from "@microsoft/omnichannel-chat-sdk/lib/core/StartChatOptionalParams";
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
-import { TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
+import { TelemetryManager, TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
 import WebChatContainerStateful from "../../webchatcontainerstateful/WebChatContainerStateful";
 import createDownloadTranscriptProps from "../common/createDownloadTranscriptProps";
 import { createFooter } from "../common/createFooter";
@@ -301,6 +302,11 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
+            // If the startChat event is not initiated by the same tab. Ignore the call
+            if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
+                return;
+            }
+            
             let stateWithUpdatedContext: ILiveChatWidgetContext = state;
             if (msg?.payload?.customContext) {
                 TelemetryHelper.logActionEvent(LogLevel.INFO, {

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -300,8 +300,9 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
-            // If the startChat event is not initiated by the same tab. Ignore the call
-            if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
+            if (!isNullOrUndefined(msg?.payload?.runtimeId) &&
+                msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId && // If the startChat event is not initiated by the same tab. Ignore the call
+                props.controlProps?.hideStartChatButton !== true) { // Skip the above check for popout chat
                 return;
             }
             
@@ -399,7 +400,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             if (msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
                 endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, true, false, false);
                 endChatStateCleanUp(dispatch);
-                chatSDK.requestId = uuidv4();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (chatSDK as any).requestId = uuidv4();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (chatSDK as any).chatToken = {};
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (chatSDK as any).reconnectId = null;
                 return;
             }
         });

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -300,9 +300,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
-            if (!isNullOrUndefined(msg?.payload?.runtimeId) &&
-                msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId && // If the startChat event is not initiated by the same tab. Ignore the call
-                props.controlProps?.hideStartChatButton !== true) { // Skip the above check for popout chat
+            // If the startChat event is not initiated by the same tab. Ignore the call
+            if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
                 return;
             }
             


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3655164](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3655164): Calling startChat() opens the widget and creates separate conversations on all tabs hosting LCW

### Description
_Include a description of the problem to be solved_
Currently when multiple tabs holding LCW are open, calling .startChat() LCW SDK (internally invoking the `StartChat` Broadcast event) will broadcast this event to all open tabs. This will create race conditions and create multiple unique chats. Since the customer is only going to focus on the most recent chats, the other (unknown to user) chats will become ghost chats

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
Include a runtimeId parameter in the event. If the runtimeId doesn't match, do not start chat. This way, when the chat button is later clicked for the other tabs, the same chat will persist.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
Calling StartChat does not start chat for all the open tabs. Closing one chat instance closes all instances. A new chat can then be created.

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
[Test Case 3655722](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3655722): [LCW OOB] [Multi Tab] Verify that calling startChat() does not start chat on all tabs
Before:
![before](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/c285a0c8-dfc8-4148-ad3d-b715844401c9)

After:
![after](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/d20eba0c-5010-4580-bd84-e6160247011e)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__