### PR TITLE
Removed problematic emoji character short cut code from default emoji map

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix for handling properly close chat for persistent chat with postsurvey
+- Fix for emoji characters showing for combination like :0 and :-0
 
 ### Changed
 - reverted - Fix `suggestedActions` with `to` property not rendering by passing `userID` to `Composer`

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
@@ -1,6 +1,6 @@
 import { StyleOptions } from "botframework-webchat-api";
 
-export const  defaultWebChatStyles: StyleOptions = {
+export const defaultWebChatStyles: StyleOptions = {
     avatarSize: 32,
     backgroundColor: "#F7F7F9",
     botAvatarBackgroundColor: "#315FA2",

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
@@ -1,6 +1,6 @@
 import { StyleOptions } from "botframework-webchat-api";
 
-export const defaultWebChatStyles: StyleOptions = {
+export const    : StyleOptions = {
     avatarSize: 32,
     backgroundColor: "#F7F7F9",
     botAvatarBackgroundColor: "#315FA2",
@@ -31,28 +31,28 @@ export const defaultWebChatStyles: StyleOptions = {
     suggestedActionsStackedOverflow: "scroll" as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     typingAnimationDuration: 3500,
     emojiSet: {
-        ':)': '😊',
-        ':-)': '😊',
-        '(:': '😊',
-        '(-:': '😊',
-        ':-|': '😐',
-        ':|': '😐',
-        ':-(': '☹️',
-        ':(': '☹️',
-        ':-D': '😀',
-        ':D': '😀',
-        ':-p': '😛',
-        ':p': '😛',
-        ':-P': '😛',
-        ':P': '😛',
-        ':-o': '😲',
-        ':o': '😲',
-        ':O': '😲',
-        ':-O': '😲',
-        ';-)': '😉',
-        ';)': '😉',
-        '<3': '❤️',
-        '</3': '💔',
-        '<\\3': '💔'
+        ":)": "😊",
+        ":-)": "😊",
+        "(:": "😊",
+        "(-:": "😊",
+        ":-|": "😐",
+        ":|": "😐",
+        ":-(": "☹️",
+        ":(": "☹️",
+        ":-D": "😀",
+        ":D": "😀",
+        ":-p": "😛",
+        ":p": "😛",
+        ":-P": "😛",
+        ":P": "😛",
+        ":-o": "😲",
+        ":o": "😲",
+        ":O": "😲",
+        ":-O": "😲",
+        ";-)": "😉",
+        ";)": "😉",
+        "<3": "❤️",
+        "</3": "💔",
+        "<\\3": "💔"
       }
 };

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
@@ -1,6 +1,6 @@
 import { StyleOptions } from "botframework-webchat-api";
 
-export const    : StyleOptions = {
+export const  defaultWebChatStyles: StyleOptions = {
     avatarSize: 32,
     backgroundColor: "#F7F7F9",
     botAvatarBackgroundColor: "#315FA2",

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
@@ -54,5 +54,5 @@ export const defaultWebChatStyles: StyleOptions = {
         "<3": "❤️",
         "</3": "💔",
         "<\\3": "💔"
-      }
+    }
 };

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
@@ -29,5 +29,30 @@ export const defaultWebChatStyles: StyleOptions = {
     showAvatarInGroup: true,
     suggestedActionsStackedHeight: 125,
     suggestedActionsStackedOverflow: "scroll" as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    typingAnimationDuration: 3500
+    typingAnimationDuration: 3500,
+    emojiSet: {
+        ':)': '😊',
+        ':-)': '😊',
+        '(:': '😊',
+        '(-:': '😊',
+        ':-|': '😐',
+        ':|': '😐',
+        ':-(': '☹️',
+        ':(': '☹️',
+        ':-D': '😀',
+        ':D': '😀',
+        ':-p': '😛',
+        ':p': '😛',
+        ':-P': '😛',
+        ':P': '😛',
+        ':-o': '😲',
+        ':o': '😲',
+        ':O': '😲',
+        ':-O': '😲',
+        ';-)': '😉',
+        ';)': '😉',
+        '<3': '❤️',
+        '</3': '💔',
+        '<\\3': '💔'
+      }
 };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### 

### Description
Task ID: 4098904
 Chat Widget with a combination of: 0, the numbers change to emojis.

## Solution Proposed
We will pass new emoji set to bot-framework through defaultWebChatStyles , we will use the default emoji set in bot-framework and remove the combination which is problamatic.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4098955/
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/4f1fca6b-2c7c-45ea-a449-018c8aed8269)

### Sanity Tests
-   [x] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__