### PR TITLE
Handle retrieval an authenticated chat conversation

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Add disclaimer note for prechat sample.
 - Uptake [@microsoft/omnichannel-chat-sdk@1.9.3](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.9.3)
-- Changed authentication token error handling to issue warnings instead of errors.
+- Updated `handleStartChatError` to log `AuthenticatedChatConversationRetrievalFailure` as warning using `logWidgetLoadCompleteWithError`.
+- Changes telemetry logging to WARN instead of ERROR.
 
 ## [1.7.1] 2024-06-21
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Add disclaimer note for prechat sample.
 - Uptake [@microsoft/omnichannel-chat-sdk@1.9.3](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.9.3)
+- Changed authentication token error handling to issue warnings instead of errors.
 
 ## [1.7.1] 2024-06-21
 

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -58,7 +58,7 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
             case ChatSDKErrorName.ClosedConversation:
                 handleInvalidOrClosedConversation(dispatch, chatSDK, props, ex);
                 return;
-            default:                
+            default:
                 logWidgetLoadFailed(ex);
         }
     }

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -50,12 +50,15 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
             case ChatSDKErrorName.UninitializedChatSDK:
                 handleUninitializedChatSDK(ex);
                 break;
+            // Handle the case indicating failure to retrieve an authenticated chat conversation 
+            case ChatSDKErrorName.AuthenticatedChatConversationRetrievalFailure:
+                logWidgetLoadCompleteWithError(ex);
+                break;
             case ChatSDKErrorName.InvalidConversation:
             case ChatSDKErrorName.ClosedConversation:
                 handleInvalidOrClosedConversation(dispatch, chatSDK, props, ex);
                 return;
-            default:
-                logWidgetLoadFailed(ex);
+            default:                logWidgetLoadFailed(ex);
         }
     }
 

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -58,7 +58,8 @@ export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, 
             case ChatSDKErrorName.ClosedConversation:
                 handleInvalidOrClosedConversation(dispatch, chatSDK, props, ex);
                 return;
-            default:                logWidgetLoadFailed(ex);
+            default:                
+                logWidgetLoadFailed(ex);
         }
     }
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### BUG-3983260.

### Description
Reliability bug, that was throwing exception {"Exception":"Widget load complete with error: AuthenticatedChatConversationRetrievalFailure"} and was logged into telemetry rightfully.  It was decided that instead of logging it as error, we throw a warning instead as it is working as expected. Therefore, it is now logged as a warning for accurate logging.

## Solution Proposed
Added a case to handle this ChatSDK error of AuthenticatedChatConversationRetrievalFailure and log it as WidgetLoadComplete with error

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [X ] You have tested all changes in Popout mode
-   [X ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__

![image](https://github.com/user-attachments/assets/d428f249-c460-42aa-82d7-0f986be51031)
