### PR TITLE
Uptake chat-sdk 1.5.7

### DIFF
--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@microsoft/omnichannel-chat-components": "^1.0.9",
-    "@microsoft/omnichannel-chat-sdk": "1.5.6",
+    "@microsoft/omnichannel-chat-sdk": "1.5.7",
     "abort-controller-es5": "^2.0.1",
     "dompurify": "^2.3.4",
     "markdown-it": "^12.3.2",

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2250,10 +2250,10 @@
     "@types/node" "^12.20.26"
     axios "^1.6.1"
 
-"@microsoft/omnichannel-amsclient@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.1.4.tgz#26b8650287bb7bc2a5baa8db47c2371fe9034434"
-  integrity sha512-iLLgQjxqYnXrcAzGrbHFqpRLdTjjadZOySEU32CoR5Had34ug4capBiqP1FYmITmfHO0u9G9oC4N1ghCtqFkNw==
+"@microsoft/omnichannel-amsclient@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.1.6.tgz#748148bf8167640fd7ca933e80b10ec6eecb5391"
+  integrity sha512-c7DyUsPy364NMb+uXzR6/QddynkAdYrucw2eUgvlslWpg9GyF1Horycs/iqNd+Qn1cBAWXXr639h3N+EPJ9AEA==
 
 "@microsoft/omnichannel-chat-components@^1.0.9":
   version "1.0.9"
@@ -2268,15 +2268,15 @@
     rxjs "^5.0.3"
     styled-components "^5.3.1"
 
-"@microsoft/omnichannel-chat-sdk@1.5.6":
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-1.5.6.tgz#c2683e9292fde07d5da07e77094b9a3a335ca63a"
-  integrity sha512-zonCbnIxqPjfGmFTTGjDmYu2OyWW1dfW0XuzOBJEo2iuusznHa7dSnfEWZwPwNjGT1bB6uls4NNTUBglEWqfLw==
+"@microsoft/omnichannel-chat-sdk@1.5.7":
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-1.5.7.tgz#cac075f4ac85406062c82adbca681a17ec769f9b"
+  integrity sha512-HySzoKCPXGbciVPySSBl3gGyXjSC8NlymZwiU0h94gV1iPoZok3mhT/gSqJn+dn2jlnwU4sDa9Jui4Jgj9VY7Q==
   dependencies:
     "@azure/communication-chat" "1.1.1"
     "@azure/communication-common" "1.1.0"
     "@microsoft/ocsdk" "^0.4.1"
-    "@microsoft/omnichannel-amsclient" "^0.1.4"
+    "@microsoft/omnichannel-amsclient" "^0.1.6"
     "@microsoft/omnichannel-ic3core" "^0.1.3"
 
 "@microsoft/omnichannel-ic3core@^0.1.3":


### PR DESCRIPTION
Currently when createObject or uploadDocument requests failed, it is still treated as a success, and a message is sent to ACS. This is causing data loss, as on C2 side the attachment is marked as successfully sent while in reality it is not

ams-client PR: https://github.com/microsoft/omnichannel-amsclient/pull/36

![proof](https://github.com/microsoft/omnichannel-chat-sdk/assets/14852927/95bbb471-8353-4d1c-a3a1-c042e778b20f)

![image](https://github.com/microsoft/omnichannel-chat-sdk/assets/14852927/b25c3cd0-42ca-40f4-af7f-80d37b86fe18)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__