### PR TITLE
Clear Internal Live Chat Context When Chat Is In Closed State

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Clear ChatSDK's internal `liveChatContext` when `conversationState` is set to `Closed` on `startChat()`
+
 ## [1.5.0] - 2023-11-21
 
 ### Added


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
3683774

### Description
In certain situations such as agent ending the chat first, closing the chat widget would not explicitly perform `ChatSDK.endChat()` which would clear the internal live chat context. `sessioninit` has a strict throttling limit (1 per `requestId` per minute). In situation where the chat gets ended then started again and the `requestId` is not reset properly, then chat widget would not work, displaying an error pane. Resetting the internal live chat context would fix the issue.

## Solution Proposed
As described above.

### Acceptance criteria
- Starting a new chat after a chat is ended should reset the live chat context properly.

## Test cases and evidence
- Validation on regular chat

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__