### PR TITLE
adding display property to notification expand Text element

### DIFF
--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -207,6 +207,9 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
         .webchat__stacked-layout_container>div {
             background: ${(props?.webChatContainerProps?.containerStyles as IRawStyle)?.background?? ""}
         }
+        .webchat__toaster__expandText {
+            display: flex;
+        }
         `}</style>
         <Stack styles={containerStyles} className="webchat__stacked-layout_container">
             <BasicWebChat></BasicWebChat>


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
rtl direction is not working for notification expander text

## Solution Proposed
added .webchat__toaster__expandText css class into webchatcontainer statefull , where having display:flex fixes the issue

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
![image](https://github.com/user-attachments/assets/67fa8027-ecf0-4e3d-ac94-5de615f23d62)

![image](https://github.com/user-attachments/assets/d61663e4-97d8-4062-8080-cc51f759f142)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__