### PR TITLE
Chat disconnect message is not showing localized version

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed an issue where Chat disconnect banner message is not showing localized text.
 - Fixed an issue where invoking `StartChat` opens pre-chat survey during out of operation hours.
 
 ### Added

--- a/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
@@ -10,11 +10,11 @@ import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleChatDisconnect = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext, setWebChatStyles: any) => {
     if (state?.appStates?.chatDisconnectEventReceived) {
+        const chatDisconnectMessage = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_CHAT_DISCONNECT ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_CHAT_DISCONNECT;
         if (props?.webChatContainerProps?.renderingMiddlewareProps?.hideSendboxOnConversationEnd !== false) {
             setWebChatStyles((styles: StyleOptions) => { return { ...styles, hideSendBox: true }; });
         }
-        NotificationHandler.notifyWarning(NotificationScenarios.ChatDisconnect,
-            defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_CHAT_DISCONNECT as string);
+        NotificationHandler.notifyWarning(NotificationScenarios.ChatDisconnect, chatDisconnectMessage as string);
         TelemetryHelper.logActionEvent(LogLevel.INFO, {
             Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
             Description: "Chat disconnected due to timeout, left or removed."


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
https://dynamicscrm.visualstudio.com/OneCRM/_queries/edit/3694550

### Description
[V2] Chat disconnect message is not showing localized version.

## Solution Proposed
Pass the localized string from script layer and read from states in widget layer. There will be separate PR from script layer

### Acceptance criteria
The chat disconnect message should be localized

## Test cases and evidence
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/a8a116a7-afa9-4249-836b-758c92272569)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__