### PR TITLE
[3653350] : StartChat SDK loads pre-chat when out of operating hours.

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where invoking `StartChat` opens pre-chat survey during out of operation hours.
+
 ### Added
 
 - [A11Y] Notification banner when e-mail address is introduced to receive transcript after chat ends.

--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
@@ -58,11 +58,9 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.LCWChatButtonClicked
             });
-            if (state.appStates.isMinimized) {
-                dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
-            } else {
-                dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
-            }
+
+            state.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
         },
         unreadMessageString: props.buttonProps?.controlProps?.unreadMessageString,
         ...outOfOfficeButtonProps?.controlProps

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -67,7 +67,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
-    const isOutOfOperatingHours = state?.domainStates.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours === "True";
+    const isOutOfOperatingHours = state?.domainStates.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true";
 
     if (showPrechat) {
         if (isOutOfOperatingHours === true) {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -67,7 +67,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
-    const isOutOfOperatingHours = state?.domainStates.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true";
+    const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
 
     if (showPrechat) {
         if (isOutOfOperatingHours === true) {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -61,13 +61,7 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
-    //Handle out of office hours scenario
-    const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
-    if (isOutOfOperatingHours) {
-        state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
-        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
-        return;
-    }
+    //Handle reconnect scenario
 
     // Getting prechat Survey Context
     const parseToJson = false;
@@ -75,9 +69,16 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
 
     if (showPrechat) {
-        dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
-        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
-        return;
+        const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
+        if (isOutOfOperatingHours) {
+            state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
+            return;
+        } else {
+            dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
+            return;
+        }
     }
 
     //Initiate start chat

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -61,25 +61,23 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
-    //Handle reconnect scenario
+    //Handle out of office hours scenario
+    const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
+    if (isOutOfOperatingHours) {
+        state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
+        return;
+    }
 
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
-    const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
 
     if (showPrechat) {
-        if (isOutOfOperatingHours === true) {
-            state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
-            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
-            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
-            return;
-        } else {
-            dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
-            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
-            return;
-        }
+        dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
+        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
+        return;
     }
 
     //Initiate start chat

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -67,11 +67,19 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
+    const isOutOfOperatingHours = state?.domainStates.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours === "True";
 
     if (showPrechat) {
-        dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
-        dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
-        return;
+        if (isOutOfOperatingHours === true) {
+            state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
+            return;
+        } else {
+            dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
+            return;
+        }
     }
 
     //Initiate start chat


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3653350/?view=edit

### Description
StartChat SDK loads pre-chat when out of operating hours.

## Solution Proposed
While setting up prechat in v2 check if OOH is configured using the state and if it is enabled, then we should flip the state for OOH pane to render.

### Acceptance criteria
If out of operating hours is configured, the pre-chat survey should not load.

## Test cases and evidence
Scenario 1 - Embedded mode, Chat button hidden with SDK StartChat. On minimizing, the chat button is hidden and after refresh the OOH pane shows up
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/1ac93f46-6572-4b03-930c-0d4ca42b0e11)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/bb0d46c3-9ce4-42d4-89b6-84b57d49f09e)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/ad227fa9-d5df-4ac4-96cb-c5cfa61209fe)

Scenario 2 - Embedded mode, Chat button **not** hidden with SDK StartChat : On minimizing, the chat button is showing and after refresh or clicking the chat button, the OOH pane shows up
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/f04a5a9f-96ab-4cef-8451-d3e8ac24ce7f)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/32ffdb62-0ea4-4d3a-af44-8392ff02b48a)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/f631ff79-c997-4620-bad4-e86b4277b4f5)

Scenario 3 - Pop outmode, Chat button hidden with SDK StartChat. On minimizing, the chat button is hidden and after refresh the OOH pane shows up
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/7a7279be-5a6c-4357-b266-13f3b903dd73)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/50ab9ca2-9d2f-4410-9386-beebdb7a5a9b)

Scenario 4 - Pop out mode, Chat button **not** hidden with SDK StartChat : On minimizing, the chat button is showing and after refresh or clicking the chat button, the OOH pane shows up
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/77bbf232-2a83-4ece-af95-5fef5f34b5f0)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/6e81d9ec-afab-43a1-8dcc-0caf26828acb)


### Sanity Tests
-   [ X] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__