### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/chat-component-release-npm-manual.yml
+++ b/.github/workflows/chat-component-release-npm-manual.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           branch_name="release-chat-components-bump-$(date +'%m-%d-%Y-%H-%M-%S')"
           git checkout -b "$branch_name"
-          echo "::set-output name=branch_name::$branch_name"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           git push --set-upstream origin "$branch_name"
 
       - name: Install jq
@@ -48,14 +48,14 @@ jobs:
             new_patch_version=$((patch_version_final))
             new_version=$(echo "$current_version" | awk -F. -v OFS=. -v patch="$new_patch_version" '{$3=patch; print}')
             jq --arg new_version "$new_version" '.version |= $new_version' chat-components/package.json > temp.json && mv temp.json chat-components/package.json
-            echo "::set-output name=version::$new_version"
+            echo "version=$new_version" >> $GITHUB_OUTPUT
           else
             current_version=$(jq -r '.version' chat-components/package.json)
             major_version=$(echo "$current_version" | cut -d. -f1)
             minor_version=$(echo "$current_version" | cut -d. -f2)
             new_version="$((major_version)).$((minor_version + 1)).0"
             jq --arg new_version "$new_version" '.version |= $new_version' chat-components/package.json > temp.json && mv temp.json chat-components/package.json
-            echo "::set-output name=version::$new_version"
+            echo "version=$new_version" >> $GITHUB_OUTPUT
           fi
 
       - name: Update Changelog
@@ -81,14 +81,14 @@ jobs:
               new_patch_version=$((patch_version + 1))-0
               new_version=$(echo "$current_version" | awk -F. -v OFS=. -v patch="$new_patch_version" '{$3=patch; print}')
               jq --arg new_version "$new_version" '.version |= $new_version' chat-components/package.json > temp.json && mv temp.json chat-components/package.json
-              echo "::set-output name=version::$new_version"
+              echo "version=$new_version" >> $GITHUB_OUTPUT
             else
               current_version=$(jq -r '.version' chat-components/package.json)
               patch_version=$(echo "$current_version" | cut -d. -f3)
               new_patch_version=$((patch_version + 1))-0
               new_version=$(echo "$current_version" | awk -F. -v OFS=. -v patch="$new_patch_version" '{$3=patch; print}')
               jq --arg new_version "$new_version" '.version |= $new_version' chat-components/package.json > temp.json && mv temp.json chat-components/package.json
-              echo "::set-output name=version::$new_version"
+              echo "version=$new_version" >> $GITHUB_OUTPUT
             fi
 
       - name: Search for 'Chat-Components' tag and add '##[Unreleased]'

--- a/.github/workflows/chat-components-release-manual.yml
+++ b/.github/workflows/chat-components-release-manual.yml
@@ -21,8 +21,8 @@ jobs:
         id: read-package-json
         working-directory: chat-components
         run: |
-          echo "::set-output name=name::$(cat package.json | jq -r '.name')"
-          echo "::set-output name=version::$(cat package.json | jq -r '.version')"
+          echo "name=$(cat package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
       - name: Install packages
         working-directory: chat-components
         run: yarn install --network-timeout 100000
@@ -68,10 +68,10 @@ jobs:
       - name: Read package.json
         id: read-package-json
         run: |
-          echo "::set-output name=name::$(tar xOf *.tgz package/package.json | jq -r '.name')"
-          echo "::set-output name=version::$(tar xOf *.tgz package/package.json | jq -r '.version')"
-          echo "::set-output name=tarball::$(ls *.tgz)"
-          echo "::set-output name=date::$(date +%Y-%m-%d)"
+          echo "name=$(tar xOf *.tgz package/package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(tar xOf *.tgz package/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "tarball=$(ls *.tgz)" >> $GITHUB_OUTPUT
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
       - name: Run npm publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
         run: |
           npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/chat-components-release.yml
+++ b/.github/workflows/chat-components-release.yml
@@ -25,8 +25,8 @@ jobs:
         id: read-package-json
         working-directory: chat-components
         run: |
-          echo "::set-output name=name::$(cat package.json | jq -r '.name')"
-          echo "::set-output name=version::$(cat package.json | jq -r '.version')"
+          echo "name=$(cat package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
       - name: Install packages
         working-directory: chat-components
         run: yarn install --network-timeout 100000
@@ -72,10 +72,10 @@ jobs:
       - name: Read package.json
         id: read-package-json
         run: |
-          echo "::set-output name=name::$(tar xOf *.tgz package/package.json | jq -r '.name')"
-          echo "::set-output name=version::$(tar xOf *.tgz package/package.json | jq -r '.version')"
-          echo "::set-output name=tarball::$(ls *.tgz)"
-          echo "::set-output name=date::$(date +%Y-%m-%d)"
+          echo "name=$(tar xOf *.tgz package/package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(tar xOf *.tgz package/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "tarball=$(ls *.tgz)" >> $GITHUB_OUTPUT
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
       - name: Run npm publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
         run: |
           npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/chat-widget-release-manual.yml
+++ b/.github/workflows/chat-widget-release-manual.yml
@@ -21,8 +21,8 @@ jobs:
         id: read-package-json
         working-directory: chat-widget
         run: |
-          echo "::set-output name=name::$(cat package.json | jq -r '.name')"
-          echo "::set-output name=version::$(cat package.json | jq -r '.version')"
+          echo "name=$(cat package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
       - name: Install packages
         working-directory: chat-widget
         run: yarn install --network-timeout 100000
@@ -68,10 +68,10 @@ jobs:
       - name: Read package.json
         id: read-package-json
         run: |
-          echo "::set-output name=name::$(tar xOf *.tgz package/package.json | jq -r '.name')"
-          echo "::set-output name=version::$(tar xOf *.tgz package/package.json | jq -r '.version')"
-          echo "::set-output name=tarball::$(ls *.tgz)"
-          echo "::set-output name=date::$(date +%Y-%m-%d)"
+          echo "name=$(tar xOf *.tgz package/package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(tar xOf *.tgz package/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "tarball=$(ls *.tgz)" >> $GITHUB_OUTPUT
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
       - name: Run npm publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
         run: |
           npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/chat-widget-release-npm-manual.yml
+++ b/.github/workflows/chat-widget-release-npm-manual.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           branch_name="release-chatwidget-bump-$(date +'%m-%d-%Y-%H-%M-%S')"
           git checkout -b "$branch_name"
-          echo "::set-output name=branch_name::$branch_name"
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           git push --set-upstream origin "$branch_name"
 
       - name: Install jq
@@ -49,14 +49,14 @@ jobs:
             new_patch_version=$((patch_version_final))
             new_version=$(echo "$current_version" | awk -F. -v OFS=. -v patch="$new_patch_version" '{$3=patch; print}')
             jq --arg new_version "$new_version" '.version |= $new_version' chat-widget/package.json > temp.json && mv temp.json chat-widget/package.json
-            echo "::set-output name=version::$new_version"
+            echo "version=$new_version" >> $GITHUB_OUTPUT
           else
             current_version=$(jq -r '.version' chat-widget/package.json)
             major_version=$(echo "$current_version" | cut -d. -f1)
             minor_version=$(echo "$current_version" | cut -d. -f2)
             new_version="$((major_version)).$((minor_version + 1)).0"
             jq --arg new_version "$new_version" '.version |= $new_version' chat-widget/package.json > temp.json && mv temp.json chat-widget/package.json
-            echo "::set-output name=version::$new_version"
+            echo "version=$new_version" >> $GITHUB_OUTPUT
           fi
 
       - name: Update Changelog
@@ -84,14 +84,14 @@ jobs:
               new_patch_version=$((patch_version + 1))-0
               new_version=$(echo "$current_version" | awk -F. -v OFS=. -v patch="$new_patch_version" '{$3=patch; print}')
               jq --arg new_version "$new_version" '.version |= $new_version' chat-widget/package.json > temp.json && mv temp.json chat-widget/package.json
-              echo "::set-output name=version::$new_version"
+              echo "version=$new_version" >> $GITHUB_OUTPUT
             else
               current_version=$(jq -r '.version' chat-widget/package.json)
               patch_version=$(echo "$current_version" | cut -d. -f3)
               new_patch_version=$((patch_version + 1))-0
               new_version=$(echo "$current_version" | awk -F. -v OFS=. -v patch="$new_patch_version" '{$3=patch; print}')
               jq --arg new_version "$new_version" '.version |= $new_version' chat-widget/package.json > temp.json && mv temp.json chat-widget/package.json
-              echo "::set-output name=version::$new_version"
+              echo "version=$new_version" >> $GITHUB_OUTPUT
             fi
 
       - name: Search for 'Chat Widget' tag and add '##[Unreleased]'

--- a/.github/workflows/chat-widget-release.yml
+++ b/.github/workflows/chat-widget-release.yml
@@ -25,8 +25,8 @@ jobs:
         id: read-package-json
         working-directory: chat-widget
         run: |
-          echo "::set-output name=name::$(cat package.json | jq -r '.name')"
-          echo "::set-output name=version::$(cat package.json | jq -r '.version')"
+          echo "name=$(cat package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
       - name: Install packages
         working-directory: chat-widget
         run: yarn install --network-timeout 100000
@@ -72,10 +72,10 @@ jobs:
       - name: Read package.json
         id: read-package-json
         run: |
-          echo "::set-output name=name::$(tar xOf *.tgz package/package.json | jq -r '.name')"
-          echo "::set-output name=version::$(tar xOf *.tgz package/package.json | jq -r '.version')"
-          echo "::set-output name=tarball::$(ls *.tgz)"
-          echo "::set-output name=date::$(date +%Y-%m-%d)"
+          echo "name=$(tar xOf *.tgz package/package.json | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "version=$(tar xOf *.tgz package/package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "tarball=$(ls *.tgz)" >> $GITHUB_OUTPUT
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
       - name: Run npm publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
         run: |
           npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


