### PR TITLE
[V2]Disconnected session doesnt allow to start a new session

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed an issue, where after the agent end the chat and C2 sees the disconnect banner after toggling, refreshing the browser does not show the message box.
 - Clear ChatSDK's internal `liveChatContext` when `conversationState` is set to `Closed` on `startChat()`
 
 ## [1.5.0] - 2023-11-21

--- a/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
@@ -9,16 +9,28 @@ import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleChatDisconnect = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext, setWebChatStyles: any) => {
-    if (state?.appStates?.chatDisconnectEventReceived) {
-        const chatDisconnectMessage = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_CHAT_DISCONNECT ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_CHAT_DISCONNECT;
-        if (props?.webChatContainerProps?.renderingMiddlewareProps?.hideSendboxOnConversationEnd !== false) {
-            setWebChatStyles((styles: StyleOptions) => { return { ...styles, hideSendBox: true }; });
-        }
-        NotificationHandler.notifyWarning(NotificationScenarios.ChatDisconnect, chatDisconnectMessage as string);
-        TelemetryHelper.logActionEvent(LogLevel.INFO, {
-            Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
-            Description: "Chat disconnected due to timeout, left or removed."
-        });
+    const chatDisconnectState = state?.appStates?.chatDisconnectEventReceived;
+    const chatDisconnectMessage = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_CHAT_DISCONNECT ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_CHAT_DISCONNECT;
+    const hideSendBoxOnConversationEnd = props?.webChatContainerProps?.renderingMiddlewareProps?.hideSendboxOnConversationEnd;
+
+    switch (chatDisconnectState) {
+        case true:
+            if (hideSendBoxOnConversationEnd !== false) {
+                setWebChatStyles((styles: StyleOptions) => { return { ...styles, hideSendBox: true }; });
+            }
+            NotificationHandler.notifyWarning(NotificationScenarios.ChatDisconnect, chatDisconnectMessage as string);
+            TelemetryHelper.logActionEvent(LogLevel.INFO, {
+                Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
+                Description: "Chat disconnected due to timeout, left or removed."
+            });
+            break;
+        case false:
+            if (hideSendBoxOnConversationEnd !== false) {
+                setWebChatStyles((styles: StyleOptions) => { return { ...styles, hideSendBox: false }; });
+            }
+            break;
+        default:
+            break;
     }
 };
 

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -109,6 +109,9 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
     }
 
     try {
+        // Clear disconnect state on start chat
+        state?.appStates?.chatDisconnectEventReceived && dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: false });
+
         //Start widget load timer
         TelemetryTimers.WidgetLoadTimer = createTimer();
 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -565,9 +565,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     // Handle Chat disconnect cases
     useEffect(() => {
-        if (state.appStates.chatDisconnectEventReceived) {
-            handleChatDisconnect(props, state, setWebChatStyles);
-        }
+        handleChatDisconnect(props, state, setWebChatStyles);
     }, [state.appStates.chatDisconnectEventReceived]);
 
     const initiateEndChatOnBrowserUnload = () => {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3642187

### Description
Issue occurs after the agent end the chat and C2 sees the disconnect banner after toggling the tab & refreshes the browser, it  does not show the message box for the new chat

![Problem](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/3e64a1d6-e69f-489d-a4a7-d81af277981f)


## Solution Proposed
Today, when C2 switches to different tab and for some reason the chat has ended behind the scene, we show Chat disconnect banner when C2 comes back to the original chat tab/window. At this point based on the conversation state (Closed or Wrapped), an event is triggered to update the chat disconnect state. We need to set this state as false for every new start chat and should also handle the false scenario in the handler. 

### Acceptance criteria
Start chat should proceed normally even if the chat disconnect banner shows up after C2 has toggled the tab and refreshes the chat browser.

## Test cases and evidence
Embedded Chat 

![StartChat](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/8477cc56-7f22-4286-be3f-2f389496c86f)

PopOut Chat

![StartChatPopOut](https://github.com/microsoft/omnichannel-chat-widget/assets/49963796/3958fb0b-5163-4c1c-a0b9-3efd4b0be72c)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__