### PR TITLE
adding attachement in new message event payload

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-
+- Added attachment in message recieved event payload
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat
 - Moved `AuthTokenAcquisition` to allow `auth` http calls to Omnichannel service before `StartChat`
 - Added `AuthTokenAcquisition` to happen during `StartChat` by default to support `pop-out chat`

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Added attachment in message recieved event payload
+- Added attachment in message received event payload
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat
 - Moved `AuthTokenAcquisition` to allow `auth` http calls to Omnichannel service before `StartChat`
 - Added `AuthTokenAcquisition` to happen during `StartChat` by default to support `pop-out chat`

--- a/chat-widget/src/plugins/newMessageEventHandler.ts
+++ b/chat-widget/src/plugins/newMessageEventHandler.ts
@@ -28,7 +28,7 @@ export const createOnNewAdapterActivityHandler = (chatId: string, userId: string
                 isChatComplete: false,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 text: (activity as any)?.text,
-                attachment: (activity as any)?.attachments.length >= 1 ? (activity as any)?.attachments : []
+                attachment: (activity as any)?.attachments?.length >= 1 ? (activity as any)?.attachments : []
             };
         };
 

--- a/chat-widget/src/plugins/newMessageEventHandler.ts
+++ b/chat-widget/src/plugins/newMessageEventHandler.ts
@@ -27,7 +27,8 @@ export const createOnNewAdapterActivityHandler = (chatId: string, userId: string
                 id: activity?.id,
                 isChatComplete: false,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                text: (activity as any)?.text
+                text: (activity as any)?.text,
+                attachment: (activity as any)?.attachments.length >= 1 ? (activity as any)?.attachments : []
             };
         };
 

--- a/chat-widget/src/plugins/newMessageEventHandler.ts
+++ b/chat-widget/src/plugins/newMessageEventHandler.ts
@@ -28,6 +28,7 @@ export const createOnNewAdapterActivityHandler = (chatId: string, userId: string
                 isChatComplete: false,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 text: (activity as any)?.text,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 attachment: (activity as any)?.attachments?.length >= 1 ? (activity as any)?.attachments : []
             };
         };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
adaptiveCard attachment was skipped in the MessageReceived event payload.

## Solution Proposed
Added check to see if attachment is present in the activity, if it is present it is added to the payload

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
![image](https://github.com/user-attachments/assets/e9777d02-7f9a-4675-a748-ea3913248387)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__