### PR TITLE
fixing disable strike through in markdown

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -34,6 +34,10 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
             "html_inline", // Rule to process html tags
             "newline" // Rule to proceess '\n'
         ]);
+
+        markdown.disable([           
+            "strikethrough"           
+        ]);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
https://portal.microsofticm.com/imp/v3/incidents/incident/520687988/summary

### Description
Disabling strikethrough markdown 

## Solution Proposed
This was already fixed in v1 but not in v2, fix is implemented in createMarkdown class of omni-channel-widget

### Acceptance criteria


## Test cases and evidence
![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/a4ba1f7f-6427-4f90-abf6-13291fb51c1a)

![image](https://github.com/microsoft/omnichannel-chat-widget/assets/63024526/d77c5f08-10b1-4307-9d00-0bda1ce1758a)


### Sanity Tests
-   [x] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__