### PR TITLE
 3823151 : reconnect pane fails to maintain UI/UX with zoom and different resolutions

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -275,6 +275,7 @@ All notable changes to this project will be documented in this file.
 
 - A11Y issue with buttons in reconnect pane.
 - A11Y issue with missing H1 tag for input pane.
+- A11Y issue with reconnect pane style when full screen mode is on.
 
 ## [1.1.1] 2024-1-4
 ### Changed

--- a/chat-components/src/components/reconnectchatpane/common/default/defaultStyles/defaultReconnectChatPaneGeneralStyles.ts
+++ b/chat-components/src/components/reconnectchatpane/common/default/defaultStyles/defaultReconnectChatPaneGeneralStyles.ts
@@ -7,6 +7,7 @@ export const defaultReconnectChatPaneGeneralStyles: IStyle = {
     borderStyle: "solid",
     borderWidth: "3px",
     padding: "15px",
-    height: "100%",
-    width: "100%"
+    height: "inherit",
+    width: "inherit",
+    overflowY: "auto"
 };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
 3823151

### Description
_Include a description of the problem to be solved_
__Pre-requisites:__

- Go to Settings > System > Display.
- To ensure consistent testing, set the machine’s target resolution to an "average" mid-range resolution (1280 x 768). And scaling should be at 100%.
- Zoom the page to 200% and refresh the page.

__Repro Steps:__

1. Hit the URL [OAuth Test (windows.net)](https://elastorageredmond.blob.core.windows.net/elopez-dev/html/A11Y/oauthTest.html) .
2. Let's chat dialogue box will open.
3. Now Apply the Resize configuration and Observe that After Applying Resize "Lets chat" Dialogue box is Truncating.

__Actual Result:__
 After Applying Resize "Lets chat" Dialogue box is Truncating.
__Expected Results:__
 After Applying Resize "Lets chat" Dialogue box should not get Truncated, it should clearly visible and Accessible.
__User Impact:__
Low Vision users will face difficulties if the "Lets chat" dialogue box is getting truncated and not able to accessible to the users.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

UX is compromissed due to issues when being in full mode and refreshing, plus missing proper CSS style for the pane.

This PR fix issues on CSS, the issues with resizing will be fixed for OOB in a different PR.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/93142b30-37fd-42c2-b064-c82b46d025cf)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/9a2b771b-7570-4d2f-9170-1646bcfb2ec2)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/d78a516e-a997-499b-a90f-7b2f7c0fcc6e)

__ios + chrome__
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/a52da375-01ba-4553-b99a-e6eb1ee37ea8)

__ios + safari__
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/4855b701-70ca-4cfd-b749-51510c15e237)

__ android + chrome __
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/0401bce1-8eed-4f51-925e-9a6ca82be0eb)





### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__