### PR TITLE
Fixed an issue where post chat does not load on first chat on a browser session

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed an issue where invoking `StartChat` event will create different chats across all tabs
+- Fixed an issue where post chat does not load on first chat on a browser session
 
 ## [1.4.0] - 2023-10-25
 

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -40,10 +40,8 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
         }
 
         // Use Case: Can render post chat scenarios
-        await getPostChatContext(chatSDK, state, dispatch);
-
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const postchatContext: any = state?.domainStates?.postChatContext;
+        const postchatContext: any = await getPostChatContext(chatSDK, state, dispatch) ?? state?.domainStates?.postChatContext;
 
         if (postchatContext === undefined) {
             // For Customer intiated conversations, just close chat widget
@@ -60,7 +58,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
         endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, true, true);
 
         // Initiate post chat render
-        if (state?.domainStates?.postChatContext) {
+        if (postchatContext) {
             await initiatePostChat(props, conversationDetails, state, dispatch, postchatContext);
             return;
         }

--- a/chat-widget/src/components/livechatwidget/common/renderSurveyHelpers.ts
+++ b/chat-widget/src/components/livechatwidget/common/renderSurveyHelpers.ts
@@ -43,30 +43,31 @@ const setSurveyMode = async (props: ILiveChatWidgetProps, participantType: strin
     }
 };
 
-const renderSurvey = async (state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const renderSurvey = async (postChatContext: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     if (postChatSurveyMode === PostChatSurveyMode.Link) {
         setWidgetStateToInactive(dispatch);
         return;
     }
     if (postChatSurveyMode === PostChatSurveyMode.Embed) {
-        await embedModePostChatWorkflow(state, dispatch);
+        await embedModePostChatWorkflow(postChatContext, dispatch);
     }
 };
 
 // Function for embed mode postchat workflow which is essentially same for both customer and agent
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const embedModePostChatWorkflow = async (state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>) => {
+const embedModePostChatWorkflow = async (postChatContext: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     TelemetryHelper.logActionEvent(LogLevel.INFO, {
         Event: TelemetryEvent.EmbedModePostChatWorkflowStarted
     });
-    if (state?.domainStates?.postChatContext) {
+    if (postChatContext) {
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.PostchatLoading });
 
         await addDelayInMs(Constants.PostChatLoadingDurationInMs);
 
         dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Postchat });
     } else {
-        const error = `Conversation was Ended but App State was not set correctly: postChatContext = ${state.domainStates.postChatContext}`;
+        const error = `Conversation was Ended but App State was not set correctly: postChatContext = ${postChatContext}`;
         TelemetryHelper.logActionEvent(LogLevel.ERROR, {
             Event: TelemetryEvent.AppStatesException,
             ExceptionDetails: {
@@ -82,7 +83,7 @@ const initiatePostChat = async (props: ILiveChatWidgetProps, conversationDetails
     const participantType = conversationDetails?.participantType ?? postchatContext.participantType;
     await setSurveyMode(props, participantType, state, dispatch);
 
-    await renderSurvey(state, dispatch);
+    await renderSurvey(postchatContext, dispatch);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -102,6 +103,7 @@ const getPostChatContext = async (chatSDK: any, state: ILiveChatWidgetContext, d
                 Description: "Postchat context call succeed."
             });
             dispatch({ type: LiveChatWidgetActionType.SET_POST_CHAT_CONTEXT, payload: context });
+            return context;
         }
     } catch (error) {
         TelemetryHelper.logSDKEvent(LogLevel.INFO, {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3665099](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3665099): [V2] The first time a chat loads on the page, post chat is not rendered

### Description
_Include a description of the problem to be solved_
The first time a chat loads on the page, post chat is not rendered. This is because we use state.domainStates.postChatContext to determine if we render post chat. However, the first time when we check context and save it to state, the state is not updated directly, so first time is always a miss

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
Check for newly acquired postchatcontext as well as state

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
The first time a chat loads on the page, post chat is rendered

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
[Test Case 2694553](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/2694553): [LCW OOB] [Post Chat] Verify Customer should be able to get embed mode survey when customer ends conversation
After:
![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/50531b40-4426-4afb-b1d8-ad6db3bf27e6)
Before:
![proof2](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/771f8a82-6202-453f-9c14-d96e59786b60)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__