### PR TITLE
use of H1 instead of label

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -274,6 +274,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - A11Y issue with buttons in reconnect pane.
+- A11Y issue with missing H1 tag for input pane.
 
 ## [1.1.1] 2024-1-4
 ### Changed

--- a/chat-components/src/components/inputvalidationpane/InputValidationPane.tsx
+++ b/chat-components/src/components/inputvalidationpane/InputValidationPane.tsx
@@ -1,6 +1,6 @@
 import { DefaultButton, PrimaryButton } from "@fluentui/react/lib/Button";
 import { IButtonStyles, ILabelStyles, IStackStyles, IStyle, ITextFieldStyles, Label, Stack, TextField } from "@fluentui/react";
-import React, {useCallback, useEffect, useState} from "react";
+import React, {CSSProperties, useCallback, useEffect, useState} from "react";
 
 import { BroadcastService } from "../../services/BroadcastService";
 import { ICustomEvent } from "../../interfaces/ICustomEvent";
@@ -119,9 +119,8 @@ function InputValidationPane(props: IInputValidationPaneProps) {
         root: Object.assign({}, defaultInputValidationPaneHeaderGroupStyles, props.styleProps?.headerGroupStyleProps)
     };
 
-    const titleStyles: ILabelStyles = {
-        root: Object.assign({}, defaultInputValidationPaneTitleStyles, props.styleProps?.titleStyleProps)
-    };
+    const titleStyles = Object.assign({}, defaultInputValidationPaneTitleStyles, props.styleProps?.titleStyleProps);
+
 
     const subtitleStyles: ILabelStyles = {
         root: Object.assign({}, defaultInputValidationPaneSubtitleStyles, props.styleProps?.subtitleStyleProps)
@@ -209,13 +208,13 @@ function InputValidationPane(props: IInputValidationPaneProps) {
                         id={elementId + "-headergroup"}>
 
                         {!props.controlProps?.hideTitle && (decodeComponentString(props.componentOverrides?.title) ||
-                        <Label
+                        <h1
                             className={props.styleProps?.classNames?.titleClassName}
-                            styles={titleStyles}
+                            style={titleStyles as CSSProperties}
                             tabIndex={-1}
                             id={elementId + "-title"}>
                             {props.controlProps?.titleText || defaultInputValidationPaneControlProps.titleText}
-                        </Label>) }
+                        </h1>) }
 
                         {!props.controlProps?.hideSubtitle && (decodeComponentString(props.componentOverrides?.subtitle) ||
                         <Label


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
 3818893

### Description
_Include a description of the problem to be solved_

__Actual Result:__
Heading Level is not defined for "Email this chat transcript" Popup.
__Expected Results:__
 Heading Should be Defined for the "Email this chat transcript" Popup.
__User Impact:__
User not able to understand the current structure of the page if three H1 heading level tag present on the same page.
__Recommendations:__
Refer [Developer Resources (sharepoint.com)](https://microsoft.sharepoint.com/sites/accessibility/SitePages/Developer-Resources.aspx?xsdata=MDV8MDF8fGY4MTA5OTIwZTkyNDQ0YzM1OTRmMDhkYmNlZDdlZDRmfDcyZjk4OGJmODZmMTQxYWY5MWFiMmQ3Y2QwMTFkYjQ3fDB8MHw2MzgzMzExOTg5OTc3NDgwNDd8VW5rbm93bnxWR1ZoYlhOVFpXTjFjbWwwZVZObGNuWnBZMlY4ZXlKV0lqb2lNQzR3TGpBd01EQWlMQ0pRSWpvaVYybHVNeklpTENKQlRpSTZJazkwYUdWeUlpd2lWMVFpT2pFeGZRPT18MXxMMk5vWVhSekx6RTVPall4TWpJelkyRmxPV1pqTURRd05tUTRNemxtT0RZd05UTTVORFl3WkRNNFFIUm9jbVZoWkM1Mk1pOXRaWE56WVdkbGN5OHhOamszTlRJek1EazVNRFk1fGNlZWU4YTA0ZjkyMjQ0MTc1OTRmMDhkYmNlZDdlZDRmfGY5ODc4NWE0MTA3YTRlYWY4OTU1ZWNhNjIzOWJjMWY2&sdata=VzQyNGxUQVYwMTZnL1d0aGt3dEhWbDhIaU5oVE5hYllLYVdETyt3UXkxdz0%3D&ovuser=72f988bf-86f1-41af-91ab-2d7cd011db47%2cv-harugula%40microsoft.com&OR=Teams-HL&CT=1697523148200&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIyNy8yMzA5MTQxNzUwNSIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D)
MAS Reference:
[MAS 1.3.1 – Info and Relationships](https://aka.ms/MAS1.3.1)

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
Switch to H1 tag instead of Label

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
H1 present for title
## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

H1 present in email input pane

<img width="842" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/40512247-6356-4c81-8a30-b4d584d05008">


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__