### PR TITLE
Fix Existing Persistent Chat Not Skipping PreChat Survey

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat
+- Moved `AuthTokenAcquisition` to allow `auth` http calls to Omnichannel service before `StartChat`
 
 ## [1.7.2] 09-03-2024
 

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -31,6 +31,20 @@ let widgetInstanceId: any | "";
 let popoutWidgetInstanceId: any | "";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+const setAuthenticationIfApplicable = async (props: ILiveChatWidgetProps, chatSDK: any) => {
+    const chatConfig = props?.chatConfig;
+    const getAuthToken = props?.getAuthToken;
+    const authClientFunction = getAuthClientFunction(chatConfig);
+    if (getAuthToken && authClientFunction) {
+        // set auth token to chat sdk before start chat
+        const authSuccess = await handleAuthentication(chatSDK, chatConfig, getAuthToken);
+        if (!authSuccess) {
+            throw new Error(WidgetLoadCustomErrorString.AuthenticationFailedErrorString);
+        }
+    }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any) => {
     optionalParams = {}; //Resetting to ensure no stale values
     widgetInstanceId = getWidgetCacheIdfromProps(props);
@@ -56,6 +70,8 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
     const isProactiveChat = state.appStates.conversationState === ConversationState.ProactiveChat;
     const isPreChatEnabledInProactiveChat = state.appStates.proactiveChatStates.proactiveChatEnablePrechat;
 
+    await setAuthenticationIfApplicable(props, chatSDK);
+
     //Setting PreChat and intiate chat
     await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, isProactiveChat, isPreChatEnabledInProactiveChat, state, props);
 };
@@ -63,17 +79,6 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
     //Handle reconnect scenario
-
-    const chatConfig = props?.chatConfig;
-    const getAuthToken = props?.getAuthToken;
-    const authClientFunction = getAuthClientFunction(chatConfig);
-    if (getAuthToken && authClientFunction) {
-        // set auth token to chat sdk before start chat
-        const authSuccess = await handleAuthentication(chatSDK, chatConfig, getAuthToken);
-        if (!authSuccess) {
-            throw new Error(WidgetLoadCustomErrorString.AuthenticationFailedErrorString);
-        }
-    }
 
     // Getting prechat Survey Context
     const parseToJson = false;


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

Bug #4309542

### Description
- Omnichannel HTTP calls before a chat is started would fail due to `authToken` was not acquired

## Solution Proposed
- Moving the token acquisition logic before start gets started

### Acceptance criteria
- Auth chats should work as expected

## Test cases and evidence
- Manual validations

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__