### PR TITLE
Fix UI/UX for adaptive card with actions

### DIFF
--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -3,6 +3,7 @@
 import { IStackStyles, Stack } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
+
 import { BotMagicCodeStore } from "./webchatcontroller/BotMagicCodeStore";
 import { Components } from "botframework-webchat";
 import { Constants } from "../../common/Constants";
@@ -197,6 +198,10 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
         .ms_lcw_webchat_sent_message a:hover,
         .ms_lcw_webchat_sent_message a:active {
             color: ${webChatContainerProps?.renderingMiddlewareProps?.sentMessageAnchorStyles?.color ?? defaultSentMessageAnchorStyles?.color};
+        }
+
+        .webchat__bubble:not(.webchat__bubble--from-user) .webchat__bubble__content {
+            border-radius: 0 !important; /* Override border-radius */
         }
         `}</style>
         <Stack styles={containerStyles}>


### PR DESCRIPTION
…send message box. UI/UX is not affected

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
3926131
### Description
_Include a description of the problem to be solved_

For adaptive cards with stacked options, when scrolling an invisible line is "injected" in the html DOM.

This is due to an issue with rendering, specifically for an inherited CSS class with property border:radious :4px

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/2e62a795-eb69-46f4-9e66-c7c7df1645ef)

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

By removing this property and set to zero via override, the rendering is back to normal , not UI/UX affectations
<img width="257" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/beeb2cfb-0334-4e54-bef8-fe2a017ad5f2">


### Acceptance criteria
- Using a bot with stacked options, scroll up/down and corroborate visually there are not injected lines that break UI in the adaptive card

_Define what are the conditions to consider the PR has achieved the intended goal_
<img width="257" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/5f7bc9f7-b8b8-48bf-b1fd-f7df6e34116c">

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
<img width="257" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/c53cde40-185f-468b-91ee-464e46e83cce">


<img width="958" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/5a4d118b-e095-4230-b957-3ea416f53fad">


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__