### PR TITLE
disabling strike through in all condition

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -34,11 +34,11 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
             "html_inline", // Rule to process html tags
             "newline" // Rule to proceess '\n'
         ]);
-
-        markdown.disable([           
-            "strikethrough"           
-        ]);
     }
+
+    markdown.disable([           
+        "strikethrough"           
+    ]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     markdown.use(MarkdownItForInline, "url_new_win", "link_open", function (tokens: any, idx: number, env: any) {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
4316203
### Description
In the original fix we added code only in the condition when disableMarkdownMessageFormatting parameter is true.
Adding this code to make it always applicable

## Solution Proposed
Added code outside of the if condition so that it is applicable in all mode

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
![image](https://github.com/user-attachments/assets/292bf195-44d7-47bc-ac22-8cfe6d4261ba)

![image](https://github.com/user-attachments/assets/df24da83-fe48-408e-a139-eba3dcc3d2e1)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__