### PR TITLE
improve of performance for starting chat

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+
+- Improve load performance for startchat logic
 - Added attachment in message received event payload
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat
 - Moved `AuthTokenAcquisition` to allow `auth` http calls to Omnichannel service before `StartChat`

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -33,7 +33,6 @@ let popoutWidgetInstanceId: any | "";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setAuthenticationIfApplicable = async (props: ILiveChatWidgetProps | undefined, chatSDK: any) => {
-    console.time("setAuthenticationIfApplicable");
     const chatConfig = props?.chatConfig;
     const getAuthToken = props?.getAuthToken;
     const authClientFunction = getAuthClientFunction(chatConfig);
@@ -44,12 +43,10 @@ const setAuthenticationIfApplicable = async (props: ILiveChatWidgetProps | undef
             throw new Error(WidgetLoadCustomErrorString.AuthenticationFailedErrorString);
         }
     }
-    console.timeEnd("setAuthenticationIfApplicable");
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any) => {
-    console.time("prepareStartChat");
     optionalParams = {}; //Resetting to ensure no stale values
     widgetInstanceId = getWidgetCacheIdfromProps(props);
 
@@ -82,12 +79,10 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 
     //Setting PreChat and intiate chat
     await setPreChatAndInitiateChat(chatSDK, dispatch, setAdapter, isProactiveChat, isPreChatEnabledInProactiveChat, state, props);
-    console.timeEnd("prepareStartChat");
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
-    console.time("setPreChatAndInitiateChat");
     //Handle reconnect scenario
 
     // Getting prechat Survey Context
@@ -127,12 +122,10 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
     const optionalParams: StartChatOptionalParams = { isProactiveChat };
     await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams);
-    console.timeEnd("setPreChatAndInitiateChat");
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, state: ILiveChatWidgetContext | undefined, props?: ILiveChatWidgetProps, params?: StartChatOptionalParams, persistedState?: any) => {
-    console.time("initStartChat");
     let isStartChatSuccessful = false;
     const persistentChatEnabled = await isPersistentChatEnabled(state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode);
 
@@ -176,10 +169,8 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
                 portalContactId: window.Microsoft?.Dynamic365?.Portal?.User?.contactId
             };
             const startChatOptionalParams: StartChatOptionalParams = Object.assign({}, params, optionalParams, defaultOptionalParams);
-            console.time("chatSDK.startChat");
             //await Promise.all([chatSDK.startChat(startChatOptionalParams), createAdapterAndSubscribe(chatSDK, dispatch, setAdapter)]);
             await chatSDK.startChat(startChatOptionalParams);
-            console.timeEnd("chatSDK.startChat");
             isStartChatSuccessful = true;
         } catch (error) {
             checkContactIdError(error);
@@ -211,11 +202,9 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         
         // Persistent Chat relies on the `reconnectId` retrieved from reconnectablechats API to reconnect upon start chat and not `liveChatContext`
         if (!persistentChatEnabled) {
-            console.time("chatSDK.getCurrentLiveChatContext");
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const liveChatContext: any = await chatSDK?.getCurrentLiveChatContext();
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: liveChatContext });
-            console.time("chatSDK.getCurrentLiveChatContext");
         }
 
         logWidgetLoadComplete();
@@ -231,27 +220,20 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         optionalParams = {};
         widgetInstanceId = "";
     }
-    console.timeEnd("initStartChat");
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const createAdapterAndSubscribe = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any) => {
-    console.time("createAdapterAndSubscribe");
     // New adapter creation
     const newAdapter = await createAdapter(chatSDK);
     setAdapter(newAdapter);
 
-    console.time("chatSDK.getChatToken");
     const chatToken = await chatSDK.getChatToken(true);
-    console.timeEnd("chatSDK.getChatToken");
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: chatToken });
-    console.log("Chat Token: ", chatToken);
     newAdapter?.activity$?.subscribe(createOnNewAdapterActivityHandler(chatToken?.chatId, chatToken?.visitorId));
-    console.timeEnd("createAdapterAndSubscribe");
 };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const canConnectToExistingChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any) => {
-    console.time("canConnectToExistingChat");
     // By pass this function in case of popout chat
     if (state?.appStates?.hideStartChatButton === true) {
         return false;
@@ -268,14 +250,11 @@ const canConnectToExistingChat = async (props: ILiveChatWidgetProps, chatSDK: an
         await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams, persistedState);
         return true;
     }
-
-    console.timeEnd("canConnectToExistingChat");
     return false;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setCustomContextParams = async (state: ILiveChatWidgetContext | undefined, props?: ILiveChatWidgetProps) => {
-    console.time("setCustomContextParams");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = (props?.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction ? true : false;
     //Should not set custom context for auth chat
@@ -313,11 +292,9 @@ const setCustomContextParams = async (state: ILiveChatWidgetContext | undefined,
             });
         }
     }
-    console.timeEnd("setCustomContextParams");
 };
 
 const canStartPopoutChat = async (props: ILiveChatWidgetProps) => {
-    console.time("canStartPopoutChat");
     if (props.allowSdkChatSupport === false) {
         return false;
     }
@@ -334,24 +311,18 @@ const canStartPopoutChat = async (props: ILiveChatWidgetProps) => {
             BroadcastService.postMessage({
                 eventName: BroadcastEvent.InitiateStartChatInPopoutMode
             });
-            console.timeEnd("canStartPopoutChat");
-
             return true;
         }
     }
-    console.timeEnd("canStartPopoutChat");
     return false;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, state: ILiveChatWidgetContext): Promise<boolean> => {
-    console.time("checkIfConversationStillValid");
     const requestIdFromCache = state.domainStates?.liveChatContext?.requestId;
     const liveChatContext = state?.domainStates?.liveChatContext;
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let conversationDetails: any = undefined;
-
     // Preserve current requestId
     const currentRequestId = chatSDK.requestId ?? "";
     dispatch({ type: LiveChatWidgetActionType.SET_INITIAL_CHAT_SDK_REQUEST_ID, payload: currentRequestId });
@@ -368,8 +339,6 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
             return false;
         }
-        console.timeEnd("checkIfConversationStillValid");
-
         return true;
     }
     catch (error) {
@@ -379,8 +348,6 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
                 exception: `Conversation is not valid: ${error}`
             }
         });
-        console.timeEnd("checkIfConversationStillValid");
-
         return false;
     }
 };
@@ -392,7 +359,6 @@ const getInitContextParamsForPopout = async (): Promise<any> => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getInitContextParamForPopoutFromOuterScope = async (scope: any): Promise<any> =>  {
-    console.time("getInitContextParamForPopoutFromOuterScope");
     let payload;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let waitPromiseResolve: any;
@@ -412,7 +378,6 @@ const getInitContextParamForPopoutFromOuterScope = async (scope: any): Promise<a
     scope.postMessage({ messageName: Constants.InitContextParamsRequest }, "*");
     await waitPromise;
     window.removeEventListener("message", getInitContextParamsFromParent, false);
-    console.timeEnd("getInitContextParamForPopoutFromOuterScope");
     return payload;
 };
 export { prepareStartChat, initStartChat, setPreChatAndInitiateChat, checkIfConversationStillValid };

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -190,6 +190,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILING, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Active });
         }
+        
         if (persistedState) {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_STATE, payload: persistedState });
             logWidgetLoadComplete(WidgetLoadTelemetryMessage.PersistedStateRetrievedMessage);

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -193,6 +193,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         if (persistedState) {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_STATE, payload: persistedState });
             logWidgetLoadComplete(WidgetLoadTelemetryMessage.PersistedStateRetrievedMessage);
+            // Set post chat context in state, load in background to do not block the load
             setPostChatContextAndLoadSurvey(chatSDK, dispatch, true);
             return;
         }

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -22,7 +22,7 @@ import { createOnNewAdapterActivityHandler } from "../../../plugins/newMessageEv
 import { isPersistentChatEnabled } from "./liveChatConfigUtils";
 import { setPostChatContextAndLoadSurvey } from "./setPostChatContextAndLoadSurvey";
 import { shouldSetPreChatIfPersistentChat } from "./persistentChatHelper";
-import { updateSessionDataForTelemetry } from "./updateSessionDataForTelemetry";
+import { updateTelemetryData } from "./updateSessionDataForTelemetry";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let optionalParams: StartChatOptionalParams = {};
@@ -169,7 +169,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
                 portalContactId: window.Microsoft?.Dynamic365?.Portal?.User?.contactId
             };
             const startChatOptionalParams: StartChatOptionalParams = Object.assign({}, params, optionalParams, defaultOptionalParams);
-            //await Promise.all([chatSDK.startChat(startChatOptionalParams), createAdapterAndSubscribe(chatSDK, dispatch, setAdapter)]);
             await chatSDK.startChat(startChatOptionalParams);
             isStartChatSuccessful = true;
         } catch (error) {
@@ -208,12 +207,10 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         }
 
         logWidgetLoadComplete();
-        // Set post chat context in state
-        // Commenting this for now as post chat context is fetched during end chat
+        // Set post chat context in state, load in background to do not block the load
         setPostChatContextAndLoadSurvey(chatSDK, dispatch);
-
         // Updating chat session detail for telemetry
-        await updateSessionDataForTelemetry(chatSDK, dispatch);
+        await updateTelemetryData(chatSDK, dispatch);
     } catch (ex) {
         handleStartChatError(dispatch, chatSDK, props, ex, isStartChatSuccessful);
     } finally {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -225,6 +225,7 @@ const createAdapterAndSubscribe = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const newAdapter = await createAdapter(chatSDK);
     setAdapter(newAdapter);
 
+    //start chat is already seeding the chat token, so no need to get it again
     const chatToken = await chatSDK.getChatToken(true);
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: chatToken });
     newAdapter?.activity$?.subscribe(createOnNewAdapterActivityHandler(chatToken?.chatId, chatToken?.visitorId));

--- a/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChatErrorHandler.ts
@@ -1,17 +1,18 @@
-import { ChatSDKErrorName, ChatSDKError } from "@microsoft/omnichannel-chat-sdk";
+import { ChatSDKError, ChatSDKErrorName } from "@microsoft/omnichannel-chat-sdk";
 import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
-import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
-import { TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
+import { PrepareEndChatDescriptionConstants, WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../../common/Constants";
+import { callingStateCleanUp, chatSDKStateCleanUp, closeChatStateCleanUp, endChatStateCleanUp } from "./endChat";
+
 import { ConversationState } from "../../../contexts/common/ConversationState";
-import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
+import { DataStoreManager } from "../../../common/contextDataStore/DataStoreManager";
 import { Dispatch } from "react";
 import { ILiveChatWidgetAction } from "../../../contexts/common/ILiveChatWidgetAction";
-import { callingStateCleanUp, endChatStateCleanUp, closeChatStateCleanUp, chatSDKStateCleanUp } from "./endChat";
-import { DataStoreManager } from "../../../common/contextDataStore/DataStoreManager";
 import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
-import { getWidgetCacheIdfromProps } from "../../../common/utils";
-import { PrepareEndChatDescriptionConstants, WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../../common/Constants";
+import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
 import { StartChatFailureType } from "../../../contexts/common/StartChatFailureType";
+import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
+import { TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
+import { getWidgetCacheIdfromProps } from "../../../common/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handleStartChatError = (dispatch: Dispatch<ILiveChatWidgetAction>, chatSDK: any, props: ILiveChatWidgetProps | undefined, ex: any, isStartChatSuccessful: boolean) => {

--- a/chat-widget/src/components/livechatwidget/common/updateSessionDataForTelemetry.ts
+++ b/chat-widget/src/components/livechatwidget/common/updateSessionDataForTelemetry.ts
@@ -10,18 +10,27 @@ import { getConversationDetailsCall } from "../../../common/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const updateSessionDataForTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
+    console.time("updateSessionDataForTelemetry");
+    await Promise.all([updateTelemetry(chatSDK, dispatch), updateConversationDataForTelemetry(chatSDK, dispatch)]);
+    console.timeEnd("updateSessionDataForTelemetry");
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const updateTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
+    console.time("updateTelemetry");
     if (chatSDK) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const chatSession: any = await chatSDK.getCurrentLiveChatContext();
         const telemetryData = TelemetryHelper.addSessionDataToTelemetry(chatSession as LiveChatContext, TelemetryManager.InternalTelemetryData);
         dispatch({ type: LiveChatWidgetActionType.SET_TELEMETRY_DATA, payload: telemetryData });
         BroadcastService.postMessage({ eventName: BroadcastEvent.UpdateSessionDataForTelemetry, payload: {chatSession}});
-        await updateConversationDataForTelemetry(chatSDK, dispatch);
     }
+    console.timeEnd("updateTelemetry");
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const updateConversationDataForTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
+    console.time("updateConversationDataForTelemetry");
     if (chatSDK) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const liveWorkItem: any = await getConversationDetailsCall(chatSDK);
@@ -29,4 +38,5 @@ const updateConversationDataForTelemetry = async (chatSDK: any, dispatch: Dispat
         dispatch({ type: LiveChatWidgetActionType.SET_TELEMETRY_DATA, payload: telemetryData });
         BroadcastService.postMessage({ eventName: BroadcastEvent.UpdateConversationDataForTelemetry, payload: {liveWorkItem}});
     }
+    console.timeEnd("updateConversationDataForTelemetry");
 };

--- a/chat-widget/src/components/livechatwidget/common/updateSessionDataForTelemetry.ts
+++ b/chat-widget/src/components/livechatwidget/common/updateSessionDataForTelemetry.ts
@@ -9,15 +9,13 @@ import { TelemetryManager } from "../../../common/telemetry/TelemetryManager";
 import { getConversationDetailsCall } from "../../../common/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const updateSessionDataForTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
-    console.time("updateSessionDataForTelemetry");
-    await Promise.all([updateTelemetry(chatSDK, dispatch), updateConversationDataForTelemetry(chatSDK, dispatch)]);
-    console.timeEnd("updateSessionDataForTelemetry");
+export const updateTelemetryData = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
+    // load it concurrently, this will reduce the load time
+    await Promise.all([updateSessionDataForTelemetry(chatSDK, dispatch), updateConversationDataForTelemetry(chatSDK, dispatch)]);
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const updateTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
-    console.time("updateTelemetry");
+const updateSessionDataForTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
     if (chatSDK) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const chatSession: any = await chatSDK.getCurrentLiveChatContext();
@@ -25,12 +23,10 @@ const updateTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetA
         dispatch({ type: LiveChatWidgetActionType.SET_TELEMETRY_DATA, payload: telemetryData });
         BroadcastService.postMessage({ eventName: BroadcastEvent.UpdateSessionDataForTelemetry, payload: {chatSession}});
     }
-    console.timeEnd("updateTelemetry");
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const updateConversationDataForTelemetry = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>) => {
-    console.time("updateConversationDataForTelemetry");
     if (chatSDK) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const liveWorkItem: any = await getConversationDetailsCall(chatSDK);
@@ -38,5 +34,4 @@ const updateConversationDataForTelemetry = async (chatSDK: any, dispatch: Dispat
         dispatch({ type: LiveChatWidgetActionType.SET_TELEMETRY_DATA, payload: telemetryData });
         BroadcastService.postMessage({ eventName: BroadcastEvent.UpdateConversationDataForTelemetry, payload: {liveWorkItem}});
     }
-    console.timeEnd("updateConversationDataForTelemetry");
 };

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -141,7 +141,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const startChat = async (props: ILiveChatWidgetProps, localState?: any) => {
-        console.time("startChat");
         const isReconnectTriggered = async (): Promise<boolean> => {
             if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
                 const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
@@ -189,7 +188,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
             }
         }
-        console.timeEnd("startChat");
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -208,7 +206,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     };
 
     useEffect(() => {
-        console.time("timer1");
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILING, payload: false });
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.Generic });
         state.domainStates.confirmationPaneConfirmedOptionClicked = false;
@@ -243,14 +240,11 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         // Unauth chat
         if (state?.appStates?.hideStartChatButton === false) {
             startChat(props);
-            console.timeEnd("timer1");
         }
-        console.timeEnd("timer1");
     }, []);
 
     // useEffect for when skip chat button rendering
     useEffect(() => {
-        console.time("timer2");
         if (state?.appStates?.hideStartChatButton === true) {
             //handle OOH pane
             if (props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
@@ -264,7 +258,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             //Pass the state to avoid getting stale state
             startChat(props, state);
         }
-        console.timeEnd("timer2");
     }, [state?.appStates?.hideStartChatButton]);
 
     // useEffect for custom context
@@ -471,7 +464,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     }, []);
 
     useEffect(() => {
-        console.time("timer3");
         // On new message
         if (state.appStates.conversationState === ConversationState.Active) {
             chatSDK?.onNewMessage(() => {
@@ -491,7 +483,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 setWebChatStyles((styles: StyleOptions) => { return { ...styles, hideSendBox: true }; });
             }
         }
-        console.timeEnd("timer3");
     }, [state.appStates.conversationState]);
 
     useEffect(() => {

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -141,6 +141,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const startChat = async (props: ILiveChatWidgetProps, localState?: any) => {
+        console.time("startChat");
         const isReconnectTriggered = async (): Promise<boolean> => {
             if (isReconnectEnabled(props.chatConfig) === true && !isPersistentEnabled(props.chatConfig)) {
                 const noValidReconnectId = await handleChatReconnect(chatSDK, props, dispatch, setAdapter, initStartChat, state);
@@ -188,6 +189,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
             }
         }
+        console.timeEnd("startChat");
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -206,6 +208,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     };
 
     useEffect(() => {
+        console.time("timer1");
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILING, payload: false });
         dispatch({ type: LiveChatWidgetActionType.SET_START_CHAT_FAILURE_TYPE, payload: StartChatFailureType.Generic });
         state.domainStates.confirmationPaneConfirmedOptionClicked = false;
@@ -240,11 +243,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         // Unauth chat
         if (state?.appStates?.hideStartChatButton === false) {
             startChat(props);
+            console.timeEnd("timer1");
         }
+        console.timeEnd("timer1");
     }, []);
 
     // useEffect for when skip chat button rendering
     useEffect(() => {
+        console.time("timer2");
         if (state?.appStates?.hideStartChatButton === true) {
             //handle OOH pane
             if (props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
@@ -258,6 +264,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             //Pass the state to avoid getting stale state
             startChat(props, state);
         }
+        console.timeEnd("timer2");
     }, [state?.appStates?.hideStartChatButton]);
 
     // useEffect for custom context
@@ -464,6 +471,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     }, []);
 
     useEffect(() => {
+        console.time("timer3");
         // On new message
         if (state.appStates.conversationState === ConversationState.Active) {
             chatSDK?.onNewMessage(() => {
@@ -483,6 +491,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 setWebChatStyles((styles: StyleOptions) => { return { ...styles, hideSendBox: true }; });
             }
         }
+        console.timeEnd("timer3");
     }, [state.appStates.conversationState]);
 
     useEffect(() => {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

Looking into the performance of launching the widget and start chat , current time launch depends on calls to backend plus additional logic.

load time in local is around 3-4secs

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

- Load post survey context in the backgroun when loading the widget
- Load getchattoken from cache, since startchat already seed the values
- load concurrently telemetry ,

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

![image](https://github.com/user-attachments/assets/90350b7c-2af7-4a61-8874-d50662d34534)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__