### PR TITLE
Fixed unread message count set as 0 on page refresh issue

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Prechat payload from survey props get used when submitting response.
 - Fixed external link icon color css issue for markdown messages.
+- Fixed unread message count set to 0 on page refresh issue.
 
 ## [1.7.0] 2024-05-30
 

--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
@@ -31,6 +31,7 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
         
         if (state.appStates.isMinimized) {
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+            dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
         } else {
             await startChat();
         }

--- a/chat-widget/src/components/headerstateful/HeaderStateful.tsx
+++ b/chat-widget/src/components/headerstateful/HeaderStateful.tsx
@@ -35,6 +35,7 @@ export const HeaderStateful = (props: IHeaderStatefulParams) => {
         onMinimizeClick: () => {
             TelemetryHelper.logActionEvent(LogLevel.INFO, { Event: TelemetryEvent.HeaderMinimizeButtonClicked, Description: "Header Minimize button clicked." });
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: true });
+            dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
         },
         onCloseClick: async () => {
             TelemetryHelper.logActionEvent(LogLevel.INFO, { Event: TelemetryEvent.HeaderCloseButtonClicked, Description: "Header Close button clicked." });

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -144,7 +144,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
                 const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
                 // If chat reconnect has kicked in chat state will become Active or Reconnect. So just exit, else go next
-                if (!noValidReconnectId && (inMemoryState.appStates.conversationState === ConversationState.Active 
+                if (!noValidReconnectId && (inMemoryState.appStates.conversationState === ConversationState.Active
                     || inMemoryState.appStates.conversationState === ConversationState.ReconnectChat)) {
                     return true;
                 }
@@ -326,7 +326,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
                 return;
             }
-            
+
             if (msg?.payload?.customContext) {
                 TelemetryHelper.logActionEvent(LogLevel.INFO, {
                     Event: TelemetryEvent.CustomContextReceived,
@@ -334,7 +334,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 });
                 dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: msg?.payload?.customContext });
             }
-            
+
             TelemetryHelper.logActionEvent(LogLevel.INFO, {
                 Event: TelemetryEvent.StartChatEventRecevied,
                 Description: "Start chat event received."
@@ -377,7 +377,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 Event: TelemetryEvent.EndChatEventReceived,
                 Description: "Received InitiateEndChat BroadcastEvent."
             });
-            
+
             // This is to ensure to get latest state from cache in multitab
             const persistedState = getStateFromCache(getWidgetCacheIdfromProps(props));
 
@@ -387,7 +387,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 // We need to simulate states for closing chat, in order to messup with close confirmation pane.
                 dispatch({ type: LiveChatWidgetActionType.SET_CONFIRMATION_STATE, payload: ConfirmationState.Ok });
                 dispatch({ type: LiveChatWidgetActionType.SET_SHOW_CONFIRMATION, payload: false });
-                
+
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_ENDED_BY, payload: ConversationEndEntity.Customer });
             } else {
                 const skipEndChatSDK = true;
@@ -483,15 +483,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         } else {
             setTimeout(() => ActivityStreamHandler.uncork(), 500);
         }
-
-        currentMessageCountRef.current = -1;
-        dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
-        const customEvent: ICustomEvent = {
-            elementType: ElementType.Custom,
-            eventName: BroadcastEvent.UnreadMessageCount,
-            payload: 0
-        };
-        BroadcastService.postMessage(customEvent);
+       
     }, [state.appStates.isMinimized]);
 
     // Broadcast the UnreadMessageCount state on any change.
@@ -501,6 +493,15 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 elementType: ElementType.Custom,
                 eventName: BroadcastEvent.UnreadMessageCount,
                 payload: `${state.appStates.unreadMessageCount}`
+            };
+            BroadcastService.postMessage(customEvent);
+        }
+        if (state.appStates.unreadMessageCount === 0) {
+            currentMessageCountRef.current = -1;
+            const customEvent: ICustomEvent = {
+                elementType: ElementType.Custom,
+                eventName: BroadcastEvent.UnreadMessageCount,
+                payload: 0
             };
             BroadcastService.postMessage(customEvent);
         }
@@ -594,7 +595,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
 
     // if props state gets updates we need to update the renderingMiddlewareProps in the state
-    useEffect(() => { 
+    useEffect(() => {
         dispatch({ type: LiveChatWidgetActionType.SET_RENDERING_MIDDLEWARE_PROPS, payload: props.webChatContainerProps?.renderingMiddlewareProps });
     }, [props.webChatContainerProps?.renderingMiddlewareProps]);
 
@@ -639,7 +640,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         },
         props.webChatContainerProps);
 
-    const livechatProps = {...props, downloadTranscriptProps};
+    const livechatProps = { ...props, downloadTranscriptProps };
 
     const chatWidgetDraggableConfig = {
         elementId: widgetElementId,
@@ -654,7 +655,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     const headerDraggableConfig = {
         draggableEventChannel: chatWidgetDraggableConfig.channel ?? "lcw",
-        draggableEventEmitterTargetWindow: props.draggableChatWidgetProps?.targetIframe? window.parent: window,
+        draggableEventEmitterTargetWindow: props.draggableChatWidgetProps?.targetIframe ? window.parent : window,
         draggable: props.draggableChatWidgetProps?.disabled !== true // Draggable by default, unless explicitly disabled
     };
 
@@ -662,7 +663,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     setOcUserAgent(chatSDK);
 
     const directLine = livechatProps.webChatContainerProps?.directLine ?? adapter ?? defaultWebChatContainerStatefulProps.directLine;
-    const userID = directLine.getState? directLine?.getState("acs.userId"): "teamsvisitor";
+    const userID = directLine.getState ? directLine?.getState("acs.userId") : "teamsvisitor";
 
     // WebChat's Composer can only be rendered if a directLine object is defined
     return directLine && (


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
BUG 4130007 https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4130007/
### Description
When an agent sends a message, the customer gets the message and an alert shows up with the button is minimized.
There is a red dot with the number of messages unread on the chat bubble. 
When the page refreshes on chat page, the alert bubble goes away.

## Solution Proposed
When we reload page at that time we call the useeffect[state.appStates.isMinimized] in and setting count to 0 
https://github.com/microsoft/omnichannel-chat-widget/blob/9703140600a371e1d3816d988649a1ec4932fd98/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx#L488
1.removed Dispatch SET_UNREAD_MESSAGE_COUNT to 0 from useEffect[state.appStates.isMinimized]
2.Dispatch SET_UNREAD_MESSAGE_COUNT to 0 when user minimize/restore the chat
3. when unreadMessageCount state goes to 0 set currentMessageCountRef.current = -1; (to reset counter to 0)


### Acceptance criteria
When the page refreshes on chat page, the alert bubble should be present with unread message count

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ y] You have tested all changes in Popout mode
-   [ y] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ y] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)

### proof
https://github.com/microsoft/omnichannel-chat-widget/assets/128818969/a35d3f5e-eaeb-4e7a-aff7-1abf50d3b51f


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

Proofs
__*Please provide justification if any of the validations has been skipped.*__