### PR TITLE
Users/mithunj/revert webchat composer userid fix

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,8 +6,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
-
 ## [1.6.4] 2024-04-29
 
 ### Changed

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- reverted the webchat-composer-userid-fix
+- reverted - Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
 
 ## [1.6.4] 2024-04-29
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- reverted the webchat-composer-userid-fix
 
 ## [1.6.4] 2024-04-29
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,6 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- reverted - Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
 
 ## [1.6.4] 2024-04-29
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- reverted - Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
+
 ## [1.6.4] 2024-04-29
 
 ### Changed

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17,7 +17,6 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fix system message dynamic themeing capability
 - Fix systems messages are not being part of markdown rendering for active links
-- Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
 
 ## [1.6.3] 2024-04-02
 

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -132,7 +132,6 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
     // Initialize the remaining Web Chat props
     const webChatProps: IWebChatProps = {
         ...defaultWebChatContainerStatefulProps.webChatProps,
-        userID: state.domainStates.chatToken?.visitorId || "teamsvisitor",
         dir: state.domainStates.globalDir,
         locale: changeLanguageCodeFormatForWebChat(getLocaleStringFromId(state.domainStates.liveChatConfig?.ChatWidgetLanguage?.msdyn_localeid)),
         store: webChatStore,


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
reverting the change Edward made which passes user id to webchat composer component

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__