### PR TITLE
Fix webchat composer userID

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix systems messages are not being part of markdown rendering for active links
+- Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
 
 ## [1.6.3] 2024-04-02
 

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -132,6 +132,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
     // Initialize the remaining Web Chat props
     const webChatProps: IWebChatProps = {
         ...defaultWebChatContainerStatefulProps.webChatProps,
+        userID: state.domainStates.chatToken?.visitorId || "teamsvisitor",
         dir: state.domainStates.globalDir,
         locale: changeLanguageCodeFormatForWebChat(getLocaleStringFromId(state.domainStates.liveChatConfig?.ChatWidgetLanguage?.msdyn_localeid)),
         store: webChatStore,

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -675,6 +675,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             <DraggableChatWidget {...chatWidgetDraggableConfig}>
                 <Composer
                     {...webChatProps}
+                    userID={state.domainStates.chatToken?.visitorId || "teamsvisitor"}
                     styleOptions={{
                         ...webChatStyles,
                         bubbleBackground: props.webChatContainerProps?.adaptiveCardStyles?.background ?? defaultAdaptiveCardStyles.background,

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -675,7 +675,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             <DraggableChatWidget {...chatWidgetDraggableConfig}>
                 <Composer
                     {...webChatProps}
-                    userID={state.domainStates.chatToken?.visitorId || "teamsvisitor"}
                     styleOptions={{
                         ...webChatStyles,
                         bubbleBackground: props.webChatContainerProps?.adaptiveCardStyles?.background ?? defaultAdaptiveCardStyles.background,


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
Bug #3983345

### Description
- `suggestedActions` containing `to` property are not rendered due to the `userID` does not match with the one specified in `suggestedActions`

## Solution Proposed
- `userID` props needed to be added to `Composer` which represents the customer user id and is the same `id` as the one specified in `suggestedActions`

### Acceptance criteria
- `suggestedActions` with `to` should be rendered 

## Test cases and evidence
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/8888565/9775eafb-0420-4107-8ca6-e62d739e3f6f)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__