### PR TITLE
Prevent starting new chat flow after reconnectUrl is used

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,27 +6,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed an issue where Chat disconnect banner message is not showing localized text.
-- Fixed an issue where invoking `StartChat` opens pre-chat survey during out of operation hours.
-
 ### Added
 
-- [A11Y] Notification banner when e-mail address is introduced to receive transcript after chat ends.
+- [A11Y] Notification banner when e-mail address is introduced to receive transcript after chat ends
 - Added `skipBroadcastChannelInit` prop to avoid duplicate initialization on BroadcastChannel
 
 ### Fixed
 
 - Fixed an issue where invoking `StartChat` event will create different chats across all tabs
 - Fixed an issue where post chat does not load on first chat on a browser session
-- Fix widget crashing due to `BroadcastChannel` not supported on `Safari` browsers below `15.4`
+- Fixed widget crashing due to `BroadcastChannel` not supported on `Safari` browsers below `15.4`
+- Fixed an issue where Chat disconnect banner message is not showing localized text
+- Fixed an issue where invoking `StartChat` opens pre-chat survey during out of operation hours
+- Fixed an issue where new chat starts even after reconnectUrl is being used
 
 ### Changed
 
 - Uptake [@microsoft/omnichannel-chat-components@1.0.8](https://www.npmjs.com/package/@microsoft/omnichannel-chat-components/v/1.0.8)
-- Uptake [@microsoft/omnichannel-chat-sdk@1.5.5](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.5.5)
-- Uptake [@microsoft/omnichannel-chat-sdk@1.5.6](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.5.6)
+- Uptake [@microsoft/omnichannel-chat-sdk@1.5.7](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.5.7)
 
 ## [1.4.0] - 2023-10-25
 

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -21,9 +21,7 @@ import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 // Return value: should start normal chat flow when reconnect is enabled
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, state: ILiveChatWidgetContext): Promise<boolean> => {
-    if (!isReconnectEnabled(props.chatConfig) || isPersistentEnabled(props.chatConfig)) return true;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = (props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
 
     // Get chat reconnect context

--- a/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/reconnectChatHelper.ts
@@ -21,7 +21,7 @@ import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 // Return value: should start normal chat flow when reconnect is enabled
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleChatReconnect = async (chatSDK: any, props: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, initStartChat: any, state: ILiveChatWidgetContext): Promise<boolean> => {
-    if (!isReconnectEnabled(props.chatConfig) || isPersistentEnabled(props.chatConfig)) return false;
+    if (!isReconnectEnabled(props.chatConfig) || isPersistentEnabled(props.chatConfig)) return true;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = (props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -18,7 +18,7 @@ import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
 import { createAdapter } from "./createAdapter";
 import { createOnNewAdapterActivityHandler } from "../../../plugins/newMessageEventHandler";
-import { handleChatReconnect } from "./reconnectChatHelper";
+import { handleChatReconnect, isPersistentEnabled, isReconnectEnabled } from "./reconnectChatHelper";
 import { setPostChatContextAndLoadSurvey } from "./setPostChatContextAndLoadSurvey";
 import { updateSessionDataForTelemetry } from "./updateSessionDataForTelemetry";
 
@@ -35,9 +35,11 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
     widgetInstanceId = getWidgetCacheIdfromProps(props);
 
     // reconnect > chat from cache
-    const shouldStartChatNormally = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
-    if (!shouldStartChatNormally) {
-        return;
+    if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
+        const shouldStartChatNormally = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+        if (!shouldStartChatNormally) {
+            return;
+        }
     }
 
     // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -35,7 +35,11 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
     widgetInstanceId = getWidgetCacheIdfromProps(props);
 
     // reconnect > chat from cache
-    await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+    const shouldStartChatNormally = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
+    if (!shouldStartChatNormally) {
+        return;
+    }
+
     // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
     if (state.appStates.conversationState === ConversationState.Active || state.appStates.conversationState === ConversationState.ReconnectChat) {
         return;


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_
When using auth chat, and a reconnectURL is provided, sometimes after clicking the chat button it starts a new chat (or shows prechat if it's configured)

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
If reconnect has already kicked in, stop going with the normal startChat flow

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
After providing reconnectURL, the chat always reconnects to the same chat if it still exists, without starting new chat sor showing prechat again

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

[Test Case 3704158](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3704158): [LCW OOB] [Reconnect Chat] Verify using reconnectUrl works on authenticated chats with prechat
[Test Case 3704160](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3704160): [LCW OOB] [Reconnect Chat] Verify using reconnectUrl works on authenticated chats without prechat
[Test Case 3704162](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3704162): [LCW OOB] [Reconnect Chat] Verify using reconnectUrl works on authenticated chats with prechat on new browser
[Test Case 3704163](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3704163): [LCW OOB] [Reconnect Chat] Verify using reconnectUrl works on authenticated chats with prechat on new browser with duplicate tab

![proof](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/438ed8b0-ff46-47b4-89a2-bfe844c320da)
![proof2](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/ecdb697d-df55-4726-a6fa-518dcbdc92d1)
![proof3](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/20084817-28fb-4da5-9249-e86e1def0b3a)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__