### PR TITLE
3841351 : Prechat pane issues with state handling

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,17 +5,21 @@ All notable changes to this project will be documented in this file.
 # Chat-Widget
 
 ## [Unreleased]
+
 ### Changed
+
 - Uptake [@microsoft/omnichannel-chat-components@1.1.2](https://www.npmjs.com/package/@microsoft/omnichannel-chat-components/v/1.1.2)
 
-
 ### Fixed
+
 - Running startChat SDK multiple times on an active chat without local storage is treated as a no-op
-- Reconnecting to an unauthenticated popout reconnect chat with prechat survey configured does not present the prechat survey again
-- Fix data `Data Masking` being enabled when `msdyn_maskforcustomer` is set to `false` and `dataMaskingRules` is not empty 
-- Forcing failures on authenticated chats to be sent immediately during reconnect flow and dont allow to continue with the chat flow.
+- Reconnecting to an unauthenticated popout reconnect chat with pre-chat survey configured does not present the pre-chat survey again
+- Fix data `Data Masking` being enabled when `msdyn_maskforcustomer` is set to `false` and `dataMaskingRules` is not empty.  
+- Forcing failures on authenticated chats to be sent immediately during reconnect flow and don't allow to continue with the chat flow.
+- Fix to handle pre-chat pane during reload and avoid the pane to be injected but no visible.
 
 ## Changed
+
 - Uptake [@microsoft/omnichannel-chat-sdk@1.6.3](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.6.3)
 
 ## [1.6.2] 2024-01-10

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -56,7 +56,8 @@ export enum BroadcastEvent {
     HideChatVisibilityChangeEvent = "hideChatVisibilityChangeEvent",
     UpdateSessionDataForTelemetry = "UpdateSessionDataForTelemetry",
     UpdateConversationDataForTelemetry = "UpdateConversationDataForTelemetry",
-    ContactIdNotFound = "ContactIdNotFound"
+    ContactIdNotFound = "ContactIdNotFound",
+    SyncMinimize = "SyncMinimize"
 }
 
 // Events being logged

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -76,10 +76,12 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
         } else {
             dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
-            // If minimized, maximize the chat
+            
+            // If minimized, maximize the chat, if the state is missing, consider it as minimized
             if (state?.appStates.isMinimized == undefined || state?.appStates?.isMinimized === true) {
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
 
+                // this event will notify the upper layer to maximize the widget, an event missing during multi-tab scenario.
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.MaximizeChat,
                     payload: {
@@ -88,8 +90,6 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
                     }
                 });
             }
-
-
             return;
         }
     }
@@ -105,7 +105,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
     let isStartChatSuccessful = false;
     const chatConfig = props?.chatConfig;
     const getAuthToken = props?.getAuthToken;
-
 
     if (state?.appStates.conversationState === ConversationState.Closed) {
         // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems
@@ -143,10 +142,8 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
                 }
             });
         }
-
         
         try {
-
             // Set custom context params
             await setCustomContextParams(state, props);
             const defaultOptionalParams: StartChatOptionalParams = {
@@ -323,11 +320,11 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
 
         return true;
     }
-    catch (erorr) {
+    catch (error) {
         TelemetryHelper.logActionEvent(LogLevel.ERROR, {
             Event: TelemetryEvent.GetConversationDetailsException,
             ExceptionDetails: {
-                exception: `Conversation is not valid: ${erorr}`
+                exception: `Conversation is not valid: ${error}`
             }
         });
         chatSDK.requestId = currentRequestId;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -31,10 +31,7 @@ let popoutWidgetInstanceId: any | "";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any) => {
     optionalParams = {}; //Resetting to ensure no stale values
-    console.log("ELOPEZANAYA ::: prepareStartChat 0");
     widgetInstanceId = getWidgetCacheIdfromProps(props);
-
-    console.log("ELOPEZANAYA ::: prepareStartChat 1");
     // reconnect > chat from cache
     if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
         const shouldStartChatNormally = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
@@ -43,25 +40,20 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
         }
     }
 
-    console.log("ELOPEZANAYA ::: prepareStartChat 2");
     // Check if there is any active popout chats in cache
     if (await canStartPopoutChat(props)) {
         return;
     }
 
-    console.log("ELOPEZANAYA ::: prepareStartChat 3");
     // Can connect to existing chat session
     if (await canConnectToExistingChat(props, chatSDK, state, dispatch, setAdapter)) {
         return;
     }
 
-    console.log("ELOPEZANAYA ::: prepareStartChat 4");
-
     // Setting Proactive chat settings
     const isProactiveChat = state.appStates.conversationState === ConversationState.ProactiveChat;
     const isPreChatEnabledInProactiveChat = state.appStates.proactiveChatStates.proactiveChatEnablePrechat;
 
-    console.log("ELOPEZANAYA ::: prepareStartChat 5");
     //Setting PreChat and intiate chat
     await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, isProactiveChat, isPreChatEnabledInProactiveChat, state, props);
 };
@@ -70,30 +62,22 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
     //Handle reconnect scenario
 
-    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 1");
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
 
-    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 2");
     if (showPrechat) {
-        console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 3");
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
         if (isOutOfOperatingHours) {
             state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
             return;
         } else {
-            console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 4") ;
             dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
-
-            console.log("ELOPEZANAYA 2222 :: StartChat Event received :: chat already initiated, minimize?? ::", state?.appStates);
             // If minimized, maximize the chat
             if (state?.appStates.isMinimized == undefined || state?.appStates?.isMinimized === true) {
-                console.log("ELOPEZANAYA 222 :: StartChat Event received :: chat already initiated, MAXIMIR?? :: maximizing");
-
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
 
                 BroadcastService.postMessage({
@@ -110,12 +94,9 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
         }
     }
 
-    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 5");
     //Initiate start chat
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
-    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 6");
     const optionalParams: StartChatOptionalParams = { isProactiveChat };
-    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 7");
     await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams);
 };
 
@@ -125,19 +106,13 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
     const chatConfig = props?.chatConfig;
     const getAuthToken = props?.getAuthToken;
 
-    console.log("ELOPEZANAYA ::: initStartChat 1");
 
     if (state?.appStates.conversationState === ConversationState.Closed) {
-        console.log("ELOPEZANAYA ::: initStartChat 2");
         // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems
         chatSDKStateCleanUp(chatSDK);
     }
 
     try {
-
-
-        console.log("ELOPEZANAYA ::: initStartChat 3");
-
         // Clear disconnect state on start chat
         state?.appStates?.chatDisconnectEventReceived && dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: false });
 
@@ -149,7 +124,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             Description: "Widget loading started",
         });
 
-        console.log("ELOPEZANAYA ::: initStartChat 4");
         const authClientFunction = getAuthClientFunction(chatConfig);
         if (getAuthToken && authClientFunction) {
             // set auth token to chat sdk before start chat
@@ -159,7 +133,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             }
         }
 
-        console.log("ELOPEZANAYA ::: initStartChat 5");
         //Check if chat retrieved from cache
         if (persistedState || params?.liveChatContext) {
             BroadcastService.postMessage({
@@ -174,7 +147,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         
         try {
 
-            console.log("ELOPEZANAYA ::: initStartChat 6");
             // Set custom context params
             await setCustomContextParams(state, props);
             const defaultOptionalParams: StartChatOptionalParams = {
@@ -186,7 +158,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             await chatSDK.startChat(startChatOptionalParams);
             isStartChatSuccessful = true;
         } catch (error) {
-            console.log("ELOPEZANAYA ::: initStartChat 7");
             checkContactIdError(error);
             TelemetryHelper.logSDKEvent(LogLevel.ERROR, {
                 Event: TelemetryEvent.StartChatMethodException,
@@ -202,7 +173,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         const newAdapter = await createAdapter(chatSDK);
         setAdapter(newAdapter);
 
-        console.log("ELOPEZANAYA ::: initStartChat 8    ");
         const chatToken = await chatSDK.getChatToken();
         dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: chatToken });
         newAdapter?.activity$?.subscribe(createOnNewAdapterActivityHandler(chatToken?.chatId, chatToken?.visitorId));
@@ -225,17 +195,13 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const liveChatContext: any = await chatSDK?.getCurrentLiveChatContext();
         dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: liveChatContext });
-
-        console.log("ELOPEZANAYA ::: initStartChat 9");
         logWidgetLoadComplete();
-
         // Set post chat context in state
         // Commenting this for now as post chat context is fetched during end chat
         await setPostChatContextAndLoadSurvey(chatSDK, dispatch);
 
         // Updating chat session detail for telemetry
         await updateSessionDataForTelemetry(chatSDK, dispatch);
-        console.log("ELOPEZANAYA ::: initStartChat 100");
     } catch (ex) {
         handleStartChatError(dispatch, chatSDK, props, ex, isStartChatSuccessful);
     } finally {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -31,8 +31,10 @@ let popoutWidgetInstanceId: any | "";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any) => {
     optionalParams = {}; //Resetting to ensure no stale values
+    console.log("ELOPEZANAYA ::: prepareStartChat 0");
     widgetInstanceId = getWidgetCacheIdfromProps(props);
 
+    console.log("ELOPEZANAYA ::: prepareStartChat 1");
     // reconnect > chat from cache
     if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
         const shouldStartChatNormally = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
@@ -41,20 +43,25 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
         }
     }
 
+    console.log("ELOPEZANAYA ::: prepareStartChat 2");
     // Check if there is any active popout chats in cache
     if (await canStartPopoutChat(props)) {
         return;
     }
 
+    console.log("ELOPEZANAYA ::: prepareStartChat 3");
     // Can connect to existing chat session
     if (await canConnectToExistingChat(props, chatSDK, state, dispatch, setAdapter)) {
         return;
     }
 
+    console.log("ELOPEZANAYA ::: prepareStartChat 4");
+
     // Setting Proactive chat settings
     const isProactiveChat = state.appStates.conversationState === ConversationState.ProactiveChat;
     const isPreChatEnabledInProactiveChat = state.appStates.proactiveChatStates.proactiveChatEnablePrechat;
 
+    console.log("ELOPEZANAYA ::: prepareStartChat 5");
     //Setting PreChat and intiate chat
     await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, isProactiveChat, isPreChatEnabledInProactiveChat, state, props);
 };
@@ -63,27 +70,52 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
     //Handle reconnect scenario
 
+    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 1");
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
 
+    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 2");
     if (showPrechat) {
+        console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 3");
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
         if (isOutOfOperatingHours) {
             state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
             return;
         } else {
+            console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 4") ;
             dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
+
+            console.log("ELOPEZANAYA 2222 :: StartChat Event received :: chat already initiated, minimize?? ::", state?.appStates);
+            // If minimized, maximize the chat
+            if (state?.appStates.isMinimized == undefined || state?.appStates?.isMinimized === true) {
+                console.log("ELOPEZANAYA 222 :: StartChat Event received :: chat already initiated, MAXIMIR?? :: maximizing");
+
+                dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+
+                BroadcastService.postMessage({
+                    eventName: BroadcastEvent.MaximizeChat,
+                    payload: {
+                        height: state?.domainStates?.widgetSize?.height,
+                        width: state?.domainStates?.widgetSize?.width
+                    }
+                });
+            }
+
+
             return;
         }
     }
 
+    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 5");
     //Initiate start chat
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
+    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 6");
     const optionalParams: StartChatOptionalParams = { isProactiveChat };
+    console.log("ELOPEZANAYA ::: setPreChatAndInitiateChat 7");
     await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams);
 };
 
@@ -93,12 +125,19 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
     const chatConfig = props?.chatConfig;
     const getAuthToken = props?.getAuthToken;
 
+    console.log("ELOPEZANAYA ::: initStartChat 1");
+
     if (state?.appStates.conversationState === ConversationState.Closed) {
+        console.log("ELOPEZANAYA ::: initStartChat 2");
         // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems
         chatSDKStateCleanUp(chatSDK);
     }
 
     try {
+
+
+        console.log("ELOPEZANAYA ::: initStartChat 3");
+
         // Clear disconnect state on start chat
         state?.appStates?.chatDisconnectEventReceived && dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: false });
 
@@ -110,6 +149,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             Description: "Widget loading started",
         });
 
+        console.log("ELOPEZANAYA ::: initStartChat 4");
         const authClientFunction = getAuthClientFunction(chatConfig);
         if (getAuthToken && authClientFunction) {
             // set auth token to chat sdk before start chat
@@ -119,6 +159,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             }
         }
 
+        console.log("ELOPEZANAYA ::: initStartChat 5");
         //Check if chat retrieved from cache
         if (persistedState || params?.liveChatContext) {
             BroadcastService.postMessage({
@@ -130,7 +171,10 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             });
         }
 
+        
         try {
+
+            console.log("ELOPEZANAYA ::: initStartChat 6");
             // Set custom context params
             await setCustomContextParams(state, props);
             const defaultOptionalParams: StartChatOptionalParams = {
@@ -142,6 +186,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             await chatSDK.startChat(startChatOptionalParams);
             isStartChatSuccessful = true;
         } catch (error) {
+            console.log("ELOPEZANAYA ::: initStartChat 7");
             checkContactIdError(error);
             TelemetryHelper.logSDKEvent(LogLevel.ERROR, {
                 Event: TelemetryEvent.StartChatMethodException,
@@ -157,6 +202,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         const newAdapter = await createAdapter(chatSDK);
         setAdapter(newAdapter);
 
+        console.log("ELOPEZANAYA ::: initStartChat 8    ");
         const chatToken = await chatSDK.getChatToken();
         dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: chatToken });
         newAdapter?.activity$?.subscribe(createOnNewAdapterActivityHandler(chatToken?.chatId, chatToken?.visitorId));
@@ -180,6 +226,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         const liveChatContext: any = await chatSDK?.getCurrentLiveChatContext();
         dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: liveChatContext });
 
+        console.log("ELOPEZANAYA ::: initStartChat 9");
         logWidgetLoadComplete();
 
         // Set post chat context in state
@@ -188,6 +235,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
 
         // Updating chat session detail for telemetry
         await updateSessionDataForTelemetry(chatSDK, dispatch);
+        console.log("ELOPEZANAYA ::: initStartChat 100");
     } catch (ex) {
         handleStartChatError(dispatch, chatSDK, props, ex, isStartChatSuccessful);
     } finally {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -142,7 +142,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
                 }
             });
         }
-        
+
         try {
             // Set custom context params
             await setCustomContextParams(state, props);

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -305,9 +305,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
         });
 
-        BroadcastService.getMessageByEventName("sync").subscribe((msg: ICustomEvent) => {
+        /**
+         * This will allow to sync multiple tabs to handle minimize and maximize state, 
+         * the event is expected to be emitted from scripting layer.
+         */
+        BroadcastService.getMessageByEventName(BroadcastEvent.SyncMinimize).subscribe((msg: ICustomEvent) => {
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: msg?.payload?.minimized });
-
         });
 
         // Start chat from SDK Event
@@ -346,7 +349,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
 
             // If minimized, maximize the chat
-            if (state?.appStates?.isMinimized === true) {
+            if (inMemoryState?.appStates?.isMinimized === true) {
 
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -173,19 +173,15 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 const reconnectTriggered = await isReconnectTriggered();
                 if (!reconnectTriggered) {
                     const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
-                    console.log("ELOPEZANAYA :: startChat :: calling setPRechatAndInitiateChat");
                     await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, undefined, undefined, inMemoryState, props);
                 }
-                console.log("ELOPEZANAYA :: startChat :: returning");
                 return;
             } else {
                 // To avoid showing blank screen in popout
                 if (state?.appStates?.hideStartChatButton === false) {
-                    console.log("ELOPEZANAYA :: startChat :: closing conversation state");
                     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Closed });
                     return;
                 }
-                console.log("ELOPEZANAYA :: startChat :: conversation state to loading");
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
             }
         }
@@ -310,21 +306,16 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         });
 
         BroadcastService.getMessageByEventName("sync").subscribe((msg: ICustomEvent) => {
-            console.log("ELOPEZANAYA :: Sync Event received");
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: msg?.payload?.minimized });
 
         });
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
-            console.log("ELOPEZANAYA :: StartChat Event received");
             // If the startChat event is not initiated by the same tab. Ignore the call
             if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
-                console.log("ELOPEZANAYA :: StartChat Event received from other tab, returning");  
                 return;
             }
-            
-            
             
             if (msg?.payload?.customContext) {
                 TelemetryHelper.logActionEvent(LogLevel.INFO, {
@@ -332,8 +323,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                     Description: "CustomContext received through startChat event."
                 });
                 dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: msg?.payload?.customContext });
-                
-              
             }
             
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
@@ -345,7 +334,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
             inMemoryState.domainStates.customContext = msg?.payload?.customContext;
 
-            console.log("ELOPEZANAYA :: StartChat Event received :: inMemoryState: ", inMemoryState.appStates.conversationState);
             // Only initiate new chat if widget runtime state is one of the followings
             if (inMemoryState.appStates?.conversationState === ConversationState.Closed ||
                 inMemoryState.appStates?.conversationState === ConversationState.InActive ||
@@ -353,15 +341,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.ChatInitiated
                 });
-                console.log("ELOPEZANAYA :: StartChat Event received :: calling prepareStartChat");
                 prepareStartChat(props, chatSDK, inMemoryState, dispatch, setAdapter);
                 return;
             }
 
-            console.log("ELOPEZANAYA :: StartChat Event received :: chat already initiated, minimize?? ::", inMemoryState.appStates);
             // If minimized, maximize the chat
             if (state?.appStates?.isMinimized === true) {
-                console.log("ELOPEZANAYA :: StartChat Event received :: chat already initiated, MAXIMIR?? :: maximizing");
 
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
 
@@ -374,7 +359,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 });
                 return;
             }
-            console.log("ELOPEZANAYA :: StartChat Event received :: DONE");
         });
 
         // End chat

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -16,6 +16,9 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
 
     if (!isNullOrUndefined(initialState)) {
         const initialStateFromCache: ILiveChatWidgetContext = JSON.parse(initialState);
+        if (initialStateFromCache.appStates.conversationState === ConversationState.Prechat) {
+            initialStateFromCache.appStates.conversationState = ConversationState.Closed;
+        }
         return initialStateFromCache;
     }
 

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -16,6 +16,13 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
 
     if (!isNullOrUndefined(initialState)) {
         const initialStateFromCache: ILiveChatWidgetContext = JSON.parse(initialState);
+
+        /*
+        * this step is needed to avoid the pre-chat pane to be injected in the DOM when the widget is reloaded, because wont be visible
+        * and it will be blocking all elements behind it
+        * as part of the flow, the pre-chat will be detected and then it will be displayed properly 
+        * this case is only and only for pre-chat pane.
+        * **/
         if (initialStateFromCache.appStates.conversationState === ConversationState.Prechat) {
             initialStateFromCache.appStates.conversationState = ConversationState.Closed;
         }

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -95,7 +95,6 @@ const reducer = (state: ILiveChatWidgetContext, action: ILiveChatWidgetAction): 
             };
 
         case LiveChatWidgetActionType.SET_MINIMIZED:
-            console.log("ELOPEZANAYA : SET MINIMIZED : " + action.payload);
             inMemory = {
                 ...inMemory,
                 appStates: {

--- a/chat-widget/src/contexts/createReducer.ts
+++ b/chat-widget/src/contexts/createReducer.ts
@@ -95,10 +95,11 @@ const reducer = (state: ILiveChatWidgetContext, action: ILiveChatWidgetAction): 
             };
 
         case LiveChatWidgetActionType.SET_MINIMIZED:
+            console.log("ELOPEZANAYA : SET MINIMIZED : " + action.payload);
             inMemory = {
                 ...inMemory,
                 appStates: {
-                    ...state.appStates,
+                    ...inMemory.appStates,
                     isMinimized: action.payload as boolean
                 }
 

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -60,7 +60,6 @@ export const shouldShowOutOfOfficeHoursPane = (state: ILiveChatWidgetContext) =>
 };
 
 export const shouldShowPreChatSurveyPane = (state: ILiveChatWidgetContext) => {
-    console.log("ELOPEZANAYA :: shouldShowPreChatSurveyPane :: state.appStates.conversationState: ", state.appStates.conversationState);
     return (state.appStates.conversationState === ConversationState.Prechat);
 };
 

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -60,6 +60,7 @@ export const shouldShowOutOfOfficeHoursPane = (state: ILiveChatWidgetContext) =>
 };
 
 export const shouldShowPreChatSurveyPane = (state: ILiveChatWidgetContext) => {
+    console.log("ELOPEZANAYA :: shouldShowPreChatSurveyPane :: state.appStates.conversationState: ", state.appStates.conversationState);
     return (state.appStates.conversationState === ConversationState.Prechat);
 };
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

When a chat with prechat is displayed, the prechat is minimized and there is a reload, during the reload as part of internal logic the  reload takes from cache state that needs to display the pane , so it triggers the launch of the pane . but then the conversation is set to close and the button is presented.

when the button is presented, by clicking the button it launch the widget and present the pre chat again, but when the button is hidden and the chat is launched via startChat method, then is not launching the chat.

but when inspecting the DOM we can see the pane present, blocking elements behind.

- Another related issue is for multiple tabs, when minimizing the chat in one tab , block the other tabs to launch the tab via start chat method, because there is no syncronization of the minimize state among tabs.

- it was detected as well that the inMemory State component, is not in sync with minimize state, but returning old state.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

- when reloading , and conversation is in prechat mode, set the state to close, this will prevent to launch the pre chat pane and wait for start logic to present the pane.

- include a listener for a new method so the OOB can notify when the minimize happened in another tab , in this way the state will be updated and next time start chat is launched, the pre chat will be displayed.


### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

- prechat pane is presented each time a start chat is trigered
- reload doesnt prevent prechat to be presented
-  multitab honors states and present pane

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__