### PR TITLE
3988767 persistent postsurvey

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix for handling properly close chat for persistent chat with postsurvey
+
 ### Changed
 - reverted - Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
 

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -83,18 +83,6 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
             return;
         }
 
-        /**
-        if (isValidCloseChatForPersistent(props?.chatConfig, state)) {
-            // enforcing closeChat , and not showing post chat survey
-            await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, true, false, true);
-        } else {
-            await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, false, true, true);
-            // Initiate post chat render
-            if (postchatContext) {
-                await initiatePostChat(props, conversationDetails, state, dispatch, postchatContext);
-                return;
-            }
-        }*/
     } catch (error) {
         TelemetryHelper.logActionEvent(LogLevel.ERROR, {
             Event: TelemetryEvent.EndChatFailed,
@@ -123,13 +111,21 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
  */
 const isValidCloseChatForPersistent = (chatConfig?: ChatConfig, state?: ILiveChatWidgetContext) => {
 
-    if (!chatConfig || !state?.appStates?.conversationEndedBy) {
-        return false;
-    }
-    
     const persistentEnabled = isPersistentEnabled(chatConfig);
-    const endedByCustomer = state?.appStates?.conversationEndedBy == "Customer" ? true : false;
-    return !endedByCustomer && persistentEnabled;
+
+    if (!persistentEnabled) {
+        // if persistent is not enabled, then show survey
+        return true;
+    } else {
+        const endedByCustomer = state?.appStates?.conversationEndedBy == "Customer" ? true : false;
+
+        // if persistent is enabled , but it was ended by customer, then don't show survey
+        if (endedByCustomer) {
+            return false;
+        }
+        // any other actor, end chat and show survey
+        return true;
+    }
 };
 
 

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -75,7 +75,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
             });
         }
 
-        const persistentEnabled = isPersistentEnabled(chatSDK.chatConfig);
+        const persistentEnabled = isPersistentEnabled(props.chatConfig);
         const inMemory = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: undefined });
         const endedByCustomer = inMemory?.appStates?.conversationEndedBy === "Customer";
 
@@ -117,7 +117,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, setWebChatStyles: any, adapter: any,
     skipEndChatSDK?: boolean, skipCloseChat?: boolean, postMessageToOtherTab?: boolean) => {
-
+    
     if (!skipEndChatSDK && chatSDK.conversation) {
         try {
             TelemetryHelper.logSDKEvent(LogLevel.INFO, {

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -77,6 +77,8 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
 
         const shouldCloseAndPresentSurvey = isValidCloseChatForPersistent(props?.chatConfig, state);
 
+        console.log("ELOPEZANAYA :: shouldCloseAndPresentSurvey", shouldCloseAndPresentSurvey);
+
         await endChat(props, chatSDK, state, dispatch, setAdapter, setWebChatStyles, adapter, shouldCloseAndPresentSurvey, !shouldCloseAndPresentSurvey, true);
         if (postchatContext && shouldCloseAndPresentSurvey) {
             await initiatePostChat(props, conversationDetails, state, dispatch, postchatContext);


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
3988767
### Description
_Include a description of the problem to be solved_
When a persistent chat is closed from the customer side, is presenting the postsurvey.

The conversation should be ended and survey presented only when agent ends the conversation.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Handle end close workflow for persistent chat when closed by the customer

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
- close chat for persistent chat should present the survey only when ended by the agent
- when ended by customer should not end the chat or present survey

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

- persistent chat , ended by agent should present survey
- persistent chat, ended by customer should not present survey
- close chat with SDK event should act the same as the button
- validate no persistent chat scenarios

- normal chat, insert link (ended by agent and ended by customer)
- 
<img width="213" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/5651bbf3-26f6-42b6-9f1b-68121e22a8bc">

- normal chat, embedded (ended by agent and ended by customer)
 
<img width="223" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/981914/57f18bb1-2a18-4550-921d-9fa3212d04ad">


[Recording-20240426_183409.webm](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/aee64d7f-a2cc-4f85-838b-5f155c2fb7da)

- normal chat validated

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__