### PR TITLE
Fixed click issue when chat is minimized in multiple tabs

### DIFF
--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
@@ -32,6 +32,10 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
         if (state.appStates.isMinimized) {
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
+            // If chat is minimized and then unminimized, start a chat if convesation state is closed
+            if (state.appStates.conversationState === ConversationState.Closed) {
+                await startChat();
+            }
         } else {
             await startChat();
         }

--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
@@ -32,7 +32,7 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
         if (state.appStates.isMinimized) {
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
-            // If chat is minimized and then unminimized, start a chat if convesation state is closed
+            // If chat is minimized and then unminimized, start a chat if convesation state is closed.
             if (state.appStates.conversationState === ConversationState.Closed) {
                 await startChat();
             }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/3944203

### Description
_Click issues: Chat button not responding when popup chat was closed after it starts the first time and click issues on the multitab after chat window is minimized_

## Solution Proposed
_Chat button not responding when popup chat was closed: In the Eventlistner we added combination check that popup window is not closed along with already existing check that popout window exists. This ensures that when chat is closed the control goes to popoutHandler_

_Click issues on the multitab after chat window is minimized: In the ChatbuttonStateful, we added an additional condition to start a chat inside existing check that if chat is minimized, action is dispatched to unminimize. Added a check if the current state of conversation is closed then start a chat_

### Acceptance criteria
_focus method on popup chat is only called when both the conditions are met_
_Check if the conversation state is closed, start new chat_

## Test cases and evidence
_TEST CASE 4136913
TEST CASE 4136821
TEST CASE 4149194_

### Sanity Tests
-   [ X] You have tested all changes in Popout mode
-   [ X] You have tested all changes in cross browsers i.e Edge, Chrome, 
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*This fix is implemented by Rakshitha Bhalal*__