### PR TITLE
Demo Chat Adapter

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Add
+
+- Add `mock` props to allow chat widget to run in `mock mode` with `DemoChatAdapter`
+
 ### Fixed
 
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat

--- a/chat-widget/samples/javascript-sample/SampleWidget.js
+++ b/chat-widget/samples/javascript-sample/SampleWidget.js
@@ -13,9 +13,7 @@ import { version as chatSdkVersion } from "@microsoft/omnichannel-chat-sdk/packa
 import { version as chatWidgetVersion } from "../../package.json";
 import { getCustomizationJson } from "./getCustomizationJson";
 import { memoryDataStore } from "./Common/MemoryDataStore";
-import { DesignerChatSDK } from "../../lib/esm/components/webchatcontainerstateful/common/DesignerChatSDK.js";
-import { DemoChatSDK } from "../../lib/esm/components/webchatcontainerstateful/common/DemoChatSDK.js";
-import { MockChatSDK } from "../../lib/esm/components/webchatcontainerstateful/common/mockchatsdk.js";
+import getMockChatSDKIfApplicable from "./getMockChatSDKIfApplicable";
 
 let liveChatWidgetProps;
 
@@ -36,18 +34,7 @@ const main = async () => {
     };
 
     let chatSDK = new OmnichannelChatSDK(omnichannelConfig);
-    if (customizationJson && customizationJson.mock && customizationJson.mock.type) {
-        switch(customizationJson.mock.type.toLowerCase()) {
-            case "demo":
-                chatSDK = new DemoChatSDK();
-                break;
-            case "designer":
-                chatSDK = new DesignerChatSDK();
-                break;
-            default:
-                chatSDK = new MockChatSDK();
-        }
-    }
+    chatSDK = getMockChatSDKIfApplicable(chatSDK, customizationJson);
 
     await chatSDK.initialize({useParallelLoad: true});
     const chatConfig = await chatSDK.getLiveChatConfig();

--- a/chat-widget/samples/javascript-sample/getMockChatSDKIfApplicable.js
+++ b/chat-widget/samples/javascript-sample/getMockChatSDKIfApplicable.js
@@ -1,0 +1,21 @@
+import { DesignerChatSDK } from "../../lib/esm/components/webchatcontainerstateful/common/DesignerChatSDK.js";
+import { DemoChatSDK } from "../../lib/esm/components/webchatcontainerstateful/common/DemoChatSDK.js";
+import { MockChatSDK } from "../../lib/esm/components/webchatcontainerstateful/common/mockchatsdk.js";
+
+const getMockChatSDKIfApplicable = (chatSDK, customizationJson) => {
+    if (customizationJson && customizationJson.mock && customizationJson.mock.type) {
+        switch(customizationJson.mock.type.toLowerCase()) {
+            case "demo":
+                chatSDK = new DemoChatSDK();
+                break;
+            case "designer":
+                chatSDK = new DesignerChatSDK();
+                break;
+            default:
+                chatSDK = new MockChatSDK();
+        }
+    }
+    return chatSDK;
+};
+
+export default getMockChatSDKIfApplicable;

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -10,6 +10,7 @@ import LiveChatWidgetStateful from "./livechatwidgetstateful/LiveChatWidgetState
 import { createReducer } from "../../contexts/createReducer";
 import { getLiveChatWidgetContextInitialState } from "../../contexts/common/LiveChatWidgetContextInitialState";
 import { MockChatSDK } from "../webchatcontainerstateful/common/mockchatsdk";
+import { DemoChatSDK } from "../webchatcontainerstateful/common/DemoChatSDK";
 
 export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
 
@@ -19,8 +20,14 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
     const [adapter, setAdapter]: [any, (adapter: any) => void] = useState(undefined);
     let chatSDK: any = props.chatSDK; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    if (props?.mock) {
-        chatSDK = new MockChatSDK();
+    if (props?.mock?.type) {
+        switch(props?.mock?.type.toLocaleLowerCase()) {
+            case "demo":
+                chatSDK = new DemoChatSDK();
+                break;
+            default:
+                chatSDK = new MockChatSDK();
+        }
     }
 
     return (

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -9,6 +9,7 @@ import { ILiveChatWidgetProps } from "./interfaces/ILiveChatWidgetProps";
 import LiveChatWidgetStateful from "./livechatwidgetstateful/LiveChatWidgetStateful";
 import { createReducer } from "../../contexts/createReducer";
 import { getLiveChatWidgetContextInitialState } from "../../contexts/common/LiveChatWidgetContextInitialState";
+import { MockChatSDK } from "../webchatcontainerstateful/common/mockchatsdk";
 
 export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
 
@@ -16,9 +17,14 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useReducer(reducer, getLiveChatWidgetContextInitialState(props));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [adapter, setAdapter]: [any, (adapter: any) => void] = useState(undefined);
+    let chatSDK: any = props.chatSDK; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    if (props?.mock) {
+        chatSDK = new MockChatSDK();
+    }
 
     return (
-        <ChatSDKStore.Provider value={props.chatSDK}>
+        <ChatSDKStore.Provider value={chatSDK}>
             <ChatAdapterStore.Provider value={[adapter, setAdapter]}>
                 <ChatContextStore.Provider value={[state, dispatch]}>
                     <LiveChatWidgetStateful {...props} />

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -18,8 +18,7 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
     const [state, dispatch]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useReducer(reducer, getLiveChatWidgetContextInitialState(props));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [adapter, setAdapter]: [any, (adapter: any) => void] = useState(undefined);
-    let chatSDK: any = props.chatSDK; // eslint-disable-line @typescript-eslint/no-explicit-any
-    chatSDK = getMockChatSDKIfApplicable(chatSDK, props?.mock?.type);
+    const chatSDK = getMockChatSDKIfApplicable(props.chatSDK, props?.mock?.type);
     overridePropsOnMockIfApplicable(props);
 
     return (

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -11,6 +11,7 @@ import { createReducer } from "../../contexts/createReducer";
 import { getLiveChatWidgetContextInitialState } from "../../contexts/common/LiveChatWidgetContextInitialState";
 import { MockChatSDK } from "../webchatcontainerstateful/common/mockchatsdk";
 import { DemoChatSDK } from "../webchatcontainerstateful/common/DemoChatSDK";
+import { DesignerChatSDK } from "../webchatcontainerstateful/common/DesignerChatSDK";
 
 export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
 
@@ -24,6 +25,9 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
         switch(props?.mock?.type.toLocaleLowerCase()) {
             case "demo":
                 chatSDK = new DemoChatSDK();
+                break;
+            case "designer":
+                chatSDK = new DesignerChatSDK();
                 break;
             default:
                 chatSDK = new MockChatSDK();

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -9,9 +9,7 @@ import { ILiveChatWidgetProps } from "./interfaces/ILiveChatWidgetProps";
 import LiveChatWidgetStateful from "./livechatwidgetstateful/LiveChatWidgetStateful";
 import { createReducer } from "../../contexts/createReducer";
 import { getLiveChatWidgetContextInitialState } from "../../contexts/common/LiveChatWidgetContextInitialState";
-import { MockChatSDK } from "../webchatcontainerstateful/common/mockchatsdk";
-import { DemoChatSDK } from "../webchatcontainerstateful/common/DemoChatSDK";
-import { DesignerChatSDK } from "../webchatcontainerstateful/common/DesignerChatSDK";
+import { getMockChatSDKIfApplicable } from "./common/getMockChatSDKIfApplicable";
 
 export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
 
@@ -20,19 +18,7 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [adapter, setAdapter]: [any, (adapter: any) => void] = useState(undefined);
     let chatSDK: any = props.chatSDK; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-    if (props?.mock?.type) {
-        switch(props?.mock?.type.toLocaleLowerCase()) {
-            case "demo":
-                chatSDK = new DemoChatSDK();
-                break;
-            case "designer":
-                chatSDK = new DesignerChatSDK();
-                break;
-            default:
-                chatSDK = new MockChatSDK();
-        }
-    }
+    chatSDK = getMockChatSDKIfApplicable(chatSDK, props?.mock?.type);
 
     return (
         <ChatSDKStore.Provider value={chatSDK}>

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -10,6 +10,7 @@ import LiveChatWidgetStateful from "./livechatwidgetstateful/LiveChatWidgetState
 import { createReducer } from "../../contexts/createReducer";
 import { getLiveChatWidgetContextInitialState } from "../../contexts/common/LiveChatWidgetContextInitialState";
 import { getMockChatSDKIfApplicable } from "./common/getMockChatSDKIfApplicable";
+import overridePropsOnMockIfApplicable from "./common/overridePropsOnMockIfApplicable";
 
 export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
 
@@ -19,6 +20,7 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
     const [adapter, setAdapter]: [any, (adapter: any) => void] = useState(undefined);
     let chatSDK: any = props.chatSDK; // eslint-disable-line @typescript-eslint/no-explicit-any
     chatSDK = getMockChatSDKIfApplicable(chatSDK, props?.mock?.type);
+    overridePropsOnMockIfApplicable(props);
 
     return (
         <ChatSDKStore.Provider value={chatSDK}>

--- a/chat-widget/src/components/livechatwidget/common/getMockChatSDKIfApplicable.ts
+++ b/chat-widget/src/components/livechatwidget/common/getMockChatSDKIfApplicable.ts
@@ -1,0 +1,21 @@
+import { DemoChatSDK } from "../../webchatcontainerstateful/common/DemoChatSDK";
+import { DesignerChatSDK } from "../../webchatcontainerstateful/common/DesignerChatSDK";
+import { MockChatSDK } from "../../webchatcontainerstateful/common/mockchatsdk";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getMockChatSDKIfApplicable = (chatSDK: any, type?: string) => {    
+    if (type) {
+        switch(type.toLocaleLowerCase()) {
+            case "demo":
+                chatSDK = new DemoChatSDK();
+                break;
+            case "designer":
+                chatSDK = new DesignerChatSDK();
+                break;
+            default:
+                chatSDK = new MockChatSDK();
+        }
+    }
+
+    return chatSDK;
+};

--- a/chat-widget/src/components/livechatwidget/common/getMockChatSDKIfApplicable.ts
+++ b/chat-widget/src/components/livechatwidget/common/getMockChatSDKIfApplicable.ts
@@ -5,7 +5,7 @@ import { MockChatSDK } from "../../webchatcontainerstateful/common/mockchatsdk";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getMockChatSDKIfApplicable = (chatSDK: any, type?: string) => {    
     if (type) {
-        switch(type.toLocaleLowerCase()) {
+        switch(type.toLowerCase()) {
             case "demo":
                 chatSDK = new DemoChatSDK();
                 break;

--- a/chat-widget/src/components/livechatwidget/common/overridePropsOnMockIfApplicable.ts
+++ b/chat-widget/src/components/livechatwidget/common/overridePropsOnMockIfApplicable.ts
@@ -1,0 +1,24 @@
+import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
+
+const overridePropsOnMockIfApplicable = (props: ILiveChatWidgetProps) => {
+    if (props?.mock?.type && props?.mock?.type.toLowerCase() === "designer") {
+        if (!props.webChatContainerProps) {
+            props.webChatContainerProps = {};
+        }
+
+        if (!props.webChatContainerProps.webChatProps) {
+            props.webChatContainerProps.webChatProps = {};
+        }
+
+        if (!props.webChatContainerProps.webChatProps.overrideLocalizedStrings) {
+            props.webChatContainerProps.webChatProps.overrideLocalizedStrings = {};
+        }
+
+        props.webChatContainerProps.webChatProps.overrideLocalizedStrings = {
+            TEXT_INPUT_PLACEHOLDER: "Send a message . . .",
+            ...props.webChatContainerProps.webChatProps.overrideLocalizedStrings
+        }
+    }
+};
+
+export default overridePropsOnMockIfApplicable;

--- a/chat-widget/src/components/livechatwidget/common/overridePropsOnMockIfApplicable.ts
+++ b/chat-widget/src/components/livechatwidget/common/overridePropsOnMockIfApplicable.ts
@@ -10,14 +10,30 @@ const overridePropsOnMockIfApplicable = (props: ILiveChatWidgetProps) => {
             props.webChatContainerProps.webChatProps = {};
         }
 
+        if (!props.webChatContainerProps.webChatStyles) {
+            props.webChatContainerProps.webChatStyles = {};
+        }
+
         if (!props.webChatContainerProps.webChatProps.overrideLocalizedStrings) {
             props.webChatContainerProps.webChatProps.overrideLocalizedStrings = {};
         }
 
-        props.webChatContainerProps.webChatProps.overrideLocalizedStrings = {
-            TEXT_INPUT_PLACEHOLDER: "Send a message . . .",
-            ...props.webChatContainerProps.webChatProps.overrideLocalizedStrings
-        }
+        props.webChatContainerProps = {
+            ...props.webChatContainerProps,
+            webChatProps: {
+                disabled: true,
+                ...props.webChatContainerProps.webChatProps,
+                overrideLocalizedStrings: {
+                    TEXT_INPUT_PLACEHOLDER: "Send a message . . .",
+                    ...props.webChatContainerProps.webChatProps.overrideLocalizedStrings
+                }
+            },
+            webChatStyles: {
+                hideUploadButton: false,
+                sendBoxBackground: "rgb(243, 242, 241)",
+                ...props.webChatContainerProps.webChatStyles
+            }
+        };
     }
 };
 

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
@@ -25,6 +25,7 @@ import { IPostChatSurveyPaneStatefulProps } from "../../postchatsurveypanestatef
 import { IScrollBarProps } from "./IScrollBarProps";
 import { IDraggableChatWidgetProps } from "./IDraggableChatWidgetProps";
 import { INotificationPaneProps } from "@microsoft/omnichannel-chat-components/lib/types/components/notificationpane/interfaces/INotificationPaneProps";
+import { IMockProps } from "./IMockProps";
 
 export interface ILiveChatWidgetProps {
     audioNotificationProps?: IAudioNotificationProps;
@@ -68,4 +69,5 @@ export interface ILiveChatWidgetProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     initialCustomContext?: any;
     draggableChatWidgetProps?: IDraggableChatWidgetProps;
+    mock?: IMockProps;
 }

--- a/chat-widget/src/components/livechatwidget/interfaces/IMockProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/IMockProps.ts
@@ -1,0 +1,8 @@
+enum LiveChatWidgetMockType {
+    Test = "Test",
+    Demo = "Demo"
+}
+
+export interface IMockProps {
+    type: LiveChatWidgetMockType
+}

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -6,7 +6,7 @@ import MockAdapter from "./mockadapter";
 import { customerUser, postBotMessageActivity, postBotAttachmentActivity, postBotTypingActivity, postEchoActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
 import { createHeroCardAttachment, createJpgFileAttachment, createSigninCardAttachment, createThumbnailCardAttachment } from "./utils/attachmentActivityUtils";
 
-enum BotCommands {
+enum MockBotCommands {
     Bot = "/bot",
     Card = "/card",
     Help = "/help",
@@ -15,6 +15,12 @@ enum BotCommands {
     SendSystemMessage = "send system message",
     SendTyping = "send typing",
     System = "/system"
+};
+
+enum MockBotCardCommandType {
+    Hero = "hero",
+    Signin = "signin",
+    Thumbnail = "thumbnail"
 };
 
 export class DemoChatAdapter extends MockAdapter {
@@ -59,34 +65,34 @@ export class DemoChatAdapter extends MockAdapter {
 
             if (activity.text) {
                 switch(true) {
-                    case activity.text === BotCommands.Help:
+                    case activity.text === MockBotCommands.Help:
                         this.postBotCommandsActivity();
                         break;
-                    case activity.text === BotCommands.SendSystemMessage:
+                    case activity.text === MockBotCommands.SendSystemMessage:
                         postSystemMessageActivity(this.activityObserver, "Contoso has joined the chat.");
                         break;
-                    case activity.text === BotCommands.SendTyping:
+                    case activity.text === MockBotCommands.SendTyping:
                         postBotTypingActivity(this.activityObserver);
                         break;
-                    case activity.text === BotCommands.SendAttachment:
+                    case activity.text === MockBotCommands.SendAttachment:
                         postBotAttachmentActivity(this.activityObserver, [createJpgFileAttachment()]);
                         break;
-                    case activity.text === BotCommands.SendBotMessage:
+                    case activity.text === MockBotCommands.SendBotMessage:
                         postBotMessageActivity(this.activityObserver, "Hi, how can I help you?");
                         break;
-                    case activity.text === `${BotCommands.Card} signin`:
+                    case activity.text === `${MockBotCommands.Card} ${MockBotCardCommandType.Signin}`:
                         postBotAttachmentActivity(this.activityObserver, [createSigninCardAttachment()]);
                         break;
-                    case activity.text === `${BotCommands.Card} hero`:
+                    case activity.text === `${MockBotCommands.Card} ${MockBotCardCommandType.Hero}`:
                         postBotAttachmentActivity(this.activityObserver, [createHeroCardAttachment()]);
                         break;
-                    case activity.text === `${BotCommands.Card} thumbnail`:
+                    case activity.text === `${MockBotCommands.Card} ${MockBotCardCommandType.Thumbnail}`:
                         postBotAttachmentActivity(this.activityObserver, [createThumbnailCardAttachment()]);
                         break;
-                    case activity.text.startsWith(`${BotCommands.Bot} `):
+                    case activity.text.startsWith(`${MockBotCommands.Bot} `):
                         postBotMessageActivity(this.activityObserver, activity.text.substring(5));
                         break;
-                    case activity.text.startsWith(`${BotCommands.System} `):
+                    case activity.text.startsWith(`${MockBotCommands.System} `):
                         postSystemMessageActivity(this.activityObserver, activity.text.substring(8));
                         break;
                 }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -4,7 +4,7 @@ import { Attachment, Message, User } from "botframework-directlinejs";
 import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
 import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
-import { postEchoActivity } from "./utils/chatAdapterUtils";
+import { postBotMessageActivity, postEchoActivity } from "./utils/chatAdapterUtils";
 
 const customerUser: User = {
     id: "usedId",
@@ -24,7 +24,7 @@ export class DemoChatAdapter extends MockAdapter {
 
         setTimeout(() => {
             this.postSystemMessageActivity("You're currently using a demo.", 0);
-            this.postBotMessageActivity("Type `/help` to learn more", undefined, 0); // send init message from bot
+            postBotMessageActivity(this.activityObserver, "Type `/help` to learn more", undefined, 0); // send init message from bot
         }, 1000);
     }
 
@@ -54,24 +54,8 @@ export class DemoChatAdapter extends MockAdapter {
         }], delay);
     }
 
-    private postBotMessageActivity(text: string, tags = "", delay = 1000) {
-        setTimeout(() => {
-            this.activityObserver?.next({
-                id: uuidv4(),
-                from: {
-                    ...botUser
-                },
-                text,
-                type: "message",
-                channelData: {
-                    tags
-                }
-            });
-        }, delay);
-    }
-
     private postSystemMessageActivity(text: string, delay = 1000) {
-        this.postBotMessageActivity(text, "system", delay);
+        postBotMessageActivity(this.activityObserver, text, "system", delay);
     }
 
     private postBotTypingActivity(delay = 1000) {
@@ -121,7 +105,7 @@ export class DemoChatAdapter extends MockAdapter {
                             contentUrl: "https://raw.githubusercontent.com/microsoft/omnichannel-chat-sdk/e7e75d4ede351e1cf2e52f13860d2284848c4af0/playwright/public/images/600x400.jpg"}]);
                         break;
                     case activity.text === "send bot message":
-                        this.postBotMessageActivity("Hi, how can I help you?");
+                        postBotMessageActivity(this.activityObserver, "Hi, how can I help you?");
                         break;
                     case activity.text === "/card signin":
                         this.postBotAttachmentActivity([{
@@ -185,7 +169,7 @@ export class DemoChatAdapter extends MockAdapter {
                         }]);
                         break;
                     case activity.text.startsWith("/bot "):
-                        this.postBotMessageActivity(activity.text.substring(5));
+                        postBotMessageActivity(this.activityObserver, activity.text.substring(5));
                         break;
                     case activity.text.startsWith("/system "):
                         this.postSystemMessageActivity(activity.text.substring(8));

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -22,17 +22,7 @@ export class DemoChatAdapter extends MockAdapter {
         super();
 
         setTimeout(() => {
-            this.activityObserver?.next({ // send system message
-                id: uuidv4(),
-                from: {
-                    ...botUser
-                },
-                text: "You're currently using a demo.",
-                type: "message",
-                channelData: {
-                    tags: "system"
-                }
-            });
+            this.postSystemMessageActivity("You're currently using a demo.");
 
             this.activityObserver?.next({ // send init message from bot
                 id: uuidv4(),
@@ -58,7 +48,7 @@ export class DemoChatAdapter extends MockAdapter {
 
         setTimeout(() => {
             this.activityObserver?.next(echoActivity); // mock message sent activity
-        }, 1500);
+        }, 1000);
     }
 
     private postBotCommandsActivity() {
@@ -90,7 +80,21 @@ export class DemoChatAdapter extends MockAdapter {
                     }
                 ]
             });
-        }, 1500);
+        }, 1000);
+    }
+
+    private postSystemMessageActivity(text: string) {
+        this.activityObserver?.next({
+            id: uuidv4(),
+            from: {
+                ...botUser
+            },
+            text,
+            type: "message",
+            channelData: {
+                tags: "system"
+            }
+        });
     }
 
     public postActivity(activity: Message): Observable<string> {

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -6,6 +6,17 @@ import MockAdapter from "./mockadapter";
 import { customerUser, postBotMessageActivity, postBotAttachmentActivity, postBotTypingActivity, postEchoActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
 import { createHeroCardAttachment, createJpgFileAttachment, createSigninCardAttachment, createThumbnailCardAttachment } from "./utils/attachmentActivityUtils";
 
+enum BotCommands {
+    Bot = "/bot",
+    Card = "/card",
+    Help = "/help",
+    SendAttachment = "send attachment",
+    SendBotMessage = "send bot message",
+    SendSystemMessage = "send system message",
+    SendTyping = "send typing",
+    System = "/system"
+};
+
 export class DemoChatAdapter extends MockAdapter {
     constructor() {
         super();
@@ -48,34 +59,34 @@ export class DemoChatAdapter extends MockAdapter {
 
             if (activity.text) {
                 switch(true) {
-                    case activity.text === "/help":
+                    case activity.text === BotCommands.Help:
                         this.postBotCommandsActivity();
                         break;
-                    case activity.text === "send system message":
+                    case activity.text === BotCommands.SendSystemMessage:
                         postSystemMessageActivity(this.activityObserver, "Contoso has joined the chat.");
                         break;
-                    case activity.text === "send typing":
+                    case activity.text === BotCommands.SendTyping:
                         postBotTypingActivity(this.activityObserver);
                         break;
-                    case activity.text === "send attachment":
+                    case activity.text === BotCommands.SendAttachment:
                         postBotAttachmentActivity(this.activityObserver, [createJpgFileAttachment()]);
                         break;
-                    case activity.text === "send bot message":
+                    case activity.text === BotCommands.SendBotMessage:
                         postBotMessageActivity(this.activityObserver, "Hi, how can I help you?");
                         break;
-                    case activity.text === "/card signin":
+                    case activity.text === `${BotCommands.Card} signin`:
                         postBotAttachmentActivity(this.activityObserver, [createSigninCardAttachment()]);
                         break;
-                    case activity.text === "/card hero":
+                    case activity.text === `${BotCommands.Card} hero`:
                         postBotAttachmentActivity(this.activityObserver, [createHeroCardAttachment()]);
                         break;
-                    case activity.text === "/card thumbnail":
+                    case activity.text === `${BotCommands.Card} thumbnail`:
                         postBotAttachmentActivity(this.activityObserver, [createThumbnailCardAttachment()]);
                         break;
-                    case activity.text.startsWith("/bot "):
+                    case activity.text.startsWith(`${BotCommands.Bot} `):
                         postBotMessageActivity(this.activityObserver, activity.text.substring(5));
                         break;
-                    case activity.text.startsWith("/system "):
+                    case activity.text.startsWith(`${BotCommands.System} `):
                         postSystemMessageActivity(this.activityObserver, activity.text.substring(8));
                         break;
                 }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -57,40 +57,29 @@ export class DemoChatAdapter extends MockAdapter {
     }
 
     private postBotCommandsActivity(delay = 1000) {
-        setTimeout(() => {
-            this.activityObserver?.next({
-                id: uuidv4(),
-                from: {
-                    ...botUser
-                },
-                type: "message",
-                attachments: [
+        this.postBotAttachmentActivity([{
+            contentType: "application/vnd.microsoft.card.thumbnail",
+            content: {
+                buttons: [
                     {
-                        contentType: "application/vnd.microsoft.card.thumbnail",
-                        content: {
-                            buttons: [
-                                {
-                                    title: "Send system message",
-                                    type: "imBack",
-                                    value: "send system message"
-                                },
-                                {
-                                    title: "Send typing",
-                                    type: "imBack",
-                                    value: "send typing"
-                                },
-                                {
-                                    title: "Send bot message",
-                                    type: "imBack",
-                                    value: "send bot message"
-                                }
-                            ],
-                            title: "Commands"
-                        }
+                        title: "Send system message",
+                        type: "imBack",
+                        value: "send system message"
+                    },
+                    {
+                        title: "Send typing",
+                        type: "imBack",
+                        value: "send typing"
+                    },
+                    {
+                        title: "Send bot message",
+                        type: "imBack",
+                        value: "send bot message"
                     }
-                ]
-            });
-        }, delay);
+                ],
+                title: "Commands"
+            }
+        }], delay);
     }
 
     private postBotMessageActivity(text: string, tags = "", delay = 1000) {

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -39,7 +39,7 @@ export class DemoChatAdapter extends MockAdapter {
                 from: {
                     ...botUser
                 },
-                text: "Type `help` to learn more",
+                text: "Type `/help` to learn more",
                 type: "message"
             });
         }, 1000);
@@ -58,12 +58,48 @@ export class DemoChatAdapter extends MockAdapter {
 
         setTimeout(() => {
             this.activityObserver?.next(echoActivity); // mock message sent activity
-        }, 2000);
+        }, 1500);
+    }
+
+    private postBotCommandsActivity() {
+        setTimeout(() => {
+            this.activityObserver?.next({
+                id: uuidv4(),
+                from: {
+                    ...botUser
+                },
+                type: "message",
+                attachments: [
+                    {
+                        contentType: "application/vnd.microsoft.card.thumbnail",
+                        content: {
+                            buttons: [
+                                {
+                                    title: "Send system message",
+                                    type: "imBack",
+                                    value: "send system message"
+                                },
+                                {
+                                    title: "Send typing",
+                                    type: "imBack",
+                                    value: "send typing"
+                                }
+                            ],
+                            title: "Commands"
+                        }
+                    }
+                ]
+            });
+        }, 1500);
     }
 
     public postActivity(activity: Message): Observable<string> {
         if (activity) {
             this.postEchoActivity(activity, customerUser);
+
+            if (activity.text === "/help") {
+                this.postBotCommandsActivity();
+            }
         }
 
         return Observable.of(activity.id || "");

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -23,21 +23,8 @@ export class DemoChatAdapter extends MockAdapter {
 
         setTimeout(() => {
             this.postSystemMessageActivity("You're currently using a demo.", 0);
-            this.postBotActivity("Type `/help` to learn more", 0); // send init message from bot
+            this.postBotMessageActivity("Type `/help` to learn more", undefined, 0); // send init message from bot
         }, 1000);
-    }
-
-    private postBotActivity(text: string, delay = 1000): void {
-        setTimeout(() => {
-            this.activityObserver?.next({
-                id: uuidv4(),
-                from: {
-                    ...botUser
-                },
-                text: "Type `/help` to learn more",
-                type: "message"
-            });
-        }, delay);
     }
 
     // WebChat expects an "echo" activity to confirm the message has been sent successfully

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -4,6 +4,7 @@ import { Message } from "botframework-directlinejs";
 import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
 import { customerUser, postBotMessageActivity, postBotAttachmentActivity, postBotTypingActivity, postEchoActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
+import { createHeroCardAttachment, createJpgFileAttachment, createSigninCardAttachment, createThumbnailCardAttachment } from "./utils/attachmentActivityUtils";
 
 export class DemoChatAdapter extends MockAdapter {
     constructor() {
@@ -57,74 +58,19 @@ export class DemoChatAdapter extends MockAdapter {
                         postBotTypingActivity(this.activityObserver);
                         break;
                     case activity.text === "send attachment":
-                        postBotAttachmentActivity(this.activityObserver, [{
-                            contentType: "image/jpeg", 
-                            name: "600x400.jpg", 
-                            contentUrl: "https://raw.githubusercontent.com/microsoft/omnichannel-chat-sdk/e7e75d4ede351e1cf2e52f13860d2284848c4af0/playwright/public/images/600x400.jpg"}]);
+                        postBotAttachmentActivity(this.activityObserver, [createJpgFileAttachment()]);
                         break;
                     case activity.text === "send bot message":
                         postBotMessageActivity(this.activityObserver, "Hi, how can I help you?");
                         break;
                     case activity.text === "/card signin":
-                        postBotAttachmentActivity(this.activityObserver, [{
-                            contentType: "application/vnd.microsoft.card.signin",
-                            content: {
-                                text: "Please login",
-                                buttons: [
-                                    {
-                                        type: "signin",
-                                        title: "Signin",
-                                        value: "https://login.live.com/"
-                                    }
-                                ]
-                            }
-                        }]);
+                        postBotAttachmentActivity(this.activityObserver, [createSigninCardAttachment()]);
                         break;
                     case activity.text === "/card hero":
-                        postBotAttachmentActivity(this.activityObserver, [{
-                            contentType: "application/vnd.microsoft.card.hero",
-                            content: {
-                                buttons: [
-                                    {
-                                        title: "Bellevue",
-                                        type: "imBack",
-                                        value: "Bellevue"
-                                    },
-                                    {
-                                        title: "Redmond",
-                                        type: "imBack",
-                                        value: "Redmond"
-                                    },
-                                    {
-                                        title: "Seattle",
-                                        type: "imBack",
-                                        value: "Seattle"
-                                    }
-                                ],
-                                title: "Choose your location"
-                            }
-                        }]);
+                        postBotAttachmentActivity(this.activityObserver, [createHeroCardAttachment()]);
                         break;
                     case activity.text === "/card thumbnail":
-                        postBotAttachmentActivity(this.activityObserver, [{
-                            contentType: "application/vnd.microsoft.card.thumbnail",
-                            content: {
-                                title: "Microsoft",
-                                subtitle: "Our mission is to empower every person and every organization on the planet to achieve more.",
-                                text: "Microsoft creates platforms and tools powered by AI to deliver innovative solutions that meet the evolving needs of our customers. The technology company is committed to making AI available broadly and doing so responsibly, with a mission to empower every person and every organization on the planet to achieve more.",
-                                images: [{
-                                    alt: "Microsoft logo",
-                                    url: "https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b?ver=5c31" // logo from https://microsoft.com
-                                }],
-                                buttons: [
-                                    {
-                                        title: "Learn more",
-                                        type: "openUrl",
-                                        value: "https://www.microsoft.com/"
-                                    }
-                                ]
-                            }
-                        }]);
+                        postBotAttachmentActivity(this.activityObserver, [createThumbnailCardAttachment()]);
                         break;
                     case activity.text.startsWith("/bot "):
                         postBotMessageActivity(this.activityObserver, activity.text.substring(5));

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -191,6 +191,27 @@ export class DemoChatAdapter extends MockAdapter {
                             }
                         }]);
                         break;
+                    case activity.text === "/card thumbnail":
+                        this.postBotAttachmentActivity([{
+                            contentType: "application/vnd.microsoft.card.thumbnail",
+                            content: {
+                                title: "Microsoft",
+                                subtitle: "Our mission is to empower every person and every organization on the planet to achieve more.",
+                                text: "Microsoft creates platforms and tools powered by AI to deliver innovative solutions that meet the evolving needs of our customers. The technology company is committed to making AI available broadly and doing so responsibly, with a mission to empower every person and every organization on the planet to achieve more.",
+                                images: [{
+                                    alt: "Microsoft logo",
+                                    url: "https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b?ver=5c31" // logo from https://microsoft.com
+                                }],
+                                buttons: [
+                                    {
+                                        title: "Learn more",
+                                        type: "openUrl",
+                                        value: "https://www.microsoft.com/"
+                                    }
+                                ]
+                            }
+                        }]);
+                        break;
                     case activity.text.startsWith("/bot "):
                         this.postBotMessageActivity(activity.text.substring(5));
                         break;

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -1,35 +1,22 @@
 import "rxjs/add/operator/share";
 import "rxjs/add/observable/of";
-import { Attachment, Message, User } from "botframework-directlinejs";
+import { Message } from "botframework-directlinejs";
 import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
-import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
-import { postBotMessageActivity, postEchoActivity } from "./utils/chatAdapterUtils";
-
-const customerUser: User = {
-    id: "usedId",
-    name: "User",
-    role: "user"
-};
-
-const botUser: User = {
-    id: "botId",
-    name: "Bot",
-    role: "bot"
-};
+import { customerUser, postBotMessageActivity, postBotAttachmentActivity, postBotTypingActivity, postEchoActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
 
 export class DemoChatAdapter extends MockAdapter {
     constructor() {
         super();
 
         setTimeout(() => {
-            this.postSystemMessageActivity("You're currently using a demo.", 0);
+            postSystemMessageActivity(this.activityObserver, "You're currently using a demo.", 0);
             postBotMessageActivity(this.activityObserver, "Type `/help` to learn more", undefined, 0); // send init message from bot
         }, 1000);
     }
 
     private postBotCommandsActivity(delay = 1000) {
-        this.postBotAttachmentActivity([{
+        postBotAttachmentActivity(this.activityObserver, [{
             contentType: "application/vnd.microsoft.card.thumbnail",
             content: {
                 buttons: [
@@ -54,35 +41,6 @@ export class DemoChatAdapter extends MockAdapter {
         }], delay);
     }
 
-    private postSystemMessageActivity(text: string, delay = 1000) {
-        postBotMessageActivity(this.activityObserver, text, "system", delay);
-    }
-
-    private postBotTypingActivity(delay = 1000) {
-        setTimeout(() => {
-            this.activityObserver?.next({
-                id: uuidv4(),
-                from: {
-                    ...botUser
-                },
-                type: "typing"
-            });
-        }, delay);
-    }
-
-    private postBotAttachmentActivity(attachments: Attachment[] = [], delay = 1000) {
-        setTimeout(() => {
-            this.activityObserver?.next({
-                id: uuidv4(),
-                from: {
-                    ...botUser
-                },
-                attachments,
-                type: "message",
-            });
-        }, delay);
-    }
-
     public postActivity(activity: Message): Observable<string> {
         if (activity) {
             postEchoActivity(this.activityObserver, activity, customerUser);
@@ -93,13 +51,13 @@ export class DemoChatAdapter extends MockAdapter {
                         this.postBotCommandsActivity();
                         break;
                     case activity.text === "send system message":
-                        this.postSystemMessageActivity("Contoso has joined the chat.");
+                        postSystemMessageActivity(this.activityObserver, "Contoso has joined the chat.");
                         break;
                     case activity.text === "send typing":
-                        this.postBotTypingActivity();
+                        postBotTypingActivity(this.activityObserver);
                         break;
                     case activity.text === "send attachment":
-                        this.postBotAttachmentActivity([{
+                        postBotAttachmentActivity(this.activityObserver, [{
                             contentType: "image/jpeg", 
                             name: "600x400.jpg", 
                             contentUrl: "https://raw.githubusercontent.com/microsoft/omnichannel-chat-sdk/e7e75d4ede351e1cf2e52f13860d2284848c4af0/playwright/public/images/600x400.jpg"}]);
@@ -108,7 +66,7 @@ export class DemoChatAdapter extends MockAdapter {
                         postBotMessageActivity(this.activityObserver, "Hi, how can I help you?");
                         break;
                     case activity.text === "/card signin":
-                        this.postBotAttachmentActivity([{
+                        postBotAttachmentActivity(this.activityObserver, [{
                             contentType: "application/vnd.microsoft.card.signin",
                             content: {
                                 text: "Please login",
@@ -123,7 +81,7 @@ export class DemoChatAdapter extends MockAdapter {
                         }]);
                         break;
                     case activity.text === "/card hero":
-                        this.postBotAttachmentActivity([{
+                        postBotAttachmentActivity(this.activityObserver, [{
                             contentType: "application/vnd.microsoft.card.hero",
                             content: {
                                 buttons: [
@@ -148,7 +106,7 @@ export class DemoChatAdapter extends MockAdapter {
                         }]);
                         break;
                     case activity.text === "/card thumbnail":
-                        this.postBotAttachmentActivity([{
+                        postBotAttachmentActivity(this.activityObserver, [{
                             contentType: "application/vnd.microsoft.card.thumbnail",
                             content: {
                                 title: "Microsoft",
@@ -172,7 +130,7 @@ export class DemoChatAdapter extends MockAdapter {
                         postBotMessageActivity(this.activityObserver, activity.text.substring(5));
                         break;
                     case activity.text.startsWith("/system "):
-                        this.postSystemMessageActivity(activity.text.substring(8));
+                        postSystemMessageActivity(this.activityObserver, activity.text.substring(8));
                         break;
                 }
             }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -1,0 +1,17 @@
+import "rxjs/add/operator/share";
+import "rxjs/add/observable/of";
+
+import {  Message } from "botframework-directlinejs";
+import { Observable } from "rxjs/Observable";
+import MockAdapter from "./mockadapter";
+
+export class DemoChatAdapter extends MockAdapter {
+    constructor() {
+        super();
+        console.log("[DemoChatAdapter]");
+    }
+
+    public postActivity(activity: Message): Observable<string> {
+        return super.postActivity(activity);
+    }
+}

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -4,6 +4,7 @@ import { Attachment, Message, User } from "botframework-directlinejs";
 import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
 import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
+import { postEchoActivity } from "./utils/chatAdapterUtils";
 
 const customerUser: User = {
     id: "usedId",
@@ -25,22 +26,6 @@ export class DemoChatAdapter extends MockAdapter {
             this.postSystemMessageActivity("You're currently using a demo.", 0);
             this.postBotMessageActivity("Type `/help` to learn more", undefined, 0); // send init message from bot
         }, 1000);
-    }
-
-    // WebChat expects an "echo" activity to confirm the message has been sent successfully
-    private postEchoActivity(activity: Message, user: User, delay = 1000): void {
-        const echoActivity: Message = {
-            ...activity,
-            id: uuidv4(),
-            from: {
-                ...activity.from,
-                ...user
-            }
-        };
-
-        setTimeout(() => {
-            this.activityObserver?.next(echoActivity); // mock message sent activity
-        }, delay);
     }
 
     private postBotCommandsActivity(delay = 1000) {
@@ -116,7 +101,7 @@ export class DemoChatAdapter extends MockAdapter {
 
     public postActivity(activity: Message): Observable<string> {
         if (activity) {
-            this.postEchoActivity(activity, customerUser);
+            postEchoActivity(this.activityObserver, activity, customerUser);
 
             if (activity.text) {
                 switch(true) {

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -4,14 +4,36 @@ import "rxjs/add/observable/of";
 import {  Message } from "botframework-directlinejs";
 import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
+import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
 
 export class DemoChatAdapter extends MockAdapter {
     constructor() {
         super();
-        console.log("[DemoChatAdapter]");
+    }
+
+    // WebChat expects an "echo" activity to confirm the message has been sent successfully
+    private postEchoActivity(activity: Message): void {
+        const echoActivity: Message = {
+            ...activity,
+            id: uuidv4(),
+            from: {
+                ...activity.from,
+                id: "usedId",
+                name: "User",
+                role: "user"
+            }
+        };
+
+        setTimeout(() => {
+            this.activityObserver?.next(echoActivity); // mock message sent activity
+        }, 2000);
     }
 
     public postActivity(activity: Message): Observable<string> {
-        return super.postActivity(activity);
+        if (activity) {
+            this.postEchoActivity(activity);
+        }
+
+        return Observable.of(activity.id || "");
     }
 }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -162,6 +162,21 @@ export class DemoChatAdapter extends MockAdapter {
                     case activity.text === "send bot message":
                         this.postBotMessageActivity("Hi, how can I help you?");
                         break;
+                    case activity.text === "/card signin":
+                        this.postBotAttachmentActivity([{
+                            contentType: "application/vnd.microsoft.card.signin",
+                            content: {
+                                text: "Please login",
+                                buttons: [
+                                    {
+                                        type: "signin",
+                                        title: "Signin",
+                                        value: "https://login.live.com/"
+                                    }
+                                ]
+                            }
+                        }]);
+                        break;
                     case activity.text.startsWith("/bot "):
                         this.postBotMessageActivity(activity.text.substring(5));
                         break;

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -146,6 +146,9 @@ export class DemoChatAdapter extends MockAdapter {
                     case activity.text.startsWith("/bot "):
                         this.postBotMessageActivity(activity.text.substring(5));
                         break;
+                    case activity.text.startsWith("/system "):
+                        this.postSystemMessageActivity(activity.text.substring(8));
+                        break;
                 }
             }
         }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -166,6 +166,31 @@ export class DemoChatAdapter extends MockAdapter {
                             }
                         }]);
                         break;
+                    case activity.text === "/card hero":
+                        this.postBotAttachmentActivity([{
+                            contentType: "application/vnd.microsoft.card.hero",
+                            content: {
+                                buttons: [
+                                    {
+                                        title: "Bellevue",
+                                        type: "imBack",
+                                        value: "Bellevue"
+                                    },
+                                    {
+                                        title: "Redmond",
+                                        type: "imBack",
+                                        value: "Redmond"
+                                    },
+                                    {
+                                        title: "Seattle",
+                                        type: "imBack",
+                                        value: "Seattle"
+                                    }
+                                ],
+                                title: "Choose your location"
+                            }
+                        }]);
+                        break;
                     case activity.text.startsWith("/bot "):
                         this.postBotMessageActivity(activity.text.substring(5));
                         break;

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -1,6 +1,6 @@
 import "rxjs/add/operator/share";
 import "rxjs/add/observable/of";
-import { Message, User } from "botframework-directlinejs";
+import { Attachment, Message, User } from "botframework-directlinejs";
 import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
 import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
@@ -125,6 +125,19 @@ export class DemoChatAdapter extends MockAdapter {
         }, delay);
     }
 
+    private postBotAttachmentActivity(attachments: Attachment[] = [], delay = 1000) {
+        setTimeout(() => {
+            this.activityObserver?.next({
+                id: uuidv4(),
+                from: {
+                    ...botUser
+                },
+                attachments,
+                type: "message",
+            });
+        }, delay);
+    }
+
     public postActivity(activity: Message): Observable<string> {
         if (activity) {
             this.postEchoActivity(activity, customerUser);
@@ -139,6 +152,12 @@ export class DemoChatAdapter extends MockAdapter {
                         break;
                     case activity.text === "send typing":
                         this.postBotTypingActivity();
+                        break;
+                    case activity.text === "send attachment":
+                        this.postBotAttachmentActivity([{
+                            contentType: "image/jpeg", 
+                            name: "600x400.jpg", 
+                            contentUrl: "https://raw.githubusercontent.com/microsoft/omnichannel-chat-sdk/e7e75d4ede351e1cf2e52f13860d2284848c4af0/playwright/public/images/600x400.jpg"}]);
                         break;
                     case activity.text === "send bot message":
                         this.postBotMessageActivity("Hi, how can I help you?");

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -5,23 +5,8 @@ import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
 import { customerUser, postBotMessageActivity, postBotAttachmentActivity, postBotTypingActivity, postEchoActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
 import { createHeroCardAttachment, createJpgFileAttachment, createSigninCardAttachment, createThumbnailCardAttachment } from "./utils/attachmentActivityUtils";
-
-enum MockBotCommands {
-    Bot = "/bot",
-    Card = "/card",
-    Help = "/help",
-    SendAttachment = "send attachment",
-    SendBotMessage = "send bot message",
-    SendSystemMessage = "send system message",
-    SendTyping = "send typing",
-    System = "/system"
-};
-
-enum MockBotCardCommandType {
-    Hero = "hero",
-    Signin = "signin",
-    Thumbnail = "thumbnail"
-};
+import MockBotCommand from "./MockBotCommand";
+import MockBotCardCommandType from "./MockBotCardCommandType";
 
 export class DemoChatAdapter extends MockAdapter {
     constructor() {
@@ -65,34 +50,34 @@ export class DemoChatAdapter extends MockAdapter {
 
             if (activity.text) {
                 switch(true) {
-                    case activity.text === MockBotCommands.Help:
+                    case activity.text === MockBotCommand.Help:
                         this.postBotCommandsActivity();
                         break;
-                    case activity.text === MockBotCommands.SendSystemMessage:
+                    case activity.text === MockBotCommand.SendSystemMessage:
                         postSystemMessageActivity(this.activityObserver, "Contoso has joined the chat.");
                         break;
-                    case activity.text === MockBotCommands.SendTyping:
+                    case activity.text === MockBotCommand.SendTyping:
                         postBotTypingActivity(this.activityObserver);
                         break;
-                    case activity.text === MockBotCommands.SendAttachment:
+                    case activity.text === MockBotCommand.SendAttachment:
                         postBotAttachmentActivity(this.activityObserver, [createJpgFileAttachment()]);
                         break;
-                    case activity.text === MockBotCommands.SendBotMessage:
+                    case activity.text === MockBotCommand.SendBotMessage:
                         postBotMessageActivity(this.activityObserver, "Hi, how can I help you?");
                         break;
-                    case activity.text === `${MockBotCommands.Card} ${MockBotCardCommandType.Signin}`:
+                    case activity.text === `${MockBotCommand.Card} ${MockBotCardCommandType.Signin}`:
                         postBotAttachmentActivity(this.activityObserver, [createSigninCardAttachment()]);
                         break;
-                    case activity.text === `${MockBotCommands.Card} ${MockBotCardCommandType.Hero}`:
+                    case activity.text === `${MockBotCommand.Card} ${MockBotCardCommandType.Hero}`:
                         postBotAttachmentActivity(this.activityObserver, [createHeroCardAttachment()]);
                         break;
-                    case activity.text === `${MockBotCommands.Card} ${MockBotCardCommandType.Thumbnail}`:
+                    case activity.text === `${MockBotCommand.Card} ${MockBotCardCommandType.Thumbnail}`:
                         postBotAttachmentActivity(this.activityObserver, [createThumbnailCardAttachment()]);
                         break;
-                    case activity.text.startsWith(`${MockBotCommands.Bot} `):
+                    case activity.text.startsWith(`${MockBotCommand.Bot} `):
                         postBotMessageActivity(this.activityObserver, activity.text.substring(5));
                         break;
-                    case activity.text.startsWith(`${MockBotCommands.System} `):
+                    case activity.text.startsWith(`${MockBotCommand.System} `):
                         postSystemMessageActivity(this.activityObserver, activity.text.substring(8));
                         break;
                 }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -78,6 +78,11 @@ export class DemoChatAdapter extends MockAdapter {
                                     title: "Send typing",
                                     type: "imBack",
                                     value: "send typing"
+                                },
+                                {
+                                    title: "Send bot message",
+                                    type: "imBack",
+                                    value: "send bot message"
                                 }
                             ],
                             title: "Commands"
@@ -88,7 +93,7 @@ export class DemoChatAdapter extends MockAdapter {
         }, delay);
     }
 
-    private postSystemMessageActivity(text: string, delay = 1000) {
+    private postBotMessageActivity(text: string, tags = "", delay = 1000) {
         setTimeout(() => {
             this.activityObserver?.next({
                 id: uuidv4(),
@@ -98,10 +103,14 @@ export class DemoChatAdapter extends MockAdapter {
                 text,
                 type: "message",
                 channelData: {
-                    tags: "system"
+                    tags
                 }
             });
         }, delay);
+    }
+
+    private postSystemMessageActivity(text: string, delay = 1000) {
+        this.postBotMessageActivity(text, "system", delay);
     }
 
     private postBotTypingActivity(delay = 1000) {
@@ -130,6 +139,8 @@ export class DemoChatAdapter extends MockAdapter {
                 case "send typing":
                     this.postBotTypingActivity();
                     break;
+                case "send bot message":
+                    this.postBotMessageActivity("Hi, how can I help you?");
             }
         }
 

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -22,9 +22,14 @@ export class DemoChatAdapter extends MockAdapter {
         super();
 
         setTimeout(() => {
-            this.postSystemMessageActivity("You're currently using a demo.");
+            this.postSystemMessageActivity("You're currently using a demo.", 0);
+            this.postBotActivity("Type `/help` to learn more", 0); // send init message from bot
+        }, 1000);
+    }
 
-            this.activityObserver?.next({ // send init message from bot
+    private postBotActivity(text: string, delay = 1000): void {
+        setTimeout(() => {
+            this.activityObserver?.next({
                 id: uuidv4(),
                 from: {
                     ...botUser
@@ -32,11 +37,11 @@ export class DemoChatAdapter extends MockAdapter {
                 text: "Type `/help` to learn more",
                 type: "message"
             });
-        }, 1000);
+        }, delay);
     }
 
     // WebChat expects an "echo" activity to confirm the message has been sent successfully
-    private postEchoActivity(activity: Message, user: User): void {
+    private postEchoActivity(activity: Message, user: User, delay = 1000): void {
         const echoActivity: Message = {
             ...activity,
             id: uuidv4(),
@@ -48,10 +53,10 @@ export class DemoChatAdapter extends MockAdapter {
 
         setTimeout(() => {
             this.activityObserver?.next(echoActivity); // mock message sent activity
-        }, 1000);
+        }, delay);
     }
 
-    private postBotCommandsActivity() {
+    private postBotCommandsActivity(delay = 1000) {
         setTimeout(() => {
             this.activityObserver?.next({
                 id: uuidv4(),
@@ -80,29 +85,36 @@ export class DemoChatAdapter extends MockAdapter {
                     }
                 ]
             });
-        }, 1000);
+        }, delay);
     }
 
-    private postSystemMessageActivity(text: string) {
-        this.activityObserver?.next({
-            id: uuidv4(),
-            from: {
-                ...botUser
-            },
-            text,
-            type: "message",
-            channelData: {
-                tags: "system"
-            }
-        });
+    private postSystemMessageActivity(text: string, delay = 1000) {
+        setTimeout(() => {
+            this.activityObserver?.next({
+                id: uuidv4(),
+                from: {
+                    ...botUser
+                },
+                text,
+                type: "message",
+                channelData: {
+                    tags: "system"
+                }
+            });
+        }, delay);
     }
 
     public postActivity(activity: Message): Observable<string> {
         if (activity) {
             this.postEchoActivity(activity, customerUser);
 
-            if (activity.text === "/help") {
-                this.postBotCommandsActivity();
+            switch(activity.text) {
+                case "/help":
+                    this.postBotCommandsActivity();
+                    break;
+                case "send system message":
+                    this.postSystemMessageActivity("Contoso has joined the chat.");
+                    break;
             }
         }
 

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -104,6 +104,18 @@ export class DemoChatAdapter extends MockAdapter {
         }, delay);
     }
 
+    private postBotTypingActivity(delay = 1000) {
+        setTimeout(() => {
+            this.activityObserver?.next({
+                id: uuidv4(),
+                from: {
+                    ...botUser
+                },
+                type: "typing"
+            });
+        }, delay);
+    }
+
     public postActivity(activity: Message): Observable<string> {
         if (activity) {
             this.postEchoActivity(activity, customerUser);
@@ -114,6 +126,9 @@ export class DemoChatAdapter extends MockAdapter {
                     break;
                 case "send system message":
                     this.postSystemMessageActivity("Contoso has joined the chat.");
+                    break;
+                case "send typing":
+                    this.postBotTypingActivity();
                     break;
             }
         }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -129,18 +129,24 @@ export class DemoChatAdapter extends MockAdapter {
         if (activity) {
             this.postEchoActivity(activity, customerUser);
 
-            switch(activity.text) {
-                case "/help":
-                    this.postBotCommandsActivity();
-                    break;
-                case "send system message":
-                    this.postSystemMessageActivity("Contoso has joined the chat.");
-                    break;
-                case "send typing":
-                    this.postBotTypingActivity();
-                    break;
-                case "send bot message":
-                    this.postBotMessageActivity("Hi, how can I help you?");
+            if (activity.text) {
+                switch(true) {
+                    case activity.text === "/help":
+                        this.postBotCommandsActivity();
+                        break;
+                    case activity.text === "send system message":
+                        this.postSystemMessageActivity("Contoso has joined the chat.");
+                        break;
+                    case activity.text === "send typing":
+                        this.postBotTypingActivity();
+                        break;
+                    case activity.text === "send bot message":
+                        this.postBotMessageActivity("Hi, how can I help you?");
+                        break;
+                    case activity.text.startsWith("/bot "):
+                        this.postBotMessageActivity(activity.text.substring(5));
+                        break;
+                }
             }
         }
 

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatAdapter.ts
@@ -1,26 +1,58 @@
 import "rxjs/add/operator/share";
 import "rxjs/add/observable/of";
-
-import {  Message } from "botframework-directlinejs";
+import { Message, User } from "botframework-directlinejs";
 import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
 import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
 
+const customerUser: User = {
+    id: "usedId",
+    name: "User",
+    role: "user"
+};
+
+const botUser: User = {
+    id: "botId",
+    name: "Bot",
+    role: "bot"
+};
+
 export class DemoChatAdapter extends MockAdapter {
     constructor() {
         super();
+
+        setTimeout(() => {
+            this.activityObserver?.next({ // send system message
+                id: uuidv4(),
+                from: {
+                    ...botUser
+                },
+                text: "You're currently using a demo.",
+                type: "message",
+                channelData: {
+                    tags: "system"
+                }
+            });
+
+            this.activityObserver?.next({ // send init message from bot
+                id: uuidv4(),
+                from: {
+                    ...botUser
+                },
+                text: "Type `help` to learn more",
+                type: "message"
+            });
+        }, 1000);
     }
 
     // WebChat expects an "echo" activity to confirm the message has been sent successfully
-    private postEchoActivity(activity: Message): void {
+    private postEchoActivity(activity: Message, user: User): void {
         const echoActivity: Message = {
             ...activity,
             id: uuidv4(),
             from: {
                 ...activity.from,
-                id: "usedId",
-                name: "User",
-                role: "user"
+                ...user
             }
         };
 
@@ -31,7 +63,7 @@ export class DemoChatAdapter extends MockAdapter {
 
     public postActivity(activity: Message): Observable<string> {
         if (activity) {
-            this.postEchoActivity(activity);
+            this.postEchoActivity(activity, customerUser);
         }
 
         return Observable.of(activity.id || "");

--- a/chat-widget/src/components/webchatcontainerstateful/common/DemoChatSDK.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DemoChatSDK.ts
@@ -1,0 +1,12 @@
+import { DemoChatAdapter } from "./DemoChatAdapter";
+import { MockChatSDK } from "./mockchatsdk";
+
+export class DemoChatSDK extends MockChatSDK {
+    constructor() {
+        super();
+    }
+
+    public createChatAdapter() {
+        return new DemoChatAdapter();
+    }
+}

--- a/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
@@ -1,5 +1,7 @@
+import { Message } from "botframework-directlinejs";
+import { Observable } from "rxjs/Observable";
 import MockAdapter from "./mockadapter";
-import { customerUser, postBotMessageActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
+import { customerUser, postBotMessageActivity, postEchoActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
 
 export class DesignerChatAdapter extends MockAdapter {
     constructor() {
@@ -21,8 +23,17 @@ export class DesignerChatAdapter extends MockAdapter {
                     ...customerUser
                 },
                 text,
-                type: "message"
+                type: "message",
+                timestamp: new Date().toISOString()
             });
         }, delay);
+    }
+
+    public postActivity(activity: Message): Observable<string> {
+        if (activity) {
+            postEchoActivity(this.activityObserver, activity, customerUser);
+        }
+
+        return Observable.of(activity.id || "");
     }
 }

--- a/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
@@ -10,22 +10,21 @@ export class DesignerChatAdapter extends MockAdapter {
         setTimeout(() => {
             postBotMessageActivity(this.activityObserver, "Id venenatis a condimentum vitae?", undefined, 0);
             this.postUserActivity("Diam donec adipiscing tristique risus nec feugiat in fermentum", 0);
-            postSystemMessageActivity(this.activityObserver, "We are finding the best agent for your inquiry, please hold ...", 0);
-            postSystemMessageActivity(this.activityObserver, "John has joined the chat", 0);
-            postBotMessageActivity(this.activityObserver, "Neque viverra justo nec ultrices dui sapien eget mi proin", undefined, 0);
+            postSystemMessageActivity(this.activityObserver, "We are finding the best agent for your inquiry, please hold ...", 100);
+            postSystemMessageActivity(this.activityObserver, "John has joined the chat", 100);
+            postBotMessageActivity(this.activityObserver, "Neque viverra justo nec ultrices dui sapien eget mi proin", undefined, 100);
         }, 1000);
     }
 
     private postUserActivity(text: string, delay = 1000) {
         setTimeout(() => {
-            this.postActivity({
+            postEchoActivity(this.activityObserver, {
+                text,
                 from: {
                     ...customerUser
                 },
-                text,
-                type: "message",
-                timestamp: new Date().toISOString()
-            });
+                type: "message"
+            }, customerUser, 0);
         }, delay);
     }
 

--- a/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
@@ -1,0 +1,28 @@
+import MockAdapter from "./mockadapter";
+import { customerUser, postBotMessageActivity, postSystemMessageActivity } from "./utils/chatAdapterUtils";
+
+export class DesignerChatAdapter extends MockAdapter {
+    constructor() {
+        super();
+
+        setTimeout(() => {
+            postBotMessageActivity(this.activityObserver, "Id venenatis a condimentum vitae?", undefined, 0);
+            this.postUserActivity("Diam donec adipiscing tristique risus nec feugiat in fermentum", 0);
+            postSystemMessageActivity(this.activityObserver, "We are finding the best agent for your inquiry, please hold ...", 0);
+            postSystemMessageActivity(this.activityObserver, "John has joined the chat", 0);
+            postBotMessageActivity(this.activityObserver, "Neque viverra justo nec ultrices dui sapien eget mi proin", undefined, 0);
+        }, 1000);
+    }
+
+    private postUserActivity(text: string, delay = 1000) {
+        setTimeout(() => {
+            this.postActivity({
+                from: {
+                    ...customerUser
+                },
+                text,
+                type: "message"
+            });
+        }, delay);
+    }
+}

--- a/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatSDK.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatSDK.ts
@@ -1,0 +1,12 @@
+import { DesignerChatAdapter } from "./DesignerChatAdapter";
+import { MockChatSDK } from "./mockchatsdk";
+
+export class DesignerChatSDK extends MockChatSDK {
+    constructor() {
+        super();
+    }
+
+    public createChatAdapter() {
+        return new DesignerChatAdapter();
+    }
+}

--- a/chat-widget/src/components/webchatcontainerstateful/common/MockBotCardCommandType.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/MockBotCardCommandType.ts
@@ -1,0 +1,7 @@
+enum MockBotCardCommandType {
+    Hero = "hero",
+    Signin = "signin",
+    Thumbnail = "thumbnail"
+}
+
+export default MockBotCardCommandType;

--- a/chat-widget/src/components/webchatcontainerstateful/common/MockBotCommand.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/MockBotCommand.ts
@@ -1,0 +1,12 @@
+enum MockBotCommand {
+    Bot = "/bot",
+    Card = "/card",
+    Help = "/help",
+    SendAttachment = "send attachment",
+    SendBotMessage = "send bot message",
+    SendSystemMessage = "send system message",
+    SendTyping = "send typing",
+    System = "/system"
+}
+
+export default MockBotCommand;

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockadapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockadapter.ts
@@ -9,7 +9,7 @@ import { Subscriber } from "rxjs/Subscriber";
 import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
 
 export default class MockAdapter {
-    private activityObserver?: Subscriber<Activity>;
+    public activityObserver?: Subscriber<Activity>;
 
     public activity$: Observable<Activity>;
     public connectionStatus$: BehaviorSubject<ConnectionStatus> = new BehaviorSubject<ConnectionStatus>(ConnectionStatus.Uninitialized);

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
@@ -12,6 +12,11 @@ export class MockChatSDK {
         orgId: "00000000-0000-0000-0000-000000000000",
         orgUrl: "https://contoso.crm.dynamics.com",
     }
+
+    public async initialize() {
+        return this.getLiveChatConfig();
+    }
+
     public async startChat() {
         await this.sleep(1000);
     }

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/attachmentActivityUtils.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/attachmentActivityUtils.ts
@@ -1,0 +1,73 @@
+import { HeroCard, Signin, Thumbnail } from "botframework-directlinejs";
+
+export const createJpgFileAttachment = () => {
+    return {
+        contentType: "image/jpeg", 
+        name: "600x400.jpg", 
+        contentUrl: "https://raw.githubusercontent.com/microsoft/omnichannel-chat-sdk/e7e75d4ede351e1cf2e52f13860d2284848c4af0/playwright/public/images/600x400.jpg"
+    };
+};
+
+export const createHeroCardAttachment = (): HeroCard => {
+    return {
+        contentType: "application/vnd.microsoft.card.hero",
+        content: {
+            buttons: [
+                {
+                    title: "Bellevue",
+                    type: "imBack",
+                    value: "Bellevue"
+                },
+                {
+                    title: "Redmond",
+                    type: "imBack",
+                    value: "Redmond"
+                },
+                {
+                    title: "Seattle",
+                    type: "imBack",
+                    value: "Seattle"
+                }
+            ],
+            title: "Choose your location"
+        }
+    };
+};
+
+export const createThumbnailCardAttachment = (): Thumbnail => {
+    return {
+        contentType: "application/vnd.microsoft.card.thumbnail",
+        content: {
+            title: "Microsoft",
+            subtitle: "Our mission is to empower every person and every organization on the planet to achieve more.",
+            text: "Microsoft creates platforms and tools powered by AI to deliver innovative solutions that meet the evolving needs of our customers. The technology company is committed to making AI available broadly and doing so responsibly, with a mission to empower every person and every organization on the planet to achieve more.",
+            images: [{
+                alt: "Microsoft logo",
+                url: "https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b?ver=5c31" // logo from https://microsoft.com
+            }],
+            buttons: [
+                {
+                    title: "Learn more",
+                    type: "openUrl",
+                    value: "https://www.microsoft.com/"
+                }
+            ]
+        }
+    };
+};
+
+export const createSigninCardAttachment = (): Signin => {
+    return {
+        contentType: "application/vnd.microsoft.card.signin",
+        content: {
+            text: "Please login",
+            buttons: [
+                {
+                    type: "signin",
+                    title: "Signin",
+                    value: "https://login.live.com/"
+                }
+            ]
+        }
+    };
+};

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
@@ -1,5 +1,5 @@
 import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
-import { Activity, Message, User } from "botframework-directlinejs";
+import { Activity, Attachment, Message, User } from "botframework-directlinejs";
 import { Subscriber } from "rxjs/Subscriber";
 
 export const customerUser: User = {
@@ -30,7 +30,7 @@ export const postEchoActivity = (activityObserver: Subscriber<Activity> | undefi
     }, delay);
 };
 
-export const postBotMessageActivity = (activityObserver: Subscriber<Activity> | undefined, text: string, tags = "", delay = 1000) => {
+export const postBotMessageActivity = (activityObserver: Subscriber<Activity> | undefined, text: string, tags = "", delay = 1000): void => {
     setTimeout(() => {
         activityObserver?.next({
             id: uuidv4(),
@@ -42,6 +42,35 @@ export const postBotMessageActivity = (activityObserver: Subscriber<Activity> | 
             channelData: {
                 tags
             }
+        });
+    }, delay);
+};
+
+export const postSystemMessageActivity = (activityObserver: Subscriber<Activity> | undefined, text: string, delay = 1000): void => {
+    postBotMessageActivity(activityObserver, text, "system", delay);
+};
+
+export const postBotTypingActivity = (activityObserver: Subscriber<Activity> | undefined, delay = 1000): void => {
+    setTimeout(() => {
+        activityObserver?.next({
+            id: uuidv4(),
+            from: {
+                ...botUser
+            },
+            type: "typing"
+        });
+    }, delay);
+};
+
+export const postBotAttachmentActivity = (activityObserver: Subscriber<Activity> | undefined, attachments: Attachment[] = [], delay = 1000): void => {
+    setTimeout(() => {
+        activityObserver?.next({
+            id: uuidv4(),
+            from: {
+                ...botUser
+            },
+            attachments,
+            type: "message",
         });
     }, delay);
 };

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
@@ -22,7 +22,8 @@ export const postEchoActivity = (activityObserver: Subscriber<Activity> | undefi
         from: {
             ...activity.from,
             ...user
-        }
+        },
+        timestamp: new Date().toISOString()
     };
 
     setTimeout(() => {
@@ -41,7 +42,8 @@ export const postBotMessageActivity = (activityObserver: Subscriber<Activity> | 
             type: "message",
             channelData: {
                 tags
-            }
+            },
+            timestamp: new Date().toISOString()
         });
     }, delay);
 };
@@ -71,6 +73,7 @@ export const postBotAttachmentActivity = (activityObserver: Subscriber<Activity>
             },
             attachments,
             type: "message",
+            timestamp: new Date().toISOString()
         });
     }, delay);
 };

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
@@ -29,3 +29,19 @@ export const postEchoActivity = (activityObserver: Subscriber<Activity> | undefi
         activityObserver?.next(echoActivity); // mock message sent activity
     }, delay);
 };
+
+export const postBotMessageActivity = (activityObserver: Subscriber<Activity> | undefined, text: string, tags = "", delay = 1000) => {
+    setTimeout(() => {
+        activityObserver?.next({
+            id: uuidv4(),
+            from: {
+                ...botUser
+            },
+            text,
+            type: "message",
+            channelData: {
+                tags
+            }
+        });
+    }, delay);
+};

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/chatAdapterUtils.ts
@@ -1,0 +1,31 @@
+import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
+import { Activity, Message, User } from "botframework-directlinejs";
+import { Subscriber } from "rxjs/Subscriber";
+
+export const customerUser: User = {
+    id: "usedId",
+    name: "User",
+    role: "user"
+};
+
+export const botUser: User = {
+    id: "botId",
+    name: "Bot",
+    role: "bot"
+};
+
+// WebChat expects an "echo" activity to confirm the message has been sent successfully
+export const postEchoActivity = (activityObserver: Subscriber<Activity> | undefined, activity: Message, user: User, delay = 1000): void => {
+    const echoActivity: Message = {
+        ...activity,
+        id: uuidv4(),
+        from: {
+            ...activity.from,
+            ...user
+        }
+    };
+
+    setTimeout(() => {
+        activityObserver?.next(echoActivity); // mock message sent activity
+    }, delay);
+};


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
- Add ability for chat widget to be in `mock` mode
- By default, a real connection to a messaging service is required to use the chat widget
- Created a demo chat adapter without real connection to a messaging service to show case different functionality of the chat widget
- The `mock` mode would allow chat widget to run into different mode for customer demo, specific testing, etc

Sample Configuration:
```ts
const liveChatWidgetProps = {
  mock: {
    type: "demo"
  }
}; 
```
### Acceptance criteria
- Chat widget is rendered properly in `mock` mode with no messaging service connection

## Test cases and evidence
- Manual validation

<img width="275" alt="image" src="https://github.com/user-attachments/assets/8e999f0e-df26-4fe4-ac8a-5b7ca1941d3e">


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__