### PR TITLE
update sanitize resolution

### DIFF
--- a/chat-components/package.json
+++ b/chat-components/package.json
@@ -92,6 +92,7 @@
     "**/nanoid": "3.1.31",
     "**/url-parse": "1.5.9",
     "**/markdown-it": "12.3.2",
-    "**/minimist": "1.2.6"
+    "**/minimist": "1.2.6",
+    "**/sanitize-html": "2.12.1"
   }
 }

--- a/chat-components/yarn.lock
+++ b/chat-components/yarn.lock
@@ -13604,10 +13604,10 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sanitize-html@2.11.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.11.0.tgz#9a6434ee8fcaeddc740d8ae7cd5dd71d3981f8f6"
-  integrity sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==
+sanitize-html@2.11.0, sanitize-html@2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.12.1.tgz#280a0f5c37305222921f6f9d605be1f6558914c7"
+  integrity sha512-Plh+JAn0UVDpBRP/xEjsk+xDCoOvMBwQUf/K+/cBAVuTbtX8bj2VB7S1sL1dssVpykqp0/KPSesHrqXtokVBpA==
   dependencies:
     deepmerge "^4.2.2"
     escape-string-regexp "^4.0.0"


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
 3965523 upgrade sanitize-html
### Description
_Include a description of the problem to be solved_
- CVE reported for sanitize-html below 2.12.1, which is included as part of webchat framework

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
- set resolution for dependency to 2.12.1

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
- Widget Loads and keep sanitization for html
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/9b8b8897-becf-4eb8-9d84-abc8213842f3)



### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__