### PR TITLE
issue with multitab sessions not being in sync

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Patch for multitab scenarios with perf changes
 - Improve load performance for startchat logic
 - Added attachment in message received event payload
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -184,7 +184,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         }
 
         await createAdapterAndSubscribe(chatSDK, dispatch, setAdapter);
-        console.log("ELOPEZANAYA:v5");
 
         // Set app state to Active
         if (isStartChatSuccessful) {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -183,6 +183,9 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             throw error;
         }
 
+        await createAdapterAndSubscribe(chatSDK, dispatch, setAdapter);
+        console.log("ELOPEZANAYA:v5");
+
         // Set app state to Active
         if (isStartChatSuccessful) {
             ActivityStreamHandler.uncork();
@@ -199,12 +202,11 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
             return;
         }
 
-        await createAdapterAndSubscribe(chatSDK, dispatch, setAdapter);
-        
         // Persistent Chat relies on the `reconnectId` retrieved from reconnectablechats API to reconnect upon start chat and not `liveChatContext`
         if (!persistentChatEnabled) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const liveChatContext: any = await chatSDK?.getCurrentLiveChatContext();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: liveChatContext });
         }
 
@@ -227,8 +229,7 @@ const createAdapterAndSubscribe = async (chatSDK: any, dispatch: Dispatch<ILiveC
     const newAdapter = await createAdapter(chatSDK);
     setAdapter(newAdapter);
 
-    //start chat is already seeding the chat token, so no need to get it again
-    const chatToken = await chatSDK.getChatToken(true);
+    const chatToken = await chatSDK.getChatToken();
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: chatToken });
     newAdapter?.activity$?.subscribe(createOnNewAdapterActivityHandler(chatToken?.chatId, chatToken?.visitorId));
 };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_
Issue on multitab scenarios, related to a late creation of the adapter, causing when having 2 buttons loaded, the second chat wont sync to the same conversation

![image](https://github.com/user-attachments/assets/c031d900-7d92-4c95-8d48-7b149e905d16)

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

![image](https://github.com/user-attachments/assets/a875fdd4-631a-4dd9-bda4-b6c861626c7f)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__