### PR TITLE
chat sets the conversation state to OutOfOffice when OOOH

### DIFF
--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -315,6 +315,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
+            // If chat is out of operating hours chat widget sets the conversation state to OutOfOffice.
+            if (props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
+                state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+                dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
+                return;
+            }
             // If the startChat event is not initiated by the same tab. Ignore the call
             if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
                 return;


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### BUG-3942475

### Description
ChatSDK.startChat()` would return 400 if being called during out of operating hours.

## Solution Proposed
Added a condition that if chat is out of operating hours, chat widget sets the conversation state to OutOfOffice and returns if the condition is met preventing it from throwing 400 by not calling ChatSDK.startChat()

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [X] You have tested all changes in Popout mode
-   [X] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox
-   not on  Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__

[OOOH_BUG.webm](https://github.com/microsoft/omnichannel-chat-widget/assets/105889689/94488ae8-acac-4f5f-9dcf-31be9ae31bd1)
