### PR TITLE
Adding authentication check to fetch new token before endchat

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -19,6 +19,9 @@ import { TelemetryManager } from "../../../common/telemetry/TelemetryManager";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, setWebChatStyles: any, adapter: any) => {
     try {
+        //Get new auth token again if chat continued for longer time, otherwise chatsdk throws 401 error for auth chats
+        await handleAuthenticationIfEnabled(props, chatSDK);
+
         // Use Case: If call is ongoing, end the call by simulating end call button click
         endVoiceVideoCallIfOngoing(chatSDK, dispatch);
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Issue 3651972](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3651972): [DFC] - Chat Survey return rate discrepancies in Consumer

[Incident 436007411](https://icmcdn.akamaized.net/imp/v3/incidents/details/436007411/home) : Post chat survey didn't load for long ongoing chats

### Description
_Include a description of the problem to be solved_
**Issue:** The chat widget fails to return post-chat surveys for long-running chats, which has been reported by several SxG organization partners. This has resulted in a significant drop of approximately 25% in receiving feedback rates.

**Investigation Findings**: Upon investigating the issue, we identified that the problem is due to 401 unauthorized error returned from the `prepareEndChat` function.

**Consistency:** The issue appears to be consistently reproducible in the context of long-running chats.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
To address this issue, the recommendation is to implement a solution that ensures the `chatSDK` has a valid authentication token before executing the remaining code in `prepareEndChat` function, in case of authenticated chats. The included fix will get a new token and allow `chatSDK.getConversationDetails()` to run successfully, without encountering unauthorized errors, and subsequently, the survey can be rendered.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
1. Ensure unauthenticated chats is working as expected.
2. Ensure authenitcated chats are working as expected without causing any regression
3. Ensure post chat survey is rendered successfully even for long running chats.

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues
Not required, as there is no change to UX.

__*Please provide justification if any of the validations has been skipped.*__