### PR TITLE
Fix webchat composer to retrieve userid

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 
 - Uptake [@microsoft/omnichannel-chat-sdk@1.8.2](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.8.2)
 
+### Changed
+
+- Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`
 
 ### Fixed
 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -653,6 +653,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     const directLine = livechatProps.webChatContainerProps?.directLine ?? adapter ?? defaultWebChatContainerStatefulProps.directLine;
     const userID = directLine.getState? directLine?.getState("acs.userId"): "teamsvisitor";
+
+    // WebChat's Composer can only be rendered if a directLine object is defined
     return directLine && (
         <>
             <style>{`

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -651,7 +651,9 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         draggable: props.draggableChatWidgetProps?.disabled !== true // Draggable by default, unless explicitly disabled
     };
 
-    return (
+    const directLine = livechatProps.webChatContainerProps?.directLine ?? adapter ?? defaultWebChatContainerStatefulProps.directLine;
+    const userID = directLine.getState? directLine?.getState("acs.userId"): "teamsvisitor";
+    return directLine && (
         <>
             <style>{`
             ::-webkit-scrollbar {
@@ -683,12 +685,13 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             <DraggableChatWidget {...chatWidgetDraggableConfig}>
                 <Composer
                     {...webChatProps}
+                    userID={userID}
                     styleOptions={{
                         ...webChatStyles,
                         bubbleBackground: props.webChatContainerProps?.adaptiveCardStyles?.background ?? defaultAdaptiveCardStyles.background,
                         bubbleTextColor: props.webChatContainerProps?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color
                     }}
-                    directLine={livechatProps.webChatContainerProps?.directLine ?? adapter ?? defaultWebChatContainerStatefulProps.directLine}>
+                    directLine={directLine}>
                     <Stack
                         id={widgetElementId}
                         styles={generalStyles}


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
Bug #3983345

### Description
- `suggestedActions` containing `to` property are not rendered due to the `userID` does not match with the one specified in `suggestedActions`

## Solution Proposed
- `userID` props needed to be added to `Composer` which represents the customer user id and is the same `id` as the one specified in `suggestedActions`

### Acceptance criteria
- `suggestedActions` with `to` should be rendered 

## Test cases and evidence
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/8888565/9775eafb-0420-4107-8ca6-e62d739e3f6f)
tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

Post Chat Survey Link Mode
<img width="272" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/8888565/349866bb-6dc1-4db1-b05b-45af8314f411">

Post Chat Survey Embed Mode
<img width="269" alt="image" src="https://github.com/microsoft/omnichannel-chat-widget/assets/8888565/fcb13427-0cce-46f0-bbdd-1687369482a8">

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__