### PR TITLE
adding fix to clean postsurvey state when ending a chat

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Updated `handleStartChatError` to log `AuthenticatedChatConversationRetrievalFailure` as warning using `logWidgetLoadCompleteWithError` instead of an error.
 
 ### Fixed
+- Cleaning postsurvey state when ending the chat.
 - Fixing disable strike through in markdown
 - checking localStorage null or undefined
 

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -163,9 +163,11 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
             });
         } finally {
             dispatch({ type: LiveChatWidgetActionType.SET_UNREAD_MESSAGE_COUNT, payload: 0 });
+            dispatch({ type: LiveChatWidgetActionType.SET_POST_CHAT_CONTEXT, payload: undefined });
             // Always allow to close the chat for embedded mode irrespective of end chat errors
             closeChatWidget(dispatch, props, state);
         }
+
     }
 
     if (postMessageToOtherTab) {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

When ending a chat with postsurvey enabled , postchat context was not being removed from localstorage, causing new chats in same browser session to use last value when sending a post survey

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

set post survey context to undefined to force the call to getsurvey invite

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

- for 2nd chat session in same session should generate its new survey invite

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

<img width="803" alt="image" src="https://github.com/user-attachments/assets/f718e093-4be6-4029-b443-85c2aa518a37">
<img width="942" alt="image" src="https://github.com/user-attachments/assets/eebfc0cd-9b16-4e54-a9a3-14d1a8a7f4b8">


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__