### PR TITLE
Fix End Call Key Shortcuts

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -283,6 +283,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Replacing `end call` shortcut key of pressing `enter` with `ctrl + shift + h` to prevent call to end while sending message
+
 ## [1.1.3] - 2024-03-11
 
 ### Fixed

--- a/chat-components/src/common/Constants.ts
+++ b/chat-components/src/common/Constants.ts
@@ -21,6 +21,7 @@ export const KeyCodes = class {
     public static readonly AcceptVideoCallHotKey = "A";
     public static readonly ToggleMicHotKey = "M";
     public static readonly ToggleCameraHotKey = "O";
+    public static readonly EndCallHotKey = "H";
 };
 
 export const Regex = class {

--- a/chat-components/src/components/callingcontainer/subcomponents/CurrentCall/CurrentCall.tsx
+++ b/chat-components/src/components/callingcontainer/subcomponents/CurrentCall/CurrentCall.tsx
@@ -164,7 +164,7 @@ function CurrentCall(props: ICurrentCallProps) {
     const hideCallTimer = props.controlProps?.hideCallTimer ?? defaultCurrentCallProps.controlProps?.hideCallTimer;
 
     useEffect(() => {
-        const endCallShortcut = (e: KeyboardEvent) => e.key === KeyCodes.ENTER;
+        const endCallShortcut = (e: KeyboardEvent) => e.ctrlKey && e.shiftKey && e.key == KeyCodes.EndCallHotKey;
         const toggleMicShortcut = (e: KeyboardEvent) => e.ctrlKey && e.shiftKey && e.key === KeyCodes.ToggleMicHotKey;
         const toggleVideoShortcut = (e: KeyboardEvent) => e.ctrlKey && e.shiftKey && e.key === KeyCodes.ToggleCameraHotKey;
 

--- a/chat-components/src/components/callingcontainer/subcomponents/CurrentCall/CurrentCall.tsx
+++ b/chat-components/src/components/callingcontainer/subcomponents/CurrentCall/CurrentCall.tsx
@@ -164,7 +164,7 @@ function CurrentCall(props: ICurrentCallProps) {
     const hideCallTimer = props.controlProps?.hideCallTimer ?? defaultCurrentCallProps.controlProps?.hideCallTimer;
 
     useEffect(() => {
-        const endCallShortcut = (e: KeyboardEvent) => e.ctrlKey && e.shiftKey && e.key == KeyCodes.EndCallHotKey;
+        const endCallShortcut = (e: KeyboardEvent) => e.ctrlKey && e.shiftKey && e.key === KeyCodes.EndCallHotKey;
         const toggleMicShortcut = (e: KeyboardEvent) => e.ctrlKey && e.shiftKey && e.key === KeyCodes.ToggleMicHotKey;
         const toggleVideoShortcut = (e: KeyboardEvent) => e.ctrlKey && e.shiftKey && e.key === KeyCodes.ToggleCameraHotKey;
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
- Removing pressing `enter` as shortcut key to end video call to prevent accident end call on typing message

## Solution Proposed
- Replacing shortcut key with `ctrl + shift + h` (same as Teams)

### Acceptance criteria
- Pressing `enter` should not end a voice video call

## Test cases and evidence
- Validated manually the scenario worked

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__