### PR TITLE
3929782 : Narrator/JAWS is announcing the entire content present in pre chat

### DIFF
--- a/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultPreChatSurveyPaneControlProps.ts
+++ b/chat-components/src/components/prechatsurveypane/common/defaultProps/defaultPreChatSurveyPaneControlProps.ts
@@ -1,10 +1,10 @@
-import { Ids } from "../../../../common/Constants";
 import { IPreChatSurveyPaneControlProps } from "../../interfaces/IPreChatSurveyPaneControlProps";
+import { Ids } from "../../../../common/Constants";
 
 export const defaultPreChatSurveyPaneControlProps: IPreChatSurveyPaneControlProps = {
     id: Ids.DefaultPreChatSurveyPaneId,
     dir: "auto",
-    role: "alert",
+    role: "form",
     hidePreChatSurveyPane: false,
     adaptiveCardHostConfig: "{\"fontFamily\":\"Segoe UI, Helvetica Neue, sans-serif\",\"containerStyles\":{\"default\":{\"foregroundColors\":{\"default\":{\"default\":\"#000000\"}},\"backgroundColor\":\"#FFFFFF\"}},\"actions\":{\"actionsOrientation\":\"Vertical\",\"actionAlignment\":\"stretch\"}}",
     payload: "{\"$schema\":\"http://adaptivecards.io/schemas/adaptive-card.json\",\"type\":\"AdaptiveCard\",\"version\":\"1.1\",\"body\":[{\"type\":\"TextBlock\",\"weight\":\"bolder\",\"text\":\"Please answer below questions.\"},{\"type\":\"Input.Text\",\"id\":\"1e5e4e7a-8f0b-ec11-b6e6-000d3a305d38\",\"label\":\"name pls?\",\"maxLength\":100,\"isRequired\":true,\"errorMessage\":\"Name is required\"},{\"type\":\"Input.Text\",\"id\":\"7f8f5d6d-995e-ec11-8f8f-000d3a31376e\",\"label\":\"multi\\nmulti\\nmulti\",\"style\":\"text\",\"isMultiline\":true,\"maxLength\":250},{\"type\":\"Input.ChoiceSet\",\"id\":\"e4bdf7cb-995e-ec11-8f8f-000d3a31376e\",\"label\":\"options\",\"isMultiSelect\":false,\"value\":\"1\",\"style\":\"compact\",\"choices\":[{\"title\":\"one\",\"value\":\"1\"},{\"title\":\"two\",\"value\":\"2\"},{\"title\":\"three\",\"value\":\"3\"}]},{\"type\":\"Input.Toggle\",\"id\":\"b26011d2-995e-ec11-8f8f-000d3a31376e\",\"title\":\"consent\",\"valueOn\":\"True\",\"valueOff\":\"False\",\"value\":\"false\"},{\"type\":\"TextBlock\",\"isSubtle\":true,\"text\":\"Fields marked with * are mandatory.\",\"wrap\":true}],\"actions\":[{\"type\":\"Action.Submit\",\"title\":\"Submit\",\"data\":{\"Type\":\"InputSubmit\"}}]}",


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
 3929782

### Description
_Include a description of the problem to be solved_

When a prechat is present with screen reader activated, the screen reader narrates the whole screen with each key stroke, 

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Prechat pane contains a role as alert, which trigers the screen reader to read the whole conten with any new event, changing the role to form changes the experience , reducing the unsolicited narration and inclusion of elements.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
- screen reader limits the narration to the component in action not to the whole screen.
- experience must be the same with NVDA, JAWs and Narrator.

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/63e49569-c1c3-4d9c-a861-3abb6c045a92)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__