### PR TITLE
prechat payload from survey props get used when submitting response

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Fixed
 
+### Fixed
+- Prechat payload from survey props get used when submitting response.
 - Fixed external link icon color css issue for markdown messages.
 
 ## [1.7.0] 2024-05-30

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -64,7 +64,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
 
     // Getting prechat Survey Context
     const parseToJson = false;
-    const preChatSurveyResponse: string = await chatSDK.getPreChatSurvey(parseToJson);
+    const preChatSurveyResponse: string = props?.preChatSurveyPaneProps?.controlProps?.payload ?? await chatSDK.getPreChatSurvey(parseToJson);
     const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
 
     if (showPrechat) {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

(https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4147873)

### Description
When user using prechat that is passed through surveyprops, while submitting the prechat survey, logic used to compute the survey response uses the prechat payload retrieved from getChatConfig

## Solution Proposed
check for the prechat payload in surveyprops when check if prechat is needed or not. Then it will be used as the payload through our the lcw lifecycle

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/4715188c-8a68-46b1-95a0-a59ad61838c4)

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/fe566b04-ce15-4917-ab8c-bd1c08a356b3)

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/fba95a7e-26ca-418d-86ca-00a7296db38e)


### Sanity Tests
-   [x] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__