### PR TITLE
Patch to prevent logging endchat exception when conversation was disconnected

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,12 +7,18 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat
 - Moved `AuthTokenAcquisition` to allow `auth` http calls to Omnichannel service before `StartChat`
+
+### Changed
+
+- Stopped logging the end chat exception when the conversation is disconnected or ended by the agent/bot.
 
 ## [1.7.2] 09-03-2024
 
 ### Changed
+
 - Uptake [@microsoft/omnichannel-chat-sdk@1.9.5](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.9.5)
 - Uptake [@microsoft/omnichannel-chat-sdk@1.9.4](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.9.4)
 - Removed postchat telemetry logs when postchat survey is disabled
@@ -21,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Updated `handleStartChatError` to log `AuthenticatedChatConversationRetrievalFailure` as warning using `logWidgetLoadCompleteWithError` instead of an error.
 
 ### Fixed
+
 - Cleaning postsurvey state when ending the chat.
 - Fixing disable strike through in markdown
 - checking localStorage null or undefined

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -94,6 +94,7 @@ export enum TelemetryEvent {
     GetConversationDetailsCallStarted = "GetConversationDetailsCallStarted",
     GetConversationDetailsCallFailed = "GetConversationDetailsCallFailed",
     EndChatSDKCallFailed = "EndChatSDKCallFailed",
+    DisconnectEndChatSDKCallFailed = "DisconnectEndChatSDKCallFailed",
     GetChatReconnectContextSDKCallStarted = "GetChatReconnectContextSDKCallStarted",
     GetChatReconnectContextSDKCallFailed = "GetChatReconnectContextSDKCallFailed",
     ParseAdaptiveCardFailed = "ParseAdaptiveCardFailed",

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -141,6 +141,13 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
                         exception: ex
                     }
                 });
+            }else{
+                TelemetryHelper.logSDKEvent(LogLevel.WARN, {
+                    Event: TelemetryEvent.DisconnectEndChatSDKCallFailed,
+                    ExceptionDetails: {
+                        exception: ex
+                    }
+                });
             }
 
             postMessageToOtherTab = false;

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -131,12 +131,18 @@ const endChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveCh
             await handleAuthentication(chatSDK, props.chatConfig, props.getAuthToken);
             await chatSDK?.endChat();
         } catch (ex) {
-            TelemetryHelper.logSDKEvent(LogLevel.ERROR, {
-                Event: TelemetryEvent.EndChatSDKCallFailed,
-                ExceptionDetails: {
-                    exception: ex
-                }
-            });
+
+            const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
+            // if the chat was disconnected or ended by the agent, we don't want to log the error
+            if (!inMemoryState?.appStates?.chatDisconnectEventReceived) {
+                TelemetryHelper.logSDKEvent(LogLevel.ERROR, {
+                    Event: TelemetryEvent.EndChatSDKCallFailed,
+                    ExceptionDetails: {
+                        exception: ex
+                    }
+                });
+            }
+
             postMessageToOtherTab = false;
         } finally {
             await endChatStateCleanUp(dispatch);


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

4345582

### Description
_Include a description of the problem to be solved_

When c2 close the widget for a session that is already ended by agent, backend throws an exception which doesnt reflect the result, since the conversation was already closed by agent.

We still want to call the endchat in case close status has not been propagated in DV, causing the conversation to stays open.


## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Evaluate state to check disconnection was received, as cause of chat ended by agent, or iddle activity.

We still want to call the endchat in case close status has not been propagated in DV, causing the conversation to stays open.


### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__