### PR TITLE
Add build for a react component <script>

### DIFF
--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -101,6 +101,7 @@
     "test:all": "yarn test:unit && yarn test:visual",
     "build:esm": "babel ./src --config-file ./babel.esm.config.json --out-dir lib/esm --extensions .ts,.js,.tsx --ignore **/*.test.ts,**/*.stories.tsx,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx",
     "build:cjs": "babel ./src --config-file ./babel.config.json --out-dir lib/cjs --extensions .ts,.js,.tsx --ignore **/*.test.ts,**/*.stories.tsx,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx",
+    "build:umd": "webpack --config ./webpack.umd.config.cjs",
     "verify": "yarn install && yarn build-storybook && yarn test:all && yarn build && yarn storybook",
     "testpack": "yarn build && yarn pack",
     "build-sample": "yarn build && webpack --config ./webpack.config.cjs",

--- a/chat-widget/webpack.umd.config.cjs
+++ b/chat-widget/webpack.umd.config.cjs
@@ -1,0 +1,65 @@
+/**
+ * This config is used to build a version of of the widget that can be loaded in
+ * the browser using a <script> tag, and once it's loaded, it gives you access
+ * to the LiveChatWidget react component under
+ * window.LiveChatWidget.LiveChatWidget
+ *
+ * So instead of including the LiveChatWidget react component in your app, you
+ * can load it externally, and still use it as a React component.
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const path = require("path");
+const webpack = require("webpack");
+
+const babelLoaderConfiguration = {
+    test: /\.(ts|js)x?$/,
+    use: {
+        loader: "babel-loader",
+        options: {
+            presets: [
+                "@babel/preset-env",
+                "@babel/preset-react",
+                "@babel/preset-typescript",
+            ]
+        },
+    },
+};
+
+module.exports = {
+    mode: "production",
+    entry: "./src/index.ts",
+    externals: {
+        react: "React",
+        reactdom: "ReactDOM",
+    },
+    resolve: {
+        extensions: [".tsx", ".ts", ".js", ".jsx", ".json"],
+        alias: {
+            crypto: require.resolve("crypto-browserify"),
+            stream: require.resolve("stream-browserify"),
+            vm: require.resolve("vm-browserify"),
+        },
+    },
+    module: {
+        rules: [babelLoaderConfiguration]
+    },
+    output: {
+        path: path.resolve(__dirname, "lib", "umd"),
+        filename: "out.js",
+        /**
+         * Library determines the package name in the global window. So, in this
+         * example, after this script is loaded by the browser, we can access
+         * LiveChatWidget under window.LiveChatWidget.LiveChatWidget
+         */
+        library: "LiveChatWidget",
+        libraryTarget: "umd",
+        globalObject: "this"
+    },
+    plugins: [
+        new webpack.IgnorePlugin(/^react-native$/),
+        new webpack.ProvidePlugin({
+            process: "process/browser",
+        }),
+    ],
+};


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description

Add another webpack build that builds the LiveChatWidget component into a UMD module. This will allow us to load it as a browser `<script>` tag, but still keep it as a react component that can be accessed from `window.LiveChatWidget.LiveChatWidget` when the script is done loading.

## Test cases and evidence
Works in tests in Modern Admin

### Sanity Tests

Not changing any production code. Only adding another build method that won't be running automatically at this point.

-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__