### PR TITLE
Fix Transcript Download Failure During Post Chat When User Ends Conversation

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,7 +8,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Uptake [@microsoft/omnichannel-chat-components@1.1.2](https://www.npmjs.com/package/@microsoft/omnichannel-chat-components/v/1.1.2)
 - Uptake [@microsoft/omnichannel-chat-components@1.1.3](https://www.npmjs.com/package/@microsoft/omnichannel-chat-components/v/1.1.3)
 - Uptake [@microsoft/omnichannel-chat-sdk@1.7.0](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.7.0)
 
@@ -20,10 +19,7 @@ All notable changes to this project will be documented in this file.
 - Forcing failures on authenticated chats to be sent immediately during reconnect flow and don't allow to continue with the chat flow.
 - Fix to handle pre-chat pane during reload and avoid the pane to be injected but no visible.
 - Fix `ChatSDK.emailLiveChatTranscript()` not working after `ChatSDK.endChat()` is called by not clearing `liveChatContext` on `chatTokenCleanUp`
-
-## Changed
-
-- Uptake [@microsoft/omnichannel-chat-sdk@1.6.3](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.6.3)
+- Fix `ChatSDK.getLiveChatTranscript()` not working during post chat survey when user ends the conversation by retreving `liveChatContext` from `inMemoryState`
 
 ## [1.6.2] 2024-01-10
 

--- a/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
+++ b/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
@@ -8,6 +8,8 @@ import createChatTranscript from "../../../plugins/createChatTranscript";
 import DOMPurify from "dompurify";
 import { createFileAndDownload, isNullOrUndefined } from "../../../common/utils";
 import { IDownloadTranscriptProps } from "./interfaces/IDownloadTranscriptProps";
+import { executeReducer } from "../../../contexts/createReducer";
+import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
 
 const processDisplayName = (displayName: string): string => {
     // if displayname matches "teamsvisitor:<some alphanumeric string>", we replace it with "Customer"
@@ -167,8 +169,14 @@ const beautifyChatTranscripts = (chatTranscripts: string, renderMarkDown?: (tran
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const downloadTranscript = async (chatSDK: any, downloadTranscriptProps: IDownloadTranscriptProps, state?: ILiveChatWidgetContext) => {
-    // Need to keep existing live chat context for scenarios when trnascript is downloaded after endchat
-    const liveChatContext = state?.domainStates?.liveChatContext;
+    const inMemoryState = executeReducer(state as ILiveChatWidgetContext, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
+
+    // Need to keep existing live chat context for scenarios when transcript is downloaded after endchat
+    let liveChatContext = state?.domainStates?.liveChatContext;
+    if (!liveChatContext) {
+        liveChatContext = inMemoryState.domainStates.liveChatContext;
+    }
+
     let data = await chatSDK?.getLiveChatTranscript({liveChatContext});
     if (typeof (data) === Constants.String) {
         data = JSON.parse(data);

--- a/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
+++ b/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
@@ -169,11 +169,11 @@ const beautifyChatTranscripts = (chatTranscripts: string, renderMarkDown?: (tran
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const downloadTranscript = async (chatSDK: any, downloadTranscriptProps: IDownloadTranscriptProps, state?: ILiveChatWidgetContext) => {
-    const inMemoryState = executeReducer(state as ILiveChatWidgetContext, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
 
     // Need to keep existing live chat context for scenarios when transcript is downloaded after endchat
     let liveChatContext = state?.domainStates?.liveChatContext;
     if (!liveChatContext) {
+        const inMemoryState = executeReducer(state as ILiveChatWidgetContext, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
         liveChatContext = inMemoryState.domainStates.liveChatContext;
     }
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
- Fix issue where `Transcript Download` would not working during `PostChatSurvey` after user ended the conversation

## Solution Proposed
- `liveChatContext` needed to be retrieve from `inMemoryState`

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__