### PR TITLE
BUG-3814814: Fixed high contrast aquatic mode Download button to show…

### DIFF
--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultAttachmentDownloadIconStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/defaultStyles/defaultAttachmentDownloadIconStyles.ts
@@ -3,5 +3,5 @@ export const defaultAttachmentDownloadIconStyles: React.CSSProperties = {
     width: "12px",
     marginLeft: "auto !important", 
     padding: "2px !important",
-    fill: "#000000 !important"
+    fill: "#000000"
 };


### PR DESCRIPTION
… in the Chat window

## **Thank you for your contribution. Before submitting this PR, please include:**

### BUG-3814814

### Description
In high contrast aquatic mode "Download" button for the uploaded attachments, are not clearly visible on the Chat Page inside the chat window.

## Solution Proposed
Removed !important from the fill property because it was creating conflict with the other fill without important

### Acceptance criteria
On changing the System Contrast Themes (to aquatic or any other), Download icon should always be visible

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [X ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, 
Not on Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__

## Evidence
![BUG-3814814](https://github.com/microsoft/omnichannel-chat-widget/assets/105889689/b92155ed-1aac-4686-9b8b-f9ab4a10d68a)
