### PR TITLE
Addded fix for LCW closeChat methods throws exception

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -210,7 +210,7 @@ export const chatSDKStateCleanUp = (chatSDK: any) => {
 export const endVoiceVideoCallIfOngoing = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     let callId = "";
     try {
-        let voiceVideoCallingSdk;
+        let voiceVideoCallingSdk=null;
         if(chatSDK.isVoiceVideoCallingEnabled()) {
             voiceVideoCallingSdk = await chatSDK.getVoiceVideoCalling();
         }

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -210,19 +210,19 @@ export const chatSDKStateCleanUp = (chatSDK: any) => {
 export const endVoiceVideoCallIfOngoing = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     let callId = "";
     try {
-        let voiceVideoCallingSdk = null;
         if (chatSDK.isVoiceVideoCallingEnabled()) {
-            voiceVideoCallingSdk = await chatSDK.getVoiceVideoCalling();
+            const voiceVideoCallingSdk = await chatSDK.getVoiceVideoCalling();
+            if (voiceVideoCallingSdk && voiceVideoCallingSdk.isInACall()) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                callId = (voiceVideoCallingSdk as any).callId;
+                voiceVideoCallingSdk.stopCall();
+                TelemetryHelper.logCallingEvent(LogLevel.INFO, {
+                    Event: TelemetryEvent.EndCallButtonClick,
+                }, callId);
+                callingStateCleanUp(dispatch);
+            }
         }
-        if (voiceVideoCallingSdk && voiceVideoCallingSdk.isInACall()) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            callId = (voiceVideoCallingSdk as any).callId;
-            voiceVideoCallingSdk.stopCall();
-            TelemetryHelper.logCallingEvent(LogLevel.INFO, {
-                Event: TelemetryEvent.EndCallButtonClick,
-            }, callId);
-            callingStateCleanUp(dispatch);
-        }
+       
     } catch (error) {
         TelemetryHelper.logCallingEvent(LogLevel.ERROR, {
             Event: TelemetryEvent.EndCallButtonClickException,

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -210,12 +210,9 @@ export const chatSDKStateCleanUp = (chatSDK: any) => {
 export const endVoiceVideoCallIfOngoing = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     let callId = "";
     try {
-        let voiceVideoCallingSdk=null;
-        if(chatSDK.isVoiceVideoCallingEnabled()) {
+        let voiceVideoCallingSdk = null;
+        if (chatSDK.isVoiceVideoCallingEnabled()) {
             voiceVideoCallingSdk = await chatSDK.getVoiceVideoCalling();
-        }
-        else{
-            return;
         }
         if (voiceVideoCallingSdk && voiceVideoCallingSdk.isInACall()) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -210,7 +210,13 @@ export const chatSDKStateCleanUp = (chatSDK: any) => {
 export const endVoiceVideoCallIfOngoing = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     let callId = "";
     try {
-        const voiceVideoCallingSdk = await chatSDK.getVoiceVideoCalling();
+        let voiceVideoCallingSdk;
+        if(chatSDK.isVoiceVideoCallingEnabled()) {
+            voiceVideoCallingSdk = await chatSDK.getVoiceVideoCalling();
+        }
+        else{
+            return;
+        }
         if (voiceVideoCallingSdk && voiceVideoCallingSdk.isInACall()) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             callId = (voiceVideoCallingSdk as any).callId;


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### 3851573 [v2] LCW closeChat methods throws exception

### Description
getVoiceVideoCalling() In omnichannel sdk file was throwing exception when user closes chat.



## Solution Proposed
Added fix to this issue by adding isVoiceVideoCallingEnabled() in omnichannel sdk and when it is enabled we will be calling  getVoiceVideoCalling() method in omnichannel chat widget.

### Acceptance criteria
When user close chat it shouldn't throw an exception about a "Feature disabled".

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

https://github.com/microsoft/omnichannel-chat-widget/assets/128818969/bcc196df-d036-4c16-8808-d9008e6084ac


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__