### PR TITLE
Logical gate to avoid multiple calls  to getLiveWorkItemDetails

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed an issue allowing multiple listeners to execute multiple times for the same event (GetLiveWorkItemDetail)
 - Fixed external link icon color css issue for markdown messages.
 
 ## [1.7.0] 2024-05-30

--- a/chat-widget/src/common/utils.ts
+++ b/chat-widget/src/common/utils.ts
@@ -2,13 +2,13 @@ import { AriaTelemetryConstants, Constants, HtmlAttributeNames, LocaleConstants 
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "./telemetry/TelemetryConstants";
 
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
+import { ChatSDKErrorName } from "@microsoft/omnichannel-chat-sdk";
 import { DataStoreManager } from "./contextDataStore/DataStoreManager";
 import { ICustomEvent } from "@microsoft/omnichannel-chat-components/lib/types/interfaces/ICustomEvent";
 import { ITimer } from "./interfaces/ITimer";
 import { KeyCodes } from "./KeyCodes";
 import { Md5 } from "md5-typescript";
 import { TelemetryHelper } from "./telemetry/TelemetryHelper";
-import { ChatSDKErrorName } from "@microsoft/omnichannel-chat-sdk";
 
 const getElementBySelector = (selector: string | HTMLElement) => {
     let element: HTMLElement;
@@ -371,7 +371,14 @@ export const debounceLeading = (fn: any, ms = 3000) => {
         timeoutId = setTimeout(() => { timeoutId = null; }, ms);
     };
 };
+export const isThisSessionPopout = (href: string): boolean => {
 
+    if (href?.includes("open-in-window=true") && !window?.location?.href?.includes("is-popout-mode=true")) {
+        return true;
+    }
+
+    return false;
+};
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getConversationDetailsCall = async (chatSDK: any, liveChatContext: any = null) => {
     let conversationDetails: any = undefined; // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -4,6 +4,8 @@ import { Components, StyleOptions } from "botframework-webchat";
 import { ConfirmationState, Constants, ConversationEndEntity, E2VVOptions, LiveWorkItemState, PrepareEndChatDescriptionConstants, StorageType } from "../../../common/Constants";
 import { IStackStyles, Stack } from "@fluentui/react";
 import React, { Dispatch, useEffect, useRef, useState } from "react";
+import { TelemetryManager, TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
+import { chatSDKStateCleanUp, endChat, endChatStateCleanUp, prepareEndChat } from "../common/endChat";
 import { checkIfConversationStillValid, initStartChat, prepareStartChat, setPreChatAndInitiateChat } from "../common/startChat";
 import {
     createTimer,
@@ -19,14 +21,12 @@ import {
     setOcUserAgent
 } from "../../../common/utils";
 import { defaultClientDataStoreProvider, isCookieAllowed } from "../../../common/storage/default/defaultClientDataStoreProvider";
-import { chatSDKStateCleanUp, endChat, endChatStateCleanUp, prepareEndChat } from "../common/endChat";
 import { handleChatReconnect, isPersistentEnabled, isReconnectEnabled } from "../common/reconnectChatHelper";
 import {
     shouldShowCallingContainer,
     shouldShowChatButton,
     shouldShowConfirmationPane,
     shouldShowEmailTranscriptPane,
-    shouldShowStartChatErrorPane,
     shouldShowHeader,
     shouldShowLoadingPane,
     shouldShowOutOfOfficeHoursPane,
@@ -35,6 +35,7 @@ import {
     shouldShowPreChatSurveyPane,
     shouldShowProactiveChatPane,
     shouldShowReconnectChatPane,
+    shouldShowStartChatErrorPane,
     shouldShowWebChatContainer
 } from "../../../controller/componentController";
 
@@ -62,16 +63,19 @@ import PostChatSurveyPaneStateful from "../../postchatsurveypanestateful/PostCha
 import PreChatSurveyPaneStateful from "../../prechatsurveypanestateful/PreChatSurveyPaneStateful";
 import ProactiveChatPaneStateful from "../../proactivechatpanestateful/ProactiveChatPaneStateful";
 import ReconnectChatPaneStateful from "../../reconnectchatpanestateful/ReconnectChatPaneStateful";
+import StartChatErrorPaneStateful from "../../startchaterrorpanestateful/StartChatErrorPaneStateful";
+import { StartChatFailureType } from "../../../contexts/common/StartChatFailureType";
 import StartChatOptionalParams from "@microsoft/omnichannel-chat-sdk/lib/core/StartChatOptionalParams";
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
-import { TelemetryManager, TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
 import WebChatContainerStateful from "../../webchatcontainerstateful/WebChatContainerStateful";
 import createDownloadTranscriptProps from "../common/createDownloadTranscriptProps";
 import { createFooter } from "../common/createFooter";
 import { createInternetConnectionChangeHandler } from "../common/createInternetConnectionChangeHandler";
+import { defaultAdaptiveCardStyles } from "../../webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles";
 import { defaultScrollBarProps } from "../common/defaultProps/defaultScrollBarProps";
 import { defaultWebChatContainerStatefulProps } from "../../webchatcontainerstateful/common/defaultProps/defaultWebChatContainerStatefulProps";
 import { disposeTelemetryLoggers } from "../common/disposeTelemetryLoggers";
+import { executeReducer } from "../../../contexts/createReducer";
 import { getGeneralStylesForButton } from "../common/getGeneralStylesForButton";
 import { handleChatDisconnect } from "../common/chatDisconnectHelper";
 import { initCallingSdk } from "../common/initCallingSdk";
@@ -84,10 +88,6 @@ import { startProactiveChat } from "../common/startProactiveChat";
 import useChatAdapterStore from "../../../hooks/useChatAdapterStore";
 import useChatContextStore from "../../../hooks/useChatContextStore";
 import useChatSDKStore from "../../../hooks/useChatSDKStore";
-import { defaultAdaptiveCardStyles } from "../../webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles";
-import StartChatErrorPaneStateful from "../../startchaterrorpanestateful/StartChatErrorPaneStateful";
-import { StartChatFailureType } from "../../../contexts/common/StartChatFailureType";
-import { executeReducer } from "../../../contexts/createReducer";
 
 export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
@@ -100,6 +100,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const [voiceVideoCallingSDK, setVoiceVideoCallingSDK] = useState<any>(undefined);
     const { Composer } = Components;
     const canStartProactiveChat = useRef(true);
+    const listenerRegistered = useRef(false);
 
     // Process general styles
     const generalStyles: IStackStyles = {
@@ -120,6 +121,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const currentMessageCountRef = useRef<number>(0);
     let widgetStateEventId = "";
     const lastLWICheckTimeRef = useRef<number>(0);
+    const callInProgress = useRef<boolean>(false);
     let optionalParams: StartChatOptionalParams;
     let activeCachedChatExist = false;
 
@@ -270,6 +272,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         });
 
         BroadcastService.getMessageByEventName(BroadcastEvent.StartProactiveChat).subscribe((msg: ICustomEvent) => {
+
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.StartProactiveChatEventReceived,
                 Description: "Start proactive chat event received."
@@ -284,27 +287,34 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
         });
 
-        // Toggle chat visibility
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        BroadcastService.getMessageByEventName(BroadcastEvent.HideChatVisibilityChangeEvent).subscribe(async (event: any) => {
-            if (event?.payload?.isChatHidden !== undefined) {
-                if (props.controlProps?.hideStartChatButton) {
-                    dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: event?.payload?.isChatHidden });
-                }
-                const dateNow = Date.now();
-                if (dateNow - lastLWICheckTimeRef.current > Constants.LWICheckOnVisibilityTimeout) {
-                    const conversationDetails = await getConversationDetailsCall(chatSDK);
-                    lastLWICheckTimeRef.current = dateNow;
-                    if (conversationDetails?.state === LiveWorkItemState.WrapUp || conversationDetails?.state === LiveWorkItemState.Closed) {
-                        dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: true });
-                        TelemetryHelper.logActionEvent(LogLevel.INFO, {
-                            Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
-                            Description: "Chat disconnected due to timeout, left or removed."
-                        });
+        if (listenerRegistered.current === false) {
+
+            // Toggle chat visibility
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            BroadcastService.getMessageByEventName(BroadcastEvent.HideChatVisibilityChangeEvent).subscribe(async (event: any) => {
+                if (event?.payload?.isChatHidden !== undefined) {
+                    if (props.controlProps?.hideStartChatButton) {
+                        dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: event?.payload?.isChatHidden });
+                    }
+                    const dateNow = Date.now();
+                  
+                    if (callInProgress.current === false && (dateNow - lastLWICheckTimeRef.current) > Constants.LWICheckOnVisibilityTimeout) {
+                        lastLWICheckTimeRef.current = dateNow;
+                        callInProgress.current = true;
+                        const conversationDetails = await getConversationDetailsCall(chatSDK);
+                        if (conversationDetails?.state === LiveWorkItemState.WrapUp || conversationDetails?.state === LiveWorkItemState.Closed) {
+                            dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: true });
+                            TelemetryHelper.logActionEvent(LogLevel.INFO, {
+                                Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
+                                Description: "Chat disconnected due to timeout, left or removed."
+                            });
+                        }
+                        callInProgress.current = false;
                     }
                 }
-            }
-        });
+            });
+            listenerRegistered.current = true;
+        }
 
         /**
          * This will allow to sync multiple tabs to handle minimize and maximize state, 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -17,6 +17,7 @@ import {
     getWidgetEndChatEventName,
     isNullOrEmptyString,
     isNullOrUndefined,
+    isThisSessionPopout,
     isUndefinedOrEmpty,
     setOcUserAgent
 } from "../../../common/utils";
@@ -295,9 +296,9 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 }
                 const dateNow = Date.now();
 
-                if (window?.location?.href?.includes("open-in-window=true") && !window?.location?.href?.includes("is-popout-mode=true")) {
+                if (isThisSessionPopout(window?.location?.href)){
                     return;
-                }
+                }              
 
                 /** 
                  * callInProgress acts as "thread lock" to prevent multiple calls to getConversationDetailsCall, 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -295,14 +295,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 }
                 const dateNow = Date.now();
 
-                console.log("ELOPEZANAYA :: window?.location?.href?.includes(open-in-window=true) ", window?.location?.href?.includes("open-in-window=true"));
-                console.log("ELOPEZANAYA :: window?.location?.href?.includes(is-popout-mode=true) ", window?.location?.href?.includes("is-popout-mode=true"));
-            
                 if (window?.location?.href?.includes("open-in-window=true") && !window?.location?.href?.includes("is-popout-mode=true")) {
-                    console.warn("ELOPEZANAYA :: Popout enabled, BLOCKING current attempt from parent window");
                     return;
-                }else{
-                    console.warn("ELOPEZANAYA :: Popout disabled, ALLOWING current attempt from parent window");
                 }
 
                 /** 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -287,8 +287,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
         });
 
+        // logical gate to prevent register multiple events
         if (listenerRegistered.current === false) {
-
             // Toggle chat visibility
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             BroadcastService.getMessageByEventName(BroadcastEvent.HideChatVisibilityChangeEvent).subscribe(async (event: any) => {
@@ -298,8 +298,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                     }
                     const dateNow = Date.now();
                   
+                    // callInProgress acts as semaphore to prevent multiple calls to getConversationDetailsCall, in case of multiple switchs between tabs
                     if (callInProgress.current === false && (dateNow - lastLWICheckTimeRef.current) > Constants.LWICheckOnVisibilityTimeout) {
                         lastLWICheckTimeRef.current = dateNow;
+                        
                         callInProgress.current = true;
                         const conversationDetails = await getConversationDetailsCall(chatSDK);
                         if (conversationDetails?.state === LiveWorkItemState.WrapUp || conversationDetails?.state === LiveWorkItemState.Closed) {

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -100,9 +100,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const [voiceVideoCallingSDK, setVoiceVideoCallingSDK] = useState<any>(undefined);
     const { Composer } = Components;
     const canStartProactiveChat = useRef(true);
-    const listenerRegistered = useRef(false);
-    const failureCounter = useRef(0);
-    const requestIdInFailure = useRef<string>("");
 
     // Process general styles
     const generalStyles: IStackStyles = {
@@ -264,7 +261,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     // useEffect for custom context
     useEffect(() => {
-        console.error("ELOPEZANAYA :: **** SETTING LISTENERS **");
         // Add the custom context on receiving the SetCustomContext event
         BroadcastService.getMessageByEventName(BroadcastEvent.SetCustomContext).subscribe((msg: ICustomEvent) => {
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
@@ -275,7 +271,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         });
 
         BroadcastService.getMessageByEventName(BroadcastEvent.StartProactiveChat).subscribe((msg: ICustomEvent) => {
-            console.error("ELOPEZANAYA :: startProactiveChat event received.");
 
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.StartProactiveChatEventReceived,
@@ -291,65 +286,34 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
         });
 
-        // logical gate to prevent register multiple events
-        //  if (listenerRegistered.current === false) {
         // Toggle chat visibility
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         BroadcastService.getMessageByEventName(BroadcastEvent.HideChatVisibilityChangeEvent).subscribe(async (event: any) => {
-            console.log("ELOPEZANAYA :: HideChatVisibilityChangeEvent event received.");
-            console.error("ELOPEZANAYA :: HideChatVisibilityChangeEvent : event?.payload?.isChatHidden .", event?.payload?.isChatHidden );
-            console.error("ELOPEZANAYA :: HideChatVisibilityChangeEvent : props ", props);
-            console.error("ELOPEZANAYA :: HideChatVisibilityChangeEvent : state ", JSON.stringify(state));
-
-            console.warn("ELOPEZANAYA :: HideChatVisibilityChangeEvent : failureCounter.current .", failureCounter.current );
-            console.warn("ELOPEZANAYA :: HideChatVisibilityChangeEvent :  requestIdInFailure ", requestIdInFailure.current );
-
             if (event?.payload?.isChatHidden !== undefined) {
-
                 if (props.controlProps?.hideStartChatButton) {
                     dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: event?.payload?.isChatHidden });
                 }
                 const dateNow = Date.now();
 
-                // callInProgress acts as semaphore to prevent multiple calls to getConversationDetailsCall, in case of multiple switchs between tabs
+                console.log("ELOPEZANAYA :: window?.location?.href?.includes(open-in-window=true) ", window?.location?.href?.includes("open-in-window=true"));
+                console.log("ELOPEZANAYA :: window?.location?.href?.includes(is-popout-mode=true) ", window?.location?.href?.includes("is-popout-mode=true"));
+            
+                if (window?.location?.href?.includes("open-in-window=true") && !window?.location?.href?.includes("is-popout-mode=true")) {
+                    console.warn("ELOPEZANAYA :: Popout enabled, BLOCKING current attempt from parent window");
+                    return;
+                }else{
+                    console.warn("ELOPEZANAYA :: Popout disabled, ALLOWING current attempt from parent window");
+                }
+
+                /** 
+                 * callInProgress acts as "thread lock" to prevent multiple calls to getConversationDetailsCall, 
+                 * in case of multiple switchs between tabs
+                 */
                 if (callInProgress.current === false && (dateNow - lastLWICheckTimeRef.current) > Constants.LWICheckOnVisibilityTimeout) {
+
                     lastLWICheckTimeRef.current = dateNow;
-
                     callInProgress.current = true;
-                    if (failureCounter.current > 2) {
-                        //if failure counter is more than 2, we assume it will keep failing due to reqId not present in dataverse
-                        // this is an scenario present for parent window when pop-out mode is ON.
-                        return;
-                    }
                     const conversationDetails = await getConversationDetailsCall(chatSDK);
-                    console.log("ELOPEZANAYA ::HideChatVisibilityChangeEvent :::  conversationDetails=>", conversationDetails);
-
-                    // if conversatioin details is undefined, we assume it failed
-                    // check if conversationDetails is an empty object
-
-                    if ((conversationDetails === undefined || conversationDetails === null) || 
-                    (Object.keys(conversationDetails).length === 0 && conversationDetails.constructor === Object)) {
-                        console.error("ELOPEZANAYA :: HideChatVisibilityChangeEvent : ****** conversationDetails is undefined. ****");
-                        const reqId = props.chatSDK.requestId;
-                        const hideStartButton = props.controlProps?.hideStartChatButton;
-                        console.warn("ELOPEZANAYA :: HideChatVisibilityChangeEvent : hideStartButton =>", hideStartButton);
-                        console.warn("ELOPEZANAYA :: HideChatVisibilityChangeEvent : reqId =>", reqId);
-
-
-                        if (hideStartButton === false) {
-                            const sameReqId = requestIdInFailure.current === reqId;
-                            if (sameReqId) {
-                                failureCounter.current++;
-
-                            }else{
-                                requestIdInFailure.current = reqId;
-                                failureCounter.current = 1;
-                            }
-                        }
-                        console.log("ELOPEZANAYA :: HideChatVisibilityChangeEvent : conversationDetails is undefined. Calling startChat.");
-                    }else{
-                        console.warn("ELOPEZANAYA :: HideChatVisibilityChangeEvent : conversationDetails present =>.",conversationDetails);
-                    }
 
                     if (conversationDetails?.state === LiveWorkItemState.WrapUp || conversationDetails?.state === LiveWorkItemState.Closed) {
                         dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: true });
@@ -362,21 +326,17 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 }
             }
         });
-        listenerRegistered.current = true;
-        //elopez }
 
         /**
          * This will allow to sync multiple tabs to handle minimize and maximize state, 
          * the event is expected to be emitted from scripting layer.
          */
         BroadcastService.getMessageByEventName(BroadcastEvent.SyncMinimize).subscribe((msg: ICustomEvent) => {
-            console.error("ELOPEZANAYA :: syncMinimize event received.");
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: msg?.payload?.minimized });
         });
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
-            console.error("ELOPEZANAYA :: startChat event received.");
             // If chat is out of operating hours chat widget sets the conversation state to OutOfOffice.
             if (props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
                 state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
@@ -418,10 +378,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
             // If minimized, maximize the chat
             if (inMemoryState?.appStates?.isMinimized === true) {
-
-                console.error("ELOPEZANAYA :: startChat event received. Minimized is true.");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
-
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.MaximizeChat,
                     payload: {
@@ -435,7 +392,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // End chat
         BroadcastService.getMessageByEventName(BroadcastEvent.InitiateEndChat).subscribe(async () => {
-            console.error("ELOPEZANAYA :: initiateEndChat event received.");
             TelemetryHelper.logSDKEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.EndChatEventReceived,
                 Description: "Received InitiateEndChat BroadcastEvent."
@@ -469,7 +425,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // End chat on browser unload
         BroadcastService.getMessageByEventName(BroadcastEvent.InitiateEndChatOnBrowserUnload).subscribe(() => {
-            console.error("ELOPEZANAYA :: initiateEndChatOnBrowserUnload event received.");
             initiateEndChatOnBrowserUnload();
         });
 
@@ -480,7 +435,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             props.controlProps?.widgetInstanceId ?? "");
 
         BroadcastService.getMessageByEventName(endChatEventName).subscribe((msg: ICustomEvent) => {
-            console.error("ELOPEZANAYA :: endChat event received.");
             if (msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
                 TelemetryHelper.logSDKEvent(LogLevel.INFO, {
                     Event: TelemetryEvent.PrepareEndChat,
@@ -495,13 +449,11 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         //Listen to WidgetSize, used for minimize to maximize
         BroadcastService.getMessageByEventName("WidgetSize").subscribe((msg: ICustomEvent) => {
-            console.error("ELOPEZANAYA :: WidgetSize event received.");
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_SIZE, payload: msg?.payload });
         });
 
         // Reset state variables
         BroadcastService.getMessageByEventName(BroadcastEvent.RaiseErrorEvent).subscribe(() => {
-            console.error("ELOPEZANAYA :: RaiseErrorEvent event received.");
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONFIG, payload: undefined });
             dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: undefined });
             dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: undefined });
@@ -656,7 +608,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     // Handle Chat disconnect cases
     useEffect(() => {
-        handleChatDisconnect(props, state, setWebChatStyles);
+        
+        const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
+
+        handleChatDisconnect(props, inMemoryState, setWebChatStyles);
     }, [state.appStates.chatDisconnectEventReceived]);
 
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
4153717 & 4153744 
### Description
_Include a description of the problem to be solved_

in current model, LCW each time the user switch focus among tabs , will call getLiveWorkItemdetails to corroborate the state of the conversation.

the problem relays on , the react component uses useEfffect when reloading the component to register the listener for this action, causing each time there is switch and launch the component again to register additional listener, 

in simple scenarios when customer do a couple of switches, multiple calls will be made, adding to the retry mechanism in oc-sdk, leads to the endpoint to return 400 HTTP Error code for all the calls.

each call will have 3 retries, so for an scenario of 3 switches, for the 4th switch it will perform 12 calls for the same endpoint,

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/2301f8ad-3c0f-40c5-bec6-49021c2631ad)
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/9744de64-2196-42d2-b46d-76081844c52c)


## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

- logic gate to avoid multiple register of listeners
- logic gate to avoid multiple calls colliding

__this should reduce our calls to the endpoint for a total of N^3, where N is the number of swichs among tabs__

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

- calls to getLiveWorkItemDetails when switching should honor the rules
   - do not register additional listeners
   - one call at the time 
   - honor 3 minutes wait time between calls
   - NOT calls in the parent window

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### embedded , single call when switching
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/8b5fd717-36d3-45cd-9943-ff7587453937)
### popout
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/981914/c7684527-70b5-4c21-9ad8-f020ba942ba7)
### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__