### PR TITLE
Refactor startChatHelper and group widget load scenarios

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Updated a few exception's details on chat start
+- Updated exception details on chat start to include http status code for all `WidgetLoadFailed` and `WidgetLoadComplete` events with error 
 
 ## [1.5.0] - 2023-11-21
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Fixed an issue, where after the agent end the chat and C2 sees the disconnect banner after toggling, refreshing the browser does not show the message box.
 - Clear ChatSDK's internal `liveChatContext` when `conversationState` is set to `Closed` on `startChat()`
 
+### Changed
+
+- Updated a few exception's details on chat start
+
 ## [1.5.0] - 2023-11-21
 
 ### Added

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@microsoft/omnichannel-chat-components": "^1.0.9",
-    "@microsoft/omnichannel-chat-sdk": "1.6.0",
+    "@microsoft/omnichannel-chat-sdk": "1.6.1",
     "abort-controller-es5": "^2.0.1",
     "dompurify": "^2.3.4",
     "markdown-it": "^12.3.2",

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@microsoft/omnichannel-chat-components": "^1.0.9",
-    "@microsoft/omnichannel-chat-sdk": "1.5.7",
+    "@microsoft/omnichannel-chat-sdk": "1.6.0",
     "abort-controller-es5": "^2.0.1",
     "dompurify": "^2.3.4",
     "markdown-it": "^12.3.2",

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -222,11 +222,6 @@ export enum ElementType {
     CallingContainerSDK = "CallingContainerSDK"
 }
 
-export enum ChatSDKError {
-    WidgetUseOutsideOperatingHour = "WidgetUseOutsideOperatingHour",
-    AuthContactIdNotFoundFailure = "AuthContactIdNotFoundFailure"
-}
-
 export enum EnvironmentVersion {
     prod = "prod",
     dogfood = "df",

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -320,3 +320,13 @@ export class AriaTelemetryConstants {
         "crm19.omnichannelengagementhub.com"
     ];
 }
+
+export class WidgetLoadTelemetryMessage {
+    public static readonly OOOHMessage = "Widget is OOOH";
+    public static readonly PersistedStateRetrievedMessage = "Persisted state retrieved";
+}
+
+export class WidgetLoadCustomErrorString {
+    public static readonly AuthenticationFailedErrorString = "Authentication was not successful";
+    public static readonly NetworkErrorString = "Network Error";
+}

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -126,7 +126,6 @@ export enum TelemetryEvent {
     ErrorUIPaneLoaded = "ErrorUIPaneLoaded",
     DownloadTranscriptFailed = "DownloadTranscriptFailed",
     StartChatFailed = "StartChatFailed",
-    IC3ThreadUpdateEventReceived = "IC3ThreadUpdateEventReceived",
     ConfirmationCancelButtonClicked = "ConfirmationCancelButtonClicked",
     ConfirmationConfirmButtonClicked = "ConfirmationConfirmButtonClicked",
     LoadingPaneLoaded = "LoadingPaneLoaded",
@@ -264,7 +263,6 @@ export class TelemetryConstants {
             case TelemetryEvent.EmailTranscriptSent:
             case TelemetryEvent.EmailTranscriptFailed:
             case TelemetryEvent.DownloadTranscriptFailed:
-            case TelemetryEvent.IC3ThreadUpdateEventReceived:
             case TelemetryEvent.ConfirmationCancelButtonClicked:
             case TelemetryEvent.ConfirmationConfirmButtonClicked:
             case TelemetryEvent.PreChatSurveyStartChatMethodFailed:

--- a/chat-widget/src/common/utils.ts
+++ b/chat-widget/src/common/utils.ts
@@ -1,4 +1,4 @@
-import { AriaTelemetryConstants, ChatSDKError, Constants, HtmlAttributeNames, LocaleConstants } from "./Constants";
+import { AriaTelemetryConstants, Constants, HtmlAttributeNames, LocaleConstants } from "./Constants";
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "./telemetry/TelemetryConstants";
 
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
@@ -8,6 +8,7 @@ import { ITimer } from "./interfaces/ITimer";
 import { KeyCodes } from "./KeyCodes";
 import { Md5 } from "md5-typescript";
 import { TelemetryHelper } from "./telemetry/TelemetryHelper";
+import { ChatSDKErrorName } from "@microsoft/omnichannel-chat-sdk";
 
 const getElementBySelector = (selector: string | HTMLElement) => {
     let element: HTMLElement;
@@ -396,7 +397,7 @@ export const getConversationDetailsCall = async (chatSDK: any) => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const checkContactIdError = (e: any) => {
-    if (e?.message === ChatSDKError.AuthContactIdNotFoundFailure) {
+    if (e?.message === ChatSDKErrorName.AuthContactIdNotFoundFailure) {
         const contactIdNotFoundErrorEvent: ICustomEvent = {
             eventName: BroadcastEvent.ContactIdNotFound,
             payload: {

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -180,9 +180,9 @@ export const chatSDKStateCleanUp = (chatSDK: any) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (chatSDK as any).requestId = uuidv4();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (chatSDK as any) = {};
+    (chatSDK as any).chatToken = {};
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (chatSDK as any) = null;
+    (chatSDK as any).reconnectId = null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -15,6 +15,7 @@ import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import { WebChatStoreLoader } from "../../webchatcontainerstateful/webchatcontroller/WebChatStoreLoader";
 import { defaultWebChatContainerStatefulProps } from "../../webchatcontainerstateful/common/defaultProps/defaultWebChatContainerStatefulProps";
 import { TelemetryManager } from "../../../common/telemetry/TelemetryManager";
+import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, setWebChatStyles: any, adapter: any) => {
@@ -142,7 +143,7 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
     }
 };
 
-export const callingStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
+export const callingStateCleanUp = (dispatch: Dispatch<ILiveChatWidgetAction>) => {
     dispatch({ type: LiveChatWidgetActionType.SHOW_CALLING_CONTAINER, payload: false });
     dispatch({ type: LiveChatWidgetActionType.SET_INCOMING_CALL, payload: true });
     dispatch({ type: LiveChatWidgetActionType.DISABLE_VIDEO_CALL, payload: true });
@@ -150,14 +151,14 @@ export const callingStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetActi
     dispatch({ type: LiveChatWidgetActionType.DISABLE_REMOTE_VIDEO, payload: true });
 };
 
-export const endChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
+export const endChatStateCleanUp = (dispatch: Dispatch<ILiveChatWidgetAction>) => {
     // Need to clear these states immediately when chat ended from OC.
     dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: false });
 };
 
-export const closeChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAction>) => {
+export const closeChatStateCleanUp = (dispatch: Dispatch<ILiveChatWidgetAction>) => {
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: undefined });
     // dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
     dispatch({ type: LiveChatWidgetActionType.SET_RECONNECT_ID, payload: undefined });
@@ -172,6 +173,16 @@ export const closeChatStateCleanUp = async (dispatch: Dispatch<ILiveChatWidgetAc
             proactiveChatInNewWindow: false
         }
     });
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const chatSDKStateCleanUp = (chatSDK: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (chatSDK as any).requestId = uuidv4();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (chatSDK as any) = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (chatSDK as any) = null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -192,28 +192,11 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         // Updating chat session detail for telemetry
         await updateSessionDataForTelemetry(chatSDK, dispatch);
     } catch (ex) {
-        handleStartChatError(dispatch, chatSDK, props ,ex);
-
-        // If sessionInit was successful but LCW startchat failed due to some reason e.g adapter didn't load
-        // we need to directly endChat to avoid leaving ghost chats in OC, not disturbing any other UI state
-        if (isStartChatSuccessful === true) {
-            await forceEndChat(chatSDK);
-        }
+        handleStartChatError(dispatch, chatSDK, props, ex, isStartChatSuccessful);
     } finally {
         optionalParams = {};
         widgetInstanceId = "";
     }
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const forceEndChat = async (chatSDK: any) => {
-    TelemetryHelper.logLoadingEvent(LogLevel.ERROR, {
-        Event: TelemetryEvent.WidgetLoadFailed,
-        ExceptionDetails: {
-            Exception: "SessionInit was successful, but widget load failed."
-        }
-    });
-    chatSDK?.endChat();
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -1,5 +1,5 @@
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
-import { Constants, LiveWorkItemState } from "../../../common/Constants";
+import { Constants, LiveWorkItemState, WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../../common/Constants";
 import { checkContactIdError, createTimer, getConversationDetailsCall, getStateFromCache, getWidgetCacheIdfromProps, isNullOrEmptyString, isUndefinedOrEmpty } from "../../../common/utils";
 import { getAuthClientFunction, handleAuthentication } from "./authHelper";
 import { ActivityStreamHandler } from "./ActivityStreamHandler";
@@ -117,8 +117,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             // set auth token to chat sdk before start chat
             const authSuccess = await handleAuthentication(chatSDK, chatConfig, getAuthToken);
             if (!authSuccess) {
-                // Replacing with error ui
-                throw new Error("Authentication was not successful");
+                throw new Error(WidgetLoadCustomErrorString.AuthenticationFailedErrorString);
             }
         }
 
@@ -174,7 +173,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
 
         if (persistedState) {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_STATE, payload: persistedState });
-            logWidgetLoadComplete("Persisted state retrieved");
+            logWidgetLoadComplete(WidgetLoadTelemetryMessage.PersistedStateRetrievedMessage);
             await setPostChatContextAndLoadSurvey(chatSDK, dispatch, true);
             return;
         }

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
@@ -6,7 +6,6 @@ import { WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../.
 import { ChatSDKError, ChatSDKErrorName } from "@microsoft/omnichannel-chat-sdk";
 import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
 import { ConversationState } from "../../../contexts/common/ConversationState";
-import { DataStoreManager } from "../../../common/contextDataStore/DataStoreManager";
 
 describe("startChatErrorHandler unit test", () => {
     it("handleStartChatError should log failed event and return if exception is undefined", () => {

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
@@ -1,0 +1,312 @@
+import { BroadcastService } from "@microsoft/omnichannel-chat-components";
+import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
+import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
+import { handleStartChatError } from "./startChatErrorHandler";
+import { WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../../common/Constants";
+import { ChatSDKError, ChatSDKErrorName } from "@microsoft/omnichannel-chat-sdk";
+import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
+import { ConversationState } from "../../../contexts/common/ConversationState";
+import { DataStoreManager } from "../../../common/contextDataStore/DataStoreManager";
+
+describe("startChatErrorHandler unit test", () => {
+    it("handleStartChatError should log failed event and return if exception is undefined", () => {
+        const dispatch = jest.fn();
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, undefined, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(1);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("ERROR", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: "Widget load complete with error: undefined"
+            })
+        }));
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("handleStartChatError should log failed with error event for AuthenticationFailedErrorString", () => {
+        const dispatch = jest.fn();
+        const mockEx = new Error(WidgetLoadCustomErrorString.AuthenticationFailedErrorString);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: Error: ${WidgetLoadCustomErrorString.AuthenticationFailedErrorString}`
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed with error event for NetworkErrorString", () => {
+        const dispatch = jest.fn();
+        const mockEx = new Error(WidgetLoadCustomErrorString.NetworkErrorString);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: Error: ${WidgetLoadCustomErrorString.NetworkErrorString}`
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log complete event for WidgetUseOutsideOperatingHour", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.WidgetUseOutsideOperatingHour);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(1);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("INFO", expect.objectContaining({
+            Description: `Widget load complete. ${WidgetLoadTelemetryMessage.OOOHMessage}`
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_OUTSIDE_OPERATING_HOURS
+        }));
+    });
+
+    it("handleStartChatError should log failed with error event for PersistentChatConversationRetrievalFailure for non-400 status", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.PersistentChatConversationRetrievalFailure, 429);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            Description: "Widget load complete with error",
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.PersistentChatConversationRetrievalFailure}`,
+                HttpResponseStatusCode: 429
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed event for PersistentChatConversationRetrievalFailure for 400 status", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.PersistentChatConversationRetrievalFailure, 400);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("ERROR", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.PersistentChatConversationRetrievalFailure}`,
+                HttpResponseStatusCode: 400
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed with error event for ConversationInitializationFailure for non-400 status", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ConversationInitializationFailure, 429);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            Description: "Widget load complete with error",
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.ConversationInitializationFailure}`,
+                HttpResponseStatusCode: 429
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed event for ConversationInitializationFailure for 400 status", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ConversationInitializationFailure, 400);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("ERROR", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.ConversationInitializationFailure}`,
+                HttpResponseStatusCode: 400
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed with error event for ChatTokenRetrievalFailure for non-400 status", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ChatTokenRetrievalFailure, 429);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            Description: "Widget load complete with error",
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.ChatTokenRetrievalFailure}`,
+                HttpResponseStatusCode: 429
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed event for ChatTokenRetrievalFailure for 400 status", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ChatTokenRetrievalFailure, 400);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("ERROR", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.ChatTokenRetrievalFailure}`,
+                HttpResponseStatusCode: 400
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed with error event for UninitializedChatSDK", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.UninitializedChatSDK);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            Description: "Widget load complete with error",
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.UninitializedChatSDK}`
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should log failed with error event for InvalidConversation", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.InvalidConversation);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(1);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            Description: "Widget load complete with error",
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.InvalidConversation}`
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(16);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE,
+            payload: ConversationState.Closed
+        }));
+    });
+
+    it("handleStartChatError should log failed with error event for ClosedConversation", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ClosedConversation);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(1);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            Description: "Widget load complete with error",
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.ClosedConversation}`
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(16);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE,
+            payload: ConversationState.Closed
+        }));
+    });
+
+    it("handleStartChatError should log failed event for any other errors", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ScriptLoadFailure, 405);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("ERROR", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.ScriptLoadFailure}`,
+                HttpResponseStatusCode: 405
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
+    it("handleStartChatError should force end chat if isStartChatSuccessful is true", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ScriptLoadFailure, 405);
+        const mockSDK = {
+            endChat: jest.fn()
+        };
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, mockSDK, {} as ILiveChatWidgetProps, mockEx, true);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(3);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("ERROR", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: "SessionInit was successful, but widget load failed."
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+        expect(mockSDK.endChat).toHaveBeenCalled();
+    });
+});

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -1,0 +1,116 @@
+import { ChatSDKErrorName, ChatSDKError } from "@microsoft/omnichannel-chat-sdk";
+import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
+import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
+import { TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
+import { ConversationState } from "../../../contexts/common/ConversationState";
+import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
+import { Dispatch } from "react";
+import { ILiveChatWidgetAction } from "../../../contexts/common/ILiveChatWidgetAction";
+import { callingStateCleanUp, endChatStateCleanUp, closeChatStateCleanUp, chatSDKStateCleanUp } from "./endChat";
+import { NotificationHandler } from "../../webchatcontainerstateful/webchatcontroller/notification/NotificationHandler";
+import { NotificationScenarios } from "../../webchatcontainerstateful/webchatcontroller/enums/NotificationScenarios";
+import { DataStoreManager } from "../../../common/contextDataStore/DataStoreManager";
+import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
+import { getWidgetCacheIdfromProps } from "../../../common/utils";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, chatSDK: any, props: ILiveChatWidgetProps | undefined, ex: any) => {
+    if (!ex) {
+        logWidgetLoadFailed();
+        return;
+    }
+
+    if (ex instanceof ChatSDKError) {
+        if (ex.message === ChatSDKErrorName.WidgetUseOutsideOperatingHour) {
+            dispatch({ type: LiveChatWidgetActionType.SET_OUTSIDE_OPERATING_HOURS, payload: true });
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
+            logWidgetLoadComplete("Widget is OOOH.");
+        } else if (ex.message === ChatSDKErrorName.PersistentChatConversationRetrievalFailure ||
+            ex.message === ChatSDKErrorName.ConversationInitializationFailure ||
+            ex.message === ChatSDKErrorName.ChatTokenRetrievalFailure ||
+            ex.message === ChatSDKErrorName.UninitializedChatSDK) {
+            if (ex.httpResponseStatusCode === 400) {
+                logWidgetLoadFailed(ex);
+            } else {
+                logWidgetLoadCompleteWithError(ex);
+            }
+        } else if (ex.message === ChatSDKErrorName.InvalidConversation ||
+            ex.message === ChatSDKErrorName.ClosedConversation) {
+            logWidgetLoadCompleteWithError(ex);
+
+            // Reset all internal states
+            callingStateCleanUp(dispatch);
+            endChatStateCleanUp(dispatch);
+            closeChatStateCleanUp(dispatch);
+            chatSDKStateCleanUp(chatSDK);
+            DataStoreManager.clientDataStore?.removeData(getWidgetCacheIdfromProps(props));
+
+            // Starts new chat
+            dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
+            return;
+        } else {
+            logWidgetLoadFailed(ex);
+        }
+    } else if (ex.message === "Authentication was not successful" ||
+        ex.message === "Network Error") {
+        logWidgetLoadCompleteWithError(ex);
+    }
+
+    NotificationHandler.notifyError(NotificationScenarios.Connection, "Start Chat Failed: " + ex);
+    dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILING, payload: true });
+    if (!props?.controlProps?.hideErrorUIPane) {
+        // Set app state to failing start chat if hideErrorUI is not turned on
+        TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
+            Event: TelemetryEvent.ErrorUIPaneLoaded,
+            Description: "Error UI Pane Loaded"
+        });
+    }
+    // Show the loading pane in other cases for failure, this will help for both hideStartChatButton case
+    dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
+};
+
+const logWidgetLoadFailed = (ex?: ChatSDKError) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const exDetails: any = {
+        Exception: `Widget load complete with error: ${ex}`
+    };
+    if (ex?.httpResponseStatusCode) {
+        exDetails.HttpResponseStatusCode = ex.httpResponseStatusCode;
+    }
+    
+    TelemetryHelper.logLoadingEvent(LogLevel.ERROR, {
+        Event: TelemetryEvent.WidgetLoadFailed,
+        ExceptionDetails: exDetails,
+        ElapsedTimeInMilliseconds: TelemetryTimers?.WidgetLoadTimer?.milliSecondsElapsed
+    });
+};
+
+export const logWidgetLoadComplete = (additionalMessage?: string) => {
+    let descriptionString = "Widget load complete";
+    if (additionalMessage) {
+        descriptionString += `. ${additionalMessage}`;
+    }
+
+    TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
+        Event: TelemetryEvent.WidgetLoadComplete,
+        Description: descriptionString,
+        ElapsedTimeInMilliseconds: TelemetryTimers?.WidgetLoadTimer?.milliSecondsElapsed
+    });
+};
+
+const logWidgetLoadCompleteWithError = (ex: ChatSDKError) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const exDetails: any = {
+        Exception: `Widget load complete with error: ${ex}`
+    };
+    if (ex?.httpResponseStatusCode) {
+        exDetails.HttpResponseStatusCode = ex.httpResponseStatusCode;
+    }
+
+    TelemetryHelper.logLoadingEvent(LogLevel.WARN, {
+        Event: TelemetryEvent.WidgetLoadComplete,
+        Description: "Widget load complete with error",
+        ExceptionDetails: exDetails,
+        ElapsedTimeInMilliseconds: TelemetryTimers?.WidgetLoadTimer?.milliSecondsElapsed
+    });
+};

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -58,7 +58,6 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
         logWidgetLoadCompleteWithError(ex);
     }
 
-    NotificationHandler.notifyError(NotificationScenarios.Connection, "Start Chat Failed: " + ex);
     dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILING, payload: true });
     if (!props?.controlProps?.hideErrorUIPane) {
         // Set app state to failing start chat if hideErrorUI is not turned on

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -12,6 +12,7 @@ import { NotificationScenarios } from "../../webchatcontainerstateful/webchatcon
 import { DataStoreManager } from "../../../common/contextDataStore/DataStoreManager";
 import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
 import { getWidgetCacheIdfromProps } from "../../../common/utils";
+import { WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../../common/Constants";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, chatSDK: any, props: ILiveChatWidgetProps | undefined, ex: any, isStartChatSuccessful: boolean) => {
@@ -24,7 +25,7 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
         if (ex.message === ChatSDKErrorName.WidgetUseOutsideOperatingHour) {
             dispatch({ type: LiveChatWidgetActionType.SET_OUTSIDE_OPERATING_HOURS, payload: true });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
-            logWidgetLoadComplete("Widget is OOOH.");
+            logWidgetLoadComplete(WidgetLoadTelemetryMessage.OOOHMessage);
             return;
         } else if (ex.message === ChatSDKErrorName.PersistentChatConversationRetrievalFailure ||
             ex.message === ChatSDKErrorName.ConversationInitializationFailure ||
@@ -52,8 +53,8 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
         } else {
             logWidgetLoadFailed(ex);
         }
-    } else if (ex.message === "Authentication was not successful" ||
-        ex.message === "Network Error") {
+    } else if (ex.message === WidgetLoadCustomErrorString.AuthenticationFailedErrorString ||
+        ex.message === WidgetLoadCustomErrorString.NetworkErrorString) {
         logWidgetLoadCompleteWithError(ex);
     }
 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -18,7 +18,7 @@ import {
     isUndefinedOrEmpty
 } from "../../../common/utils";
 import { defaultClientDataStoreProvider, isCookieAllowed } from "../../../common/storage/default/defaultClientDataStoreProvider";
-import { endChat, endChatStateCleanUp, prepareEndChat } from "../common/endChat";
+import { chatSDKStateCleanUp, endChat, endChatStateCleanUp, prepareEndChat } from "../common/endChat";
 import { handleChatReconnect, isPersistentEnabled, isReconnectEnabled } from "../common/reconnectChatHelper";
 import {
     shouldShowCallingContainer,
@@ -83,7 +83,6 @@ import useChatAdapterStore from "../../../hooks/useChatAdapterStore";
 import useChatContextStore from "../../../hooks/useChatContextStore";
 import useChatSDKStore from "../../../hooks/useChatSDKStore";
 import { defaultAdaptiveCardStyles } from "../../webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles";
-import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
 
 export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
@@ -402,12 +401,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             if (msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
                 endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, true, false, false);
                 endChatStateCleanUp(dispatch);
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (chatSDK as any).requestId = uuidv4();
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (chatSDK as any).chatToken = {};
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (chatSDK as any).reconnectId = null;
+                chatSDKStateCleanUp(chatSDK);
                 return;
             }
         });

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.spec.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.spec.ts
@@ -22,7 +22,7 @@ describe("activityMiddleware test", () => {
 
         const results = createActivityMiddleware()()(next)(args);
         expect(results()).toEqual(false);
-        expect(TelemetryHelper.logActionEvent).toHaveBeenCalledTimes(1);
+        expect(TelemetryHelper.logActionEvent).toHaveBeenCalledTimes(0);
     });
 
     it ("createActivityMiddleware() with Hidden tag should return nothing", () => {

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
@@ -12,7 +12,6 @@ import { LogLevel, TelemetryEvent } from "../../../../../common/telemetry/Teleme
 import { Constants } from "../../../../../common/Constants";
 import { DirectLineActivityType } from "../../enums/DirectLineActivityType";
 import { DirectLineSenderRole } from "../../enums/DirectLineSenderRole";
-import { MessageTypes } from "../../enums/MessageType";
 import React from "react";
 import { TelemetryHelper } from "../../../../../common/telemetry/TelemetryHelper";
 import { defaultSystemMessageStyles } from "./defaultStyles/defaultSystemMessageStyles";
@@ -72,12 +71,6 @@ export const createActivityMiddleware = (systemMessageStyleProps?: React.CSSProp
     const [card] = args;
     if (card.activity) {
         if (card.activity.from?.role === DirectLineSenderRole.Channel) {
-            if (card.activity.channelData?.type === MessageTypes.Thread) {
-                TelemetryHelper.logActionEvent(LogLevel.INFO, {
-                    Event: TelemetryEvent.IC3ThreadUpdateEventReceived,
-                    Description: "IC3 ThreadUpdateEvent Received"
-                });
-            }
             return () => false;
         }
 

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2241,10 +2241,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/load-themed-styles/-/load-themed-styles-1.10.295.tgz#d3c8d7ab186f422727ba112d6ebe5fe8e41051d9"
   integrity sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==
 
-"@microsoft/ocsdk@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.4.1.tgz#a379457f09ec149eb3bf35bf7f8187b86cfe9b67"
-  integrity sha512-3W8joowPyf2qVNBG7FQjGugNLBT34gVQB4KtF9G3PEbIKiJyVOdgCHl91foNMU0u82rZHxUIg7grfbWxskkfJw==
+"@microsoft/ocsdk@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.4.2.tgz#7cc9740308b6d24dfeb775844d9f5e5070fa5157"
+  integrity sha512-x2cMpdkKB5psuS6ChE6w9R7TygSeJwXJBJTo8iGD0BEo03JbV85hHJUL7xaV2oBHAvCpwl5CcWUQez1ZnE/3mQ==
   dependencies:
     "@babel/runtime" "^7.15.4"
     "@types/node" "^12.20.26"
@@ -2268,14 +2268,14 @@
     rxjs "^5.0.3"
     styled-components "^5.3.1"
 
-"@microsoft/omnichannel-chat-sdk@1.5.7":
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-1.5.7.tgz#cac075f4ac85406062c82adbca681a17ec769f9b"
-  integrity sha512-HySzoKCPXGbciVPySSBl3gGyXjSC8NlymZwiU0h94gV1iPoZok3mhT/gSqJn+dn2jlnwU4sDa9Jui4Jgj9VY7Q==
+"@microsoft/omnichannel-chat-sdk@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-1.6.1.tgz#14469c185ab086798144acf375adf60429a29fff"
+  integrity sha512-/Ros5D5fki5p6aoIPspapKNng5Jd3QGY/a1DlYxTUXwE9yg2ErgF1awi+SQh2lDu12rPgzcv6kDZOjhZECq4FA==
   dependencies:
     "@azure/communication-chat" "1.1.1"
     "@azure/communication-common" "1.1.0"
-    "@microsoft/ocsdk" "^0.4.1"
+    "@microsoft/ocsdk" "^0.4.2"
     "@microsoft/omnichannel-amsclient" "^0.1.6"
     "@microsoft/omnichannel-ic3core" "^0.1.3"
 

--- a/docs/Telemetry.md
+++ b/docs/Telemetry.md
@@ -188,10 +188,8 @@ Refer to the below table to understand different critical telemetry events raise
 | `ProcessingHTMLTextMiddlewareFailed`     |On HTML Field adding noopener noreferrer failed |
 | `ProcessingSanitizationMiddlewareFailed`     |On HTML Field sanitization failed |
 | `FormatTagsMiddlewareJSONStringifyFailed`     |On ACS Format Message Tags Middleware failed |
-| `IC3ThreadUpdateEventReceived`|On `IC3 ThreadUpdateEvent` Received|
 | `AverageWaitTimeMessageRecieved`|On Average Wait Time system message Received|
 | `QueuePositionMessageRecieved`|On Queue Position system message Received|
-| `IC3ThreadUpdateEventReceived`|On `IC3 ThreadUpdateEvent` Received|
 | `ConversationEndedThreadEventReceived`     |On Conversation ended by agent side or by timeout |
 | `InvalidConfiguration`     |On Invalid data masking regex rule collection |
 | `DataMaskingRuleApplied`     |On data masking regex rule applied |


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Task 3656721](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3656721): Investigate root causes for ConversationInitializationFailure
[Task 3656725](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3656725): investigate over PersistentChatConversationRetrievalFailure
[Task 3656727](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3656727): "Authentication was not successful" shouldnt be a cause for WidgetLoadFailed Event
[Task 3656736](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3656736):  ChatTokenRetrievalFailure
[Task 3682279](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3682279): [ICM] [Reliability] Startchat Method should not log WidgetLoadFailed for closed conversation

### Description
_Include a description of the problem to be solved_
Redefining WidgetLoadComplete and WidgetLoadFailed criteria, and refactoring code into error handler

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
Uptake chat-sdk which exports ChatSDKError with standardized error name. Decision is made in startChatErrorHandler

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
For sessioninit, getchattoken, reconnect, only report WidgetLoadFailed when the status code is 400
For auth error, mark as load complete
For other errors, mark as failure

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
No test case
![proof1](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/072318a6-8a92-48e1-8ed5-02c131516e30)
![proof2](https://github.com/microsoft/omnichannel-chat-widget/assets/14852927/3dd102c3-8b4f-448d-a79a-8c152af10d1b)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__