### PR TITLE
new messsage for when storage is not enabled

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Update banner message for browser storage unavailable.
 - Uptake [@microsoft/omnichannel-chat-components@1.1.3](https://www.npmjs.com/package/@microsoft/omnichannel-chat-components/v/1.1.3)
 - Uptake [@microsoft/omnichannel-chat-sdk@1.7.0](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.7.0)
 - Uptake [@microsoft/omnichannel-chat-sdk@1.7.2](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.7.2)

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
@@ -27,7 +27,7 @@ export const defaultMiddlewareLocalizedTexts: ILiveChatWidgetLocalizedTexts = {
     MIDDLEWARE_MESSAGE_NOT_DELIVERED: "Not Delivered",
     MIDDLEWARE_MESSAGE_RETRY: "Retry",
     MIDDLEWARE_BANNER_CHAT_DISCONNECT: "Your conversation has been disconnected. For additional assistance, please start a new chat.",
-    THIRD_PARTY_COOKIES_BLOCKED_ALERT_MESSAGE: "Allow sites to save/read cookies in browser settings. Reloading page starts enew chat.",
+    THIRD_PARTY_COOKIES_BLOCKED_ALERT_MESSAGE: "Allow sites to save/read cookies in browser settings. Reloading page starts a new chat.",
     MIDDLEWARE_BANNER_FILE_IS_MALICIOUS: "{0} has been blocked because the file may contain a malware.",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS: "Email will be sent after chat ends!",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR: "Email {0} could not be saved, try again later."    

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
@@ -27,7 +27,7 @@ export const defaultMiddlewareLocalizedTexts: ILiveChatWidgetLocalizedTexts = {
     MIDDLEWARE_MESSAGE_NOT_DELIVERED: "Not Delivered",
     MIDDLEWARE_MESSAGE_RETRY: "Retry",
     MIDDLEWARE_BANNER_CHAT_DISCONNECT: "Your conversation has been disconnected. For additional assistance, please start a new chat.",
-    THIRD_PARTY_COOKIES_BLOCKED_ALERT_MESSAGE: "Allow sites to save and read cookie data in browser settings. Reloading this page will start a new conversation.",
+    THIRD_PARTY_COOKIES_BLOCKED_ALERT_MESSAGE: "Allow sites to save/read cookies in browser settings. Reloading page starts enew chat.",
     MIDDLEWARE_BANNER_FILE_IS_MALICIOUS: "{0} has been blocked because the file may contain a malware.",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS: "Email will be sent after chat ends!",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR: "Email {0} could not be saved, try again later."    

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
@@ -27,7 +27,7 @@ export const defaultMiddlewareLocalizedTexts: ILiveChatWidgetLocalizedTexts = {
     MIDDLEWARE_MESSAGE_NOT_DELIVERED: "Not Delivered",
     MIDDLEWARE_MESSAGE_RETRY: "Retry",
     MIDDLEWARE_BANNER_CHAT_DISCONNECT: "Your conversation has been disconnected. For additional assistance, please start a new chat.",
-    THIRD_PARTY_COOKIES_BLOCKED_ALERT_MESSAGE: "Third party cookies are blocked. Reloading this page will start a new conversation.",
+    THIRD_PARTY_COOKIES_BLOCKED_ALERT_MESSAGE: "Allow sites to save and read cookie data in browser settings. Reloading this page will start a new conversation.",
     MIDDLEWARE_BANNER_FILE_IS_MALICIOUS: "{0} has been blocked because the file may contain a malware.",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS: "Email will be sent after chat ends!",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR: "Email {0} could not be saved, try again later."    


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

in past browser versions, blocking TPC meant to block localstorage as well, nowadays those are separated, but browsers like Edge can block total writing in storage , therefore we need an updated banner message to reflect new conditions..

For firefox, a total block means blocking also broadcast channel, which is required for the widget to function.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_


Text provided by Jessica Li.

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/4b63eccf-70eb-4000-bab4-08f69124bc17)

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__