### PR TITLE
Add authentication related error strings for start chat error pane

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Enabled customizations for the start chat error pane by adding new `IStartChatErrorPaneProps` interface
+- Add specific error strings to start chat error pane for authentication related failure scenarios by including new texts to `IStartChatErrorPaneControlProps`
 
 ### Fixed
 

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -303,8 +303,6 @@ export class StartChatErrorPaneConstants {
     public static readonly DefaultStartChatErrorPaneId = "oc-lcw-start-chat-error-pane";
     public static readonly DefaultStartChatErrorTitleText = "We are unable to load chat at this time.";
     public static readonly DefaultStartChatErrorSubtitleText = "Please try again later.";
-    public static readonly DefaultStartChatErrorAuthTitleText = "Chat authentication has failed.";
-    // public static readonly DefaultStartChatErrorAuthSubtitleText = "Please check authentication setup and try again.";
     public static readonly DefaultStartChatErrorUnauthorizedTitleText = "Chat authentication has failed.";
     public static readonly DefaultStartChatErrorAuthSetupErrorTitleText = "Chat authentication has failed.";
     public static readonly DefaultStartChatErrorUnauthorizedSubtitleText = "UNAUTHORIZED";

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -303,6 +303,12 @@ export class StartChatErrorPaneConstants {
     public static readonly DefaultStartChatErrorPaneId = "oc-lcw-start-chat-error-pane";
     public static readonly DefaultStartChatErrorTitleText = "We are unable to load chat at this time.";
     public static readonly DefaultStartChatErrorSubtitleText = "Please try again later.";
+    public static readonly DefaultStartChatErrorAuthTitleText = "Chat authentication has failed.";
+    // public static readonly DefaultStartChatErrorAuthSubtitleText = "Please check authentication setup and try again.";
+    public static readonly DefaultStartChatErrorUnauthorizedTitleText = "Chat authentication has failed.";
+    public static readonly DefaultStartChatErrorAuthSetupErrorTitleText = "Chat authentication has failed.";
+    public static readonly DefaultStartChatErrorUnauthorizedSubtitleText = "UNAUTHORIZED";
+    public static readonly DefaultStartChatErrorAuthSetupErrorSubtitleText = "AUTH SETUP ERROR";
 }
 
 export class AriaTelemetryConstants {

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
@@ -36,7 +36,7 @@ describe("startChatErrorHandler unit test", () => {
                 Exception: `Widget load complete with error: Error: ${WidgetLoadCustomErrorString.AuthenticationFailedErrorString}`
             })
         }));
-        expect(dispatch).toHaveBeenCalledTimes(2);
+        expect(dispatch).toHaveBeenCalledTimes(3);
         expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
             type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
         }));

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.spec.ts
@@ -204,6 +204,26 @@ describe("startChatErrorHandler unit test", () => {
         }));
     });
 
+    it("handleStartChatError should log failed with error event for ChatTokenRetrievalFailure for 401 status", () => {
+        const dispatch = jest.fn();
+        const mockEx = new ChatSDKError(ChatSDKErrorName.ChatTokenRetrievalFailure, 401);
+        spyOn(BroadcastService, "postMessage").and.callFake(() => false);
+        spyOn(TelemetryHelper, "logLoadingEvent").and.callFake(() => false);
+        handleStartChatError(dispatch, {}, {} as ILiveChatWidgetProps, mockEx, false);
+
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledTimes(2);
+        expect(TelemetryHelper.logLoadingEvent).toHaveBeenCalledWith("WARN", expect.objectContaining({
+            ExceptionDetails: expect.objectContaining({
+                Exception: `Widget load complete with error: ${ChatSDKErrorName.ChatTokenRetrievalFailure}`,
+                HttpResponseStatusCode: 401
+            })
+        }));
+        expect(dispatch).toHaveBeenCalledTimes(3);
+        expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({
+            type: LiveChatWidgetActionType.SET_CONVERSATION_STATE
+        }));
+    });
+
     it("handleStartChatError should log failed with error event for UninitializedChatSDK", () => {
         const dispatch = jest.fn();
         const mockEx = new ChatSDKError(ChatSDKErrorName.UninitializedChatSDK);

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -22,7 +22,6 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
 
     // Handle internal or misc errors
     if (ex.message === WidgetLoadCustomErrorString.AuthenticationFailedErrorString) {
-        console.log("ADAD AuthenticationFailedErrorString");
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.AuthSetupError });
         logWidgetLoadCompleteWithError(ex);
     }
@@ -167,7 +166,6 @@ const handleChatTokenRetrievalFailure = (dispatch: Dispatch<ILiveChatWidgetActio
         logWidgetLoadFailed(ex);
     } else {
         if (ex.httpResponseStatusCode === 401) {
-            console.log("ADAD 401");
             dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.Unauthorized });
         }
         logWidgetLoadCompleteWithError(ex);

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -11,6 +11,7 @@ import { DataStoreManager } from "../../../common/contextDataStore/DataStoreMana
 import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
 import { getWidgetCacheIdfromProps } from "../../../common/utils";
 import { WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../../common/Constants";
+import { StartChatFailureType } from "../../../contexts/common/StartChatFailureType";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, chatSDK: any, props: ILiveChatWidgetProps | undefined, ex: any, isStartChatSuccessful: boolean) => {
@@ -20,8 +21,12 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
     }
 
     // Handle internal or misc errors
-    if (ex.message === WidgetLoadCustomErrorString.AuthenticationFailedErrorString ||
-        ex.message === WidgetLoadCustomErrorString.NetworkErrorString) {
+    if (ex.message === WidgetLoadCustomErrorString.AuthenticationFailedErrorString) {
+        console.log("ADAD AuthenticationFailedErrorString");
+        dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.AuthSetupError });
+        logWidgetLoadCompleteWithError(ex);
+    }
+    if (ex.message === WidgetLoadCustomErrorString.NetworkErrorString) {
         logWidgetLoadCompleteWithError(ex);
     }
 
@@ -38,7 +43,7 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
                 handleConversationInitializationFailure(ex);
                 break;
             case ChatSDKErrorName.ChatTokenRetrievalFailure:
-                handleChatTokenRetrievalFailure(ex);
+                handleChatTokenRetrievalFailure(dispatch, ex);
                 break;
             case ChatSDKErrorName.UninitializedChatSDK:
                 handleUninitializedChatSDK(ex);
@@ -157,10 +162,14 @@ const handleConversationInitializationFailure = (ex: any) => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const handleChatTokenRetrievalFailure = (ex: any) => {
+const handleChatTokenRetrievalFailure = (dispatch: Dispatch<ILiveChatWidgetAction>, ex: any) => {
     if (ex.httpResponseStatusCode === 400) {
         logWidgetLoadFailed(ex);
     } else {
+        if (ex.httpResponseStatusCode === 401) {
+            console.log("ADAD 401");
+            dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.Unauthorized });
+        }
         logWidgetLoadCompleteWithError(ex);
     }
 };

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -203,8 +203,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     };
 
     useEffect(() => {
-        console.log("ADAD state.appStates.startChatFailed", state.appStates.startChatFailed);
-        console.log("ADAD state.domainStates.startChatFailureType", state.domainStates.startChatFailureType);
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILING, payload: false });
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.Generic });
         state.domainStates.confirmationPaneConfirmedOptionClicked = false;

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -85,6 +85,7 @@ import useChatContextStore from "../../../hooks/useChatContextStore";
 import useChatSDKStore from "../../../hooks/useChatSDKStore";
 import { defaultAdaptiveCardStyles } from "../../webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles";
 import StartChatErrorPaneStateful from "../../startchaterrorpanestateful/StartChatErrorPaneStateful";
+import { StartChatFailureType } from "../../../contexts/common/StartChatFailureType";
 
 export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
@@ -202,7 +203,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     };
 
     useEffect(() => {
+        console.log("ADAD state.appStates.startChatFailed", state.appStates.startChatFailed);
+        console.log("ADAD state.domainStates.startChatFailureType", state.domainStates.startChatFailureType);
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILING, payload: false });
+        dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.Generic });
         state.domainStates.confirmationPaneConfirmedOptionClicked = false;
         state.domainStates.confirmationState = ConfirmationState.NotSet;
         setupClientDataStore();

--- a/chat-widget/src/components/startchaterrorpanestateful/StartChatErrorPaneStateful.tsx
+++ b/chat-widget/src/components/startchaterrorpanestateful/StartChatErrorPaneStateful.tsx
@@ -21,8 +21,6 @@ import { StartChatFailureType } from "../../contexts/common/StartChatFailureType
 
 export const StartChatErrorPaneStateful = (startChatErrorPaneProps: IStartChatErrorPaneProps) => {
     const [state, ]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
-
-    console.log("ADAD startChatErrorPaneProps", startChatErrorPaneProps);
     
     const generalStyleProps: IStyle = Object.assign({}, defaultStartChatErrorPaneGeneralStyleProps, startChatErrorPaneProps?.styleProps?.generalStyleProps);
     const titleStyleProps: IStyle = Object.assign({}, defaultStartChatErrorPaneTitleStyleProps, startChatErrorPaneProps?.styleProps?.titleStyleProps);
@@ -38,35 +36,21 @@ export const StartChatErrorPaneStateful = (startChatErrorPaneProps: IStartChatEr
         iconImageProps: iconImageProps,
     };
 
-    console.log("ADAD state.domainStates.startChatFailureType", state.domainStates.startChatFailureType);
-
-    // let errorPaneTitleText = startChatErrorPaneProps?.controlProps?.titleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorTitleText;
-    // let errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.subtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorSubtitleText;
     let errorPaneTitleText;
     let errorPaneSubtitleText;
-
     switch (state.domainStates.startChatFailureType) {
         case StartChatFailureType.Unauthorized:
-            console.log("ADAD updating error strings with unauthorized scenario");
             errorPaneTitleText = startChatErrorPaneProps?.controlProps?.unauthorizedTitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorUnauthorizedTitleText;
             errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.unauthorizedSubtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorUnauthorizedSubtitleText;
             break;
         case StartChatFailureType.AuthSetupError:
-            console.log("ADAD updating error strings with auth setup error scenario");
             errorPaneTitleText = startChatErrorPaneProps?.controlProps?.authSetupErrorTitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthSetupErrorTitleText;
             errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.authSetupErrorSubtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthSetupErrorSubtitleText;
             break;
         default:
-            console.log("ADAD updating error strings with generic error scenario");
             errorPaneTitleText = startChatErrorPaneProps?.controlProps?.titleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorTitleText;
             errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.subtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorSubtitleText;
     }
-
-    // if (state.domainStates.startChatFailureType === StartChatFailureType.Authentication) {
-    //     console.log("ADAD updating error strings with auth scenario");
-    //     errorPaneTitleText = startChatErrorPaneProps?.controlProps?.authTitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthTitleText;
-    //     errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.authSubtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthSubtitleText;
-    // }
 
     const errorUIControlProps: ILoadingPaneControlProps = {
         id: StartChatErrorPaneConstants.DefaultStartChatErrorPaneId,
@@ -77,10 +61,6 @@ export const StartChatErrorPaneStateful = (startChatErrorPaneProps: IStartChatEr
         titleText: errorPaneTitleText,
         subtitleText: errorPaneSubtitleText,
     };
-
-    console.log("ADAD errorUIStyleProps", errorUIStyleProps);
-
-    console.log("ADAD errorUIControlProps", errorUIControlProps);
 
     // Move focus to the first button
     useEffect(() => {

--- a/chat-widget/src/components/startchaterrorpanestateful/StartChatErrorPaneStateful.tsx
+++ b/chat-widget/src/components/startchaterrorpanestateful/StartChatErrorPaneStateful.tsx
@@ -17,9 +17,12 @@ import { defaultStartChatErrorPaneIconStyleProps } from "./common/defaultStartCh
 import { defaultStartChatErrorPaneIconImageStyleProps } from "./common/defaultStartChatErrorPaneIconImageProps";
 import { IStartChatErrorPaneProps } from "./interfaces/IStartChatErrorPaneProps";
 import { StartChatErrorPaneConstants } from "../../common/Constants";
+import { StartChatFailureType } from "../../contexts/common/StartChatFailureType";
 
 export const StartChatErrorPaneStateful = (startChatErrorPaneProps: IStartChatErrorPaneProps) => {
     const [state, ]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
+
+    console.log("ADAD startChatErrorPaneProps", startChatErrorPaneProps);
     
     const generalStyleProps: IStyle = Object.assign({}, defaultStartChatErrorPaneGeneralStyleProps, startChatErrorPaneProps?.styleProps?.generalStyleProps);
     const titleStyleProps: IStyle = Object.assign({}, defaultStartChatErrorPaneTitleStyleProps, startChatErrorPaneProps?.styleProps?.titleStyleProps);
@@ -35,18 +38,49 @@ export const StartChatErrorPaneStateful = (startChatErrorPaneProps: IStartChatEr
         iconImageProps: iconImageProps,
     };
 
-    const errorPaneTitleText = startChatErrorPaneProps?.controlProps?.titleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorTitleText;
-    const errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.subtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorSubtitleText;
+    console.log("ADAD state.domainStates.startChatFailureType", state.domainStates.startChatFailureType);
+
+    // let errorPaneTitleText = startChatErrorPaneProps?.controlProps?.titleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorTitleText;
+    // let errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.subtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorSubtitleText;
+    let errorPaneTitleText;
+    let errorPaneSubtitleText;
+
+    switch (state.domainStates.startChatFailureType) {
+        case StartChatFailureType.Unauthorized:
+            console.log("ADAD updating error strings with unauthorized scenario");
+            errorPaneTitleText = startChatErrorPaneProps?.controlProps?.unauthorizedTitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorUnauthorizedTitleText;
+            errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.unauthorizedSubtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorUnauthorizedSubtitleText;
+            break;
+        case StartChatFailureType.AuthSetupError:
+            console.log("ADAD updating error strings with auth setup error scenario");
+            errorPaneTitleText = startChatErrorPaneProps?.controlProps?.authSetupErrorTitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthSetupErrorTitleText;
+            errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.authSetupErrorSubtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthSetupErrorSubtitleText;
+            break;
+        default:
+            console.log("ADAD updating error strings with generic error scenario");
+            errorPaneTitleText = startChatErrorPaneProps?.controlProps?.titleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorTitleText;
+            errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.subtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorSubtitleText;
+    }
+
+    // if (state.domainStates.startChatFailureType === StartChatFailureType.Authentication) {
+    //     console.log("ADAD updating error strings with auth scenario");
+    //     errorPaneTitleText = startChatErrorPaneProps?.controlProps?.authTitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthTitleText;
+    //     errorPaneSubtitleText = startChatErrorPaneProps?.controlProps?.authSubtitleText ?? StartChatErrorPaneConstants.DefaultStartChatErrorAuthSubtitleText;
+    // }
 
     const errorUIControlProps: ILoadingPaneControlProps = {
         id: StartChatErrorPaneConstants.DefaultStartChatErrorPaneId,
         dir: state.domainStates.globalDir,
-        titleText: errorPaneTitleText,
-        subtitleText: errorPaneSubtitleText,
         hideSpinner: true,
         hideSpinnerText: true,
         ...startChatErrorPaneProps?.controlProps,
+        titleText: errorPaneTitleText,
+        subtitleText: errorPaneSubtitleText,
     };
+
+    console.log("ADAD errorUIStyleProps", errorUIStyleProps);
+
+    console.log("ADAD errorUIControlProps", errorUIControlProps);
 
     // Move focus to the first button
     useEffect(() => {

--- a/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneControlProps.ts
+++ b/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneControlProps.ts
@@ -7,4 +7,8 @@ export interface IStartChatErrorPaneControlProps {
     hideSubtitle?: boolean;
     titleText?: string;
     subtitleText?: string;
+    unauthorizedTitleText?: string;
+    unauthorizedSubtitleText?: string;
+    authSetupErrorTitleText?: string;
+    authSetupErrorSubtitleText?: string;
 }

--- a/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetContext.ts
@@ -4,6 +4,7 @@ import { IInternalTelemetryData } from "../../common/telemetry/interfaces/IInter
 import { ILiveChatWidgetLocalizedTexts } from "./ILiveChatWidgetLocalizedTexts";
 import { IRenderingMiddlewareProps } from "../../components/webchatcontainerstateful/interfaces/IRenderingMiddlewareProps";
 import { ConfirmationState, ConversationEndEntity, ParticipantType } from "../../common/Constants";
+import { StartChatFailureType } from "./StartChatFailureType";
 
 export interface ILiveChatWidgetContext {
     domainStates: {
@@ -29,6 +30,7 @@ export interface ILiveChatWidgetContext {
         transcriptRequestId: string; //Contains request id for downloading transcript
         confirmationPaneConfirmedOptionClicked: boolean; //shows if confirmation pane already displayed
         confirmationState: ConfirmationState;
+        startChatFailureType: StartChatFailureType;
     };
     appStates: {
         conversationState: ConversationState; // The state that the conversation is currently in

--- a/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetActionType.ts
@@ -52,6 +52,12 @@ export enum LiveChatWidgetActionType {
 
     /*
         Parameters:
+        - string: The start chat failure type
+    */
+    SET_START_CHAT_FAILURE_TYPE,
+
+    /*
+        Parameters:
         - true: When chat is outside operating hours
         - false: When chat is not outside operatin hours
     */

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -5,6 +5,7 @@ import { defaultMiddlewareLocalizedTexts } from "../../components/webchatcontain
 import { getWidgetCacheIdfromProps, isNullOrUndefined } from "../../common/utils";
 import { defaultClientDataStoreProvider } from "../../common/storage/default/defaultClientDataStoreProvider";
 import { ConfirmationState, Constants, ConversationEndEntity, StorageType } from "../../common/Constants";
+import { StartChatFailureType } from "./StartChatFailureType";
 
 export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps) => {
 
@@ -36,7 +37,8 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
             initialChatSdkRequestId: "",
             transcriptRequestId: "",
             confirmationPaneConfirmedOptionClicked: false,
-            confirmationState: ConfirmationState.NotSet
+            confirmationState: ConfirmationState.NotSet,
+            startChatFailureType: StartChatFailureType.Generic
         },
         appStates: {
             conversationState: ConversationState.Closed,

--- a/chat-widget/src/contexts/common/StartChatFailureType.ts
+++ b/chat-widget/src/contexts/common/StartChatFailureType.ts
@@ -1,5 +1,4 @@
 export enum StartChatFailureType {
-    // Authentication = "authentication",
     Unauthorized = "unauthorized",
     AuthSetupError = "authSetupError",
     Generic = "generic"

--- a/chat-widget/src/contexts/common/StartChatFailureType.ts
+++ b/chat-widget/src/contexts/common/StartChatFailureType.ts
@@ -1,0 +1,6 @@
+export enum StartChatFailureType {
+    // Authentication = "authentication",
+    Unauthorized = "unauthorized",
+    AuthSetupError = "authSetupError",
+    Generic = "generic"
+}

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -9,6 +9,7 @@ import { IRenderingMiddlewareProps } from "../components/webchatcontainerstatefu
 import { LiveChatWidgetActionType } from "./common/LiveChatWidgetActionType";
 import { ConfirmationState, ConversationEndEntity, ParticipantType } from "../common/Constants";
 import { PostChatSurveyMode } from "../components/postchatsurveypanestateful/enums/PostChatSurveyMode";
+import { StartChatFailureType } from "./common/StartChatFailureType";
 
 export const createReducer = () => {
     const reducer = (state: ILiveChatWidgetContext, action: ILiveChatWidgetAction): ILiveChatWidgetContext => {
@@ -73,6 +74,15 @@ export const createReducer = () => {
                     appStates: {
                         ...state.appStates,
                         startChatFailed: action.payload as boolean
+                    }
+                };
+
+            case LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE:
+                return {
+                    ...state,
+                    domainStates: {
+                        ...state.domainStates,
+                        startChatFailureType: action.payload as StartChatFailureType
                     }
                 };
 

--- a/docs/customizations/startchaterrorpane.md
+++ b/docs/customizations/startchaterrorpane.md
@@ -45,6 +45,10 @@ hideTitle | boolean | No | Whether to hide the title string on the start chat er
 hideSubtitle | boolean | No | Whether to hide the subtitle on the start chat error pane | false
 titleText | string | No | The title text of the start chat error pane | "We are unable to load chat at this time."
 subtitleText | string | No | The subtitle text of the start chat error pane | "Please try again later."
+unauthorizedTitleText | string | No | The title text of the start chat error pane during unauthorized error | "Chat authentication has failed."
+unauthorizedSubtitleText | string | No | The subtitle text of the start chat error pane during unauthorized error | "UNAUTHORIZED"
+authSetupErrorTitleText | string | No | The title text of the start chat error pane during auth setup error | "Chat authentication has failed."
+authSetupErrorSubtitleText | string | No | The subtitle text of the start chat error pane during auth setup error | "AUTH SETUP ERROR"
 
 > :pushpin: If both `hide-` option and `componentOverride` are used on the same sub-component, that sub-component will be hidden. `hide-` options take higher priority.
 

--- a/docs/customizations/startchaterrorpane.md
+++ b/docs/customizations/startchaterrorpane.md
@@ -13,7 +13,7 @@
 
 ## Interfaces
 
-### [IStartChatErrorPaneProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-components/src/components/StartChatErrorPane/interfaces/IStartChatErrorPaneProps.ts)
+### [IStartChatErrorPaneProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneProps.ts)
 
 The top-level interface for customizing `StartChatErrorPane`.
 
@@ -23,7 +23,7 @@ The top-level interface for customizing `StartChatErrorPane`.
 controlProps | [IStartChatErrorPaneControlProps](#istartchaterrorpanecontrolprops) | No | Properties that control the element behaviors | -
 styleProps | [IStartChatErrorPaneStyleProps](#istartchaterrorpanestyleprops) | No | Properties that control the element styles | -
 
-### [IStartChatErrorPaneComponentOverrides](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-components/src/components/StartChatErrorPane/interfaces/IStartChatErrorPaneComponentOverrides.ts)
+### [IStartChatErrorPaneComponentOverrides](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneComponentOverrides.ts)
 
 Custom React components can be passed as input to override the default sub-components. Alternatively, you can stringify the React component before passing it in. The `chat-components` library provides one util function that can be used: [encodeComponentString](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-components/src/common/encodeComponentString.ts).
 
@@ -33,7 +33,7 @@ Custom React components can be passed as input to override the default sub-compo
 title | ReactNode\|string | No | Used for overriding default start chat error pane title | -
 subtitle | ReactNode\|string | No | Used for overriding default start chat error pane subtitle | -
 
-### [IStartChatErrorPaneControlProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-components/src/components/StartChatErrorPane/interfaces/IStartChatErrorPaneControlProps.ts)
+### [IStartChatErrorPaneControlProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneControlProps.ts)
 
 | Property | Type | Required | Description | Default |
 | - | - | - | - | - |
@@ -48,20 +48,20 @@ subtitleText | string | No | The subtitle text of the start chat error pane | "P
 
 > :pushpin: If both `hide-` option and `componentOverride` are used on the same sub-component, that sub-component will be hidden. `hide-` options take higher priority.
 
-### [IStartChatErrorPaneStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-components/src/components/StartChatErrorPane/interfaces/IStartChatErrorPaneStyleProps.ts)
+### [IStartChatErrorPaneStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneStyleProps.ts)
 
 [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) is the interface provided by [FluentUI](https://developer.microsoft.com/en-us/fluentui#/).
 
 | Property | Type | Required | Description | Default |
 | - | - | - | - | - |
-| generalStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Overall styles of the `StartChatErrorPane` component, including the container | [defaultStartChatErrorPaneGeneralStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/d9ea24e14e0363dce0d771e6d8686edd95a32335/chat-components/src/components/StartChatErrorPane/common/defaultProps/defaultStyles/defaultStartChatErrorPaneGeneralStyles.ts) |
-| titleStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane title | [defaultStartChatErrorPaneTitleStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/d9ea24e14e0363dce0d771e6d8686edd95a32335/chat-components/src/components/StartChatErrorPane/common/defaultProps/defaultStyles/defaultStartChatErrorPaneTitleStyles.ts) |
-| subtitleStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane subtitle | [defaultStartChatErrorPaneSubtitleStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/d9ea24e14e0363dce0d771e6d8686edd95a32335/chat-components/src/components/StartChatErrorPane/common/defaultProps/defaultStyles/defaultStartChatErrorPaneSubtitleStyles.ts) |
-| iconStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane icon | [defaultStartChatErrorPaneIconStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/d9ea24e14e0363dce0d771e6d8686edd95a32335/chat-components/src/components/StartChatErrorPane/common/defaultProps/defaultStyles/defaultStartChatErrorPaneIconStyles.ts) |
-| iconImageProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane icon image | [defaultStartChatErrorPaneIconImageStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/d9ea24e14e0363dce0d771e6d8686edd95a32335/chat-components/src/components/StartChatErrorPane/common/defaultProps/defaultStyles/defaultStartChatErrorPaneIconImageProps.ts) |
-| classNames | [IStartChatErrorPaneClassNames](https://github.com/microsoft/omnichannel-chat-widget/blob/d9ea24e14e0363dce0d771e6d8686edd95a32335/chat-components/src/components/StartChatErrorPane/interfaces/IStartChatErrorPaneClassNames.ts) | No | Sets custom class names for sub-components | - |
+| generalStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Overall styles of the `StartChatErrorPane` component, including the container | [defaultStartChatErrorPaneGeneralStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/common/defaultStartChatErrorPaneGeneralStyleProps.ts) |
+| titleStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane title | [defaultStartChatErrorPaneTitleStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/common/defaultStartChatErrorPaneTitleStyleProps.ts) |
+| subtitleStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane subtitle | [defaultStartChatErrorPaneSubtitleStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/common/defaultStartChatErrorPaneSubtitleStyleProps.ts) |
+| iconStyleProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane icon | [defaultStartChatErrorPaneIconStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/common/defaultStartChatErrorPaneIconStyleProps.ts) |
+| iconImageProps | [IStyle](https://github.com/microsoft/fluentui/blob/master/packages/merge-styles/src/IStyle.ts) | No | Styles of the start chat error pane icon image | [defaultStartChatErrorPaneIconImageStyleProps](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/common/defaultStartChatErrorPaneIconImageProps.ts) |
+| classNames | [IStartChatErrorPaneClassNames](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneClassNames.ts) | No | Sets custom class names for sub-components | - |
 
-### [IStartChatErrorPaneClassNames](https://github.com/microsoft/omnichannel-chat-widget/blob/d9ea24e14e0363dce0d771e6d8686edd95a32335/chat-components/src/components/StartChatErrorPane/interfaces/IStartChatErrorPaneClassNames.ts)
+### [IStartChatErrorPaneClassNames](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/startchaterrorpanestateful/interfaces/IStartChatErrorPaneClassNames.ts)
 
 | Property | Type | Required | Description | Default |
 | - | - | - | - | - |


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
When chat fails to start due to an authenticated related error (ie. `getChatToken` returns 401 or `AuthTokenProvider` fails or is undefined), we show the StartChatErrorPane with a generic failed to start chat error. These auth related errors are not issues with the product -- it is expected behavior. 

However, despite being expected behavior, LCW team is still getting ICMs raised for these auth scenarios because customers are not able to differentiate these auth start chat errors with other start chat errors. 

This PR's goal is to give a more granular error string for these auth related errors and to deflect LCW ICMs.

## Solution Proposed
- Add `unauthorizedTitleText`, `unauthorizedSubtitleText`, `authSetupErrorTitleText`, and `authSetupErrorSubtitleText` to `IStartChatErrorPaneControlProps`
- Add `StartChatFailureType` to determine the specific start chat error scenario and differentiate the displayed string on `StartChatErrorPane` for the auth related scenarios via dispatch, managing state, and switching

### Acceptance criteria
StartChatErrorPane will show granular error strings for auth related error scenarios. The same general customizations for `StartChatErrorPane` will be applied across the different auth related error scenarios; the only difference in these scenarios is the error strings to be displayed.

## Test cases and evidence
**Default:**
1) `getChatToken` returns 401
<img width="782" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/f24cff33-43be-4853-9d5e-4a98b5746b14">

2) `AuthTokenProvider` issues, such as `authTokenProvider` not defined
<img width="781" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/9c30d0e9-20a5-4977-9b92-95c898f6d6aa">

3) Non-auth related, generic start chat error flows:
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/653ba468-3745-466c-bfaf-09ecb00e96c3)

**Customized:**
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/2c75c487-c490-4d4f-9c07-d874a3623afb)

1) `getChatToken` returns 401
<img width="773" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/e0681e46-fad0-4179-abd3-08f1e56d84ce">

2) `AuthTokenProvider` issues, such as `authTokenProvider` not defined
<img width="767" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/2324cab1-4fc0-4a39-8bf0-e9436c19f9eb">

3) Non-auth related, generic start chat error flows:
<img width="761" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/13504205/a3fe9e51-b65a-4662-a152-73d48cd66762">

### Sanity Tests
-   [x] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [x] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__