### PR TITLE
BUG-3944203-Implemented the fix for BUG-3944203

### DIFF
--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
@@ -31,6 +31,9 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
         
         if (state.appStates.isMinimized) {
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+            if (state.appStates.conversationState === ConversationState.Closed) {
+                await startChat();
+            }
         } else {
             await startChat();
         }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

###Issue Id: BUG-3944203

### Description
BUG-3944203: Minimize state preventing launch chat at first click on multitab

## Solution Proposed
Add a condition to consider ConverstationState = closed during chat window is minimized

### Acceptance criteria
Button to be launched in second at first try in the following scenario
 - Launch widget in one tab, minimize the same
 - Go to another tab, and once the button is loaded, click on the button just once 

## Test cases and evidence
_Included in the ticket BUG-3944203

### Sanity Tests
-   [ Y] You have tested all changes in Popout mode
-   [Y ] You have tested all changes in cross browsers i.e Edge and Chrome
