### PR TITLE
Added `skipBroadcastChannelInit` prop to avoid duplicate initialization on BroadcastChannel

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 # Chat Widget
 
 ## [Unreleased]
+
 ### Added
+
 - [A11Y] Notification banner when e-mail address is introduced to receive transcript after chat ends.
+- Added `skipBroadcastChannelInit` prop to avoid duplicate initialization on BroadcastChannel
 
 ### Fixed
 

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetControlProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetControlProps.ts
@@ -17,4 +17,5 @@ export interface ILiveChatWidgetControlProps {
     hideStartChatButton?: boolean;
     widgetInstanceId?: string | undefined;
     cacheTtlInMins?: number;
+    skipBroadcastChannelInit?: boolean;
 }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -105,8 +105,11 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     //Scrollbar styles
     const scrollbarProps: IScrollBarProps = Object.assign({}, defaultScrollBarProps, props?.scrollBarProps);
 
-    const broadcastServiceChannelName = getBroadcastChannelName(chatSDK?.omnichannelConfig?.widgetId, props.controlProps?.widgetInstanceId ?? "");
-    BroadcastServiceInitialize(broadcastServiceChannelName);
+    // In case the broadcast channel is already initialized elsewhere; One tab can only hold 1 instance
+    if (props?.controlProps?.skipBroadcastChannelInit !== true) {
+        const broadcastServiceChannelName = getBroadcastChannelName(chatSDK?.omnichannelConfig?.widgetId, props.controlProps?.widgetInstanceId ?? "");
+        BroadcastServiceInitialize(broadcastServiceChannelName);
+    }
     TelemetryTimers.LcwLoadToChatButtonTimer = createTimer();
 
     const widgetElementId: string = props.controlProps?.id || "oc-lcw";


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 3676119](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3676119): Chat widget doesn't load on Safari older than v15.4

### Description
_Include a description of the problem to be solved_
LCW V2 doesn't work on older browsers where BroadcastChannel is not supported OOB, and indexedDB is used. In that case initializing the BroadcastChannel object twice causes some conflicts

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
Create a new prop. If the channel has already been created, don't initialize again

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
LCW V2 should work on 

Chrome: 71 (2018)
Edge: 79 (2020)
Firefox: 65 (2019)
Safari: 12.1 (2018)
Opera: 58 (2018)

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

Chrome 71:
![chrome71](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/6e0cfb64-fcc5-453a-ac65-87599f15c765)

Safari 12.1:
![OSX12](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/38b72038-2add-460b-a094-006cc19d7a3d)

iOS Safari 14:
![ios12](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/5e6ba1a6-2d4d-4722-ae37-0ab62f690925)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__