### PR TITLE
Fix Existing Persistent Chat Rendering Prechat 

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat
+
 ## [1.7.2] 09-03-2024
 
 ### Changed

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -5,3 +5,10 @@ export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> =
         ?.msdyn_postconversationsurveyenable.toString().toLowerCase();
     return postChatEnabled === "true";
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isPersistentChatEnabled = async (chatSDK: any): Promise<boolean> => {
+    const chatConfig = await chatSDK.getLiveChatConfig();
+    const conversationMode = chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode.toString().toLowerCase();
+    return conversationMode === "192350001";
+};

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -1,3 +1,5 @@
+import { ConversationMode } from "../../../common/Constants";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> => {
     const chatConfig = await chatSDK.getLiveChatConfig();
@@ -10,5 +12,5 @@ export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> =
 export const isPersistentChatEnabled = async (chatSDK: any): Promise<boolean> => {
     const chatConfig = await chatSDK.getLiveChatConfig();
     const conversationMode = chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode.toString().toLowerCase();
-    return conversationMode === "192350001";
+    return conversationMode === ConversationMode.Persistent.toString();
 };

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -8,6 +8,6 @@ export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> =
     return postChatEnabled === "true";
 };
 
-export const isPersistentChatEnabled = async (conversationMode: string): Promise<boolean> => {
-    return conversationMode.toString().toLowerCase() === ConversationMode.Persistent;
+export const isPersistentChatEnabled = async (conversationMode: string | undefined): Promise<boolean> => {
+    return conversationMode?.toString().toLowerCase() === ConversationMode.Persistent;
 };

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -1,4 +1,5 @@
 import { ConversationMode } from "../../../common/Constants";
+import { isNullOrUndefined } from "../../../common/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> => {
@@ -9,5 +10,9 @@ export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> =
 };
 
 export const isPersistentChatEnabled = async (conversationMode: string | undefined): Promise<boolean> => {
+    if (isNullOrUndefined(conversationMode)) {
+        return false;
+    }
+
     return conversationMode?.toString().toLowerCase() === ConversationMode.Persistent;
 };

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -1,5 +1,4 @@
 import { ConversationMode } from "../../../common/Constants";
-import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> => {
@@ -9,8 +8,6 @@ export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> =
     return postChatEnabled === "true";
 };
 
-export const isPersistentChatEnabled = async (state: ILiveChatWidgetContext | undefined): Promise<boolean> => {
-    const chatConfig = state?.domainStates.liveChatConfig;
-    const conversationMode = chatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode.toString().toLowerCase();
-    return conversationMode === ConversationMode.Persistent;
+export const isPersistentChatEnabled = async (conversationMode: string): Promise<boolean> => {
+    return conversationMode.toString().toLowerCase() === ConversationMode.Persistent;
 };

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -1,4 +1,5 @@
 import { ConversationMode } from "../../../common/Constants";
+import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> => {
@@ -8,9 +9,8 @@ export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> =
     return postChatEnabled === "true";
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isPersistentChatEnabled = async (chatSDK: any): Promise<boolean> => {
-    const chatConfig = await chatSDK.getLiveChatConfig();
-    const conversationMode = chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode.toString().toLowerCase();
+export const isPersistentChatEnabled = async (state: ILiveChatWidgetContext | undefined): Promise<boolean> => {
+    const chatConfig = state?.domainStates.liveChatConfig;
+    const conversationMode = chatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode.toString().toLowerCase();
     return conversationMode === ConversationMode.Persistent;
 };

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -12,5 +12,5 @@ export const isPostChatSurveyEnabled = async (chatSDK: any) : Promise<boolean> =
 export const isPersistentChatEnabled = async (chatSDK: any): Promise<boolean> => {
     const chatConfig = await chatSDK.getLiveChatConfig();
     const conversationMode = chatConfig.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode.toString().toLowerCase();
-    return conversationMode === ConversationMode.Persistent.toString();
+    return conversationMode === ConversationMode.Persistent;
 };

--- a/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
@@ -1,0 +1,19 @@
+import { isPersistentChatEnabled } from "./liveChatConfigUtils";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const shouldSetPreChatIfPersistentChat = async (chatSDK: any, showPreChat: boolean) => {
+    const persistentEnabled = await isPersistentChatEnabled(chatSDK);
+    let skipPreChat = false;
+    if (persistentEnabled) {
+        const reconnectableChatsParams = {
+            authenticatedUserToken: chatSDK.authenticatedUserToken as string
+        };
+
+        const reconnectableChatsResponse = await chatSDK.OCClient.getReconnectableChats(reconnectableChatsParams);
+        if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) { // Skip rendering prechat on existing persistent chat session
+            skipPreChat = true;
+        }
+    }
+
+    return showPreChat && !skipPreChat;
+};

--- a/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
@@ -1,9 +1,8 @@
-import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 import { isPersistentChatEnabled } from "./liveChatConfigUtils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const shouldSetPreChatIfPersistentChat = async (chatSDK: any, state: ILiveChatWidgetContext | undefined, showPreChat: boolean) => {
-    const persistentEnabled = await isPersistentChatEnabled(state);
+export const shouldSetPreChatIfPersistentChat = async (chatSDK: any, conversationMode: string, showPreChat: boolean) => {
+    const persistentEnabled = await isPersistentChatEnabled(conversationMode);
     let skipPreChat = false;
     if (persistentEnabled) {
         const reconnectableChatsParams = {

--- a/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
@@ -9,9 +9,13 @@ export const shouldSetPreChatIfPersistentChat = async (chatSDK: any, showPreChat
             authenticatedUserToken: chatSDK.authenticatedUserToken as string
         };
 
-        const reconnectableChatsResponse = await chatSDK.OCClient.getReconnectableChats(reconnectableChatsParams);
-        if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) { // Skip rendering prechat on existing persistent chat session
-            skipPreChat = true;
+        try {
+            const reconnectableChatsResponse = await chatSDK.OCClient.getReconnectableChats(reconnectableChatsParams);
+            if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) { // Skip rendering prechat on existing persistent chat session
+                skipPreChat = true;
+            }
+        } catch {
+            // eslint-disable-line no-empty
         }
     }
 

--- a/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
@@ -1,8 +1,9 @@
+import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 import { isPersistentChatEnabled } from "./liveChatConfigUtils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const shouldSetPreChatIfPersistentChat = async (chatSDK: any, showPreChat: boolean) => {
-    const persistentEnabled = await isPersistentChatEnabled(chatSDK);
+export const shouldSetPreChatIfPersistentChat = async (chatSDK: any, state: ILiveChatWidgetContext | undefined, showPreChat: boolean) => {
+    const persistentEnabled = await isPersistentChatEnabled(state);
     let skipPreChat = false;
     if (persistentEnabled) {
         const reconnectableChatsParams = {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -66,7 +66,19 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     // Getting prechat Survey Context
     const parseToJson = false;
     const preChatSurveyResponse: string = props?.preChatSurveyPaneProps?.controlProps?.payload ?? await chatSDK.getPreChatSurvey(parseToJson);
-    const showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
+    let showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
+    const persistentEnabled = await isPersistentChatEnabled(chatSDK);
+
+    if (persistentEnabled) {
+        const reconnectableChatsParams = {
+            authenticatedUserToken: chatSDK.authenticatedUserToken as string
+        };
+
+        const reconnectableChatsResponse = await chatSDK.OCClient.getReconnectableChats(reconnectableChatsParams);
+        if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) { // Skip rendering prechat on existing persistent chat session
+            showPrechat = false;
+        }
+    }
 
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -68,7 +68,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const parseToJson = false;
     const preChatSurveyResponse: string = props?.preChatSurveyPaneProps?.controlProps?.payload ?? await chatSDK.getPreChatSurvey(parseToJson);
     let showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
-    showPrechat = await shouldSetPreChatIfPersistentChat(chatSDK, state, showPrechat as boolean);
+    showPrechat = await shouldSetPreChatIfPersistentChat(chatSDK, state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode, showPrechat as boolean);
 
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
@@ -108,7 +108,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
     let isStartChatSuccessful = false;
     const chatConfig = props?.chatConfig;
     const getAuthToken = props?.getAuthToken;
-    const persistentChatEnabled = await isPersistentChatEnabled(state);
+    const persistentChatEnabled = await isPersistentChatEnabled(state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode);
 
     if (state?.appStates.conversationState === ConversationState.Closed) {
         // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -68,7 +68,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const parseToJson = false;
     const preChatSurveyResponse: string = props?.preChatSurveyPaneProps?.controlProps?.payload ?? await chatSDK.getPreChatSurvey(parseToJson);
     let showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
-    showPrechat = await shouldSetPreChatIfPersistentChat(chatSDK, showPrechat as boolean);
+    showPrechat = await shouldSetPreChatIfPersistentChat(chatSDK, state, showPrechat as boolean);
 
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toLowerCase() === "true";
@@ -108,7 +108,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
     let isStartChatSuccessful = false;
     const chatConfig = props?.chatConfig;
     const getAuthToken = props?.getAuthToken;
-    const persistentChatEnabled = await isPersistentChatEnabled(chatSDK);
+    const persistentChatEnabled = await isPersistentChatEnabled(state);
 
     if (state?.appStates.conversationState === ConversationState.Closed) {
         // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
@@ -66,8 +66,13 @@ export class MockChatSDK {
     public getLiveChatConfig() {      
         return {
             LiveWSAndLiveChatEngJoin: {
-                msdyn_postconversationsurveyenable: "true"
+                msdyn_postconversationsurveyenable: "true",
+                msdyn_conversationmode: "192350000"
             }
         };
+    }
+
+    public sendTypingEvent() {
+        return null;
     }
 }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
Bug #4309542

### Description
- Upon reconnect to an existing persistent chat session with pre-chat enabled, the pre-chat survey is still rendered although the pre-chat response has been submitted initially.

## Solution Proposed
- We need to perform an API call to verify whether it is an existing persistent chat session, then not render the pre-chat survey if that's the case

### Acceptance criteria
- Pre-chat survey is not rendered on existing persistent chat session

## Test cases and evidence
- Manual validation

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__