### PR TITLE
Support dynamic style customization for System messages

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,12 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+
 ### Changed
 
 - Uptake [@microsoft/omnichannel-chat-components@1.1.5](https://www.npmjs.com/package/@microsoft/omnichannel-chat-components/v/1.1.5)
 
 ### Fixed
-
+- Fix system message dynamic themeing capability
 - Fix systems messages are not being part of markdown rendering for active links
 - Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -585,6 +585,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         handleChatDisconnect(props, state, setWebChatStyles);
     }, [state.appStates.chatDisconnectEventReceived]);
 
+
+    // if props state gets updates we need to update the renderingMiddlewareProps in the state
+    useEffect(() => { 
+        dispatch({ type: LiveChatWidgetActionType.SET_RENDERING_MIDDLEWARE_PROPS, payload: props.webChatContainerProps?.renderingMiddlewareProps });
+    }, [props.webChatContainerProps?.renderingMiddlewareProps]);
+
+
+
     const initiateEndChatOnBrowserUnload = () => {
         TelemetryHelper.logActionEvent(LogLevel.INFO, {
             Event: TelemetryEvent.BrowserUnloadEventStarted,

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { IStackStyles, Stack } from "@fluentui/react";
+import { IStackStyles, Stack, IRawStyle } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
 
@@ -203,8 +203,12 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
         .webchat__bubble:not(.webchat__bubble--from-user) .webchat__bubble__content {
             border-radius: 0 !important; /* Override border-radius */
         }
+
+        .webchat__stacked-layout_container>div {
+            background: ${(props?.webChatContainerProps?.containerStyles as IRawStyle)?.background?? ""}
+        }
         `}</style>
-        <Stack styles={containerStyles}>
+        <Stack styles={containerStyles} className="webchat__stacked-layout_container">
             <BasicWebChat></BasicWebChat>
         </Stack>
         </>


### PR DESCRIPTION

ID: https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3988316

### Description
Problem Statement:
SxG, when they switch the theme to dark mode dynamically, they are not able to change the colors of the system messages, so it is unreadable and does not pass accessibility tests.


Ask:
SxG has a fast-follow ask to be able to edit the system messages in the WebChat container "An agent will be with you in just a minute." dynamically. 

They want to be able to change the color, and size of the font for all system messages.

P0- is be able to different color and size of fonts to apply these settings for all the messages.

P1 - font family, font style


## Solution Proposed
Added new useEffect react hook in liveChatWidgetStatefull class which will monitor updates to props object. When 
SDK.updateCustomizationProperties is called with new props, newly added useEffect will be called and it will then call the dispatch method to update the state variable SET_RENDERING_MIDDLEWARE_PROPS

### Acceptance criteria
User able to dynamically update the system message color,fonts, font family, font style etc

## Test cases and evidence
https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/3922332

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/15a6e822-b1e9-4820-a381-0de3190827ca)

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/36253f82-e5fe-4aa8-ae8d-d2c241221509)

### Sanity Tests
-   [x] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__