### PR TITLE
Fix loading pane icon image fit

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -218,6 +218,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed loading pane icon image fit
+
 ## [1.0.9] 2023-10-31
 
 ### Changed

--- a/chat-components/src/components/loadingpane/LoadingPane.tsx
+++ b/chat-components/src/components/loadingpane/LoadingPane.tsx
@@ -1,4 +1,4 @@
-import { IIconStyles, ILabelStyles, ISpinnerStyles, IStackStyles, Icon, Label, Spinner, Stack } from "@fluentui/react";
+import { IIconStyles, IImageProps, ILabelStyles, ISpinnerStyles, IStackStyles, Icon, Label, Spinner, Stack } from "@fluentui/react";
 
 import { ILoadingPaneProps } from "./interfaces/ILoadingPaneProps";
 import React from "react";
@@ -24,7 +24,7 @@ function LoadingPane(props: ILoadingPaneProps) {
         root: Object.assign({}, defaultLoadingPaneIconStyles, props.styleProps?.iconStyleProps)
     };
 
-    const iconImageProps = props.styleProps?.iconImageProps ?? defaultLoadingPaneIconImageProps;
+    const iconImageProps: IImageProps = Object.assign({}, defaultLoadingPaneIconImageProps, props.styleProps?.iconImageProps);
 
     const titleStyles: ILabelStyles = {
         root: Object.assign({}, defaultLoadingPaneTitleStyles, props.styleProps?.titleStyleProps)

--- a/chat-components/src/components/loadingpane/common/defaultProps/defaultStyles/defaultLoadingPaneIconImageProps.ts
+++ b/chat-components/src/components/loadingpane/common/defaultProps/defaultStyles/defaultLoadingPaneIconImageProps.ts
@@ -4,7 +4,7 @@ import { ModernChatIconBase64 } from "../../../../../assets/Icons";
 
 export const defaultLoadingPaneIconImageProps: IImageProps = {
     src: ModernChatIconBase64,
-    imageFit: ImageFit.center,
+    imageFit: ImageFit.centerContain,
     width: "86px",
     height: "86px",
     shouldFadeIn: false,


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3648684](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3648684): [LCW] Loading pane custom icon styling is not correct

### Description
Loading pane icon is not sized correctly when specific custom images are provided. Specifically below, for an image that is larger than the icon container space, it does not fit within the container:

## Solution Proposed
Modify the `imageFit` attribute to become `centerContain` to maintain aspect ratio, center the image, and contain it within the container.

### Acceptance criteria
Loading pane icon fits appropriately within the container, for various custom image sizes.

## Test cases and evidence
Large image:
<img width="185" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/0dd411e9-c6fc-446e-bdb6-c2f9fde737d2">

Default image:
<img width="187" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/68e4f642-aab3-4d67-a0e9-99d78bcb41d0">

Small image:
<img width="187" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/1ebb88dd-94d6-4245-b970-6c31e6ec5e42">

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__