### PR TITLE
Users/mithunj/empty adaptive card

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Add
 
+- Add New adapter subscriber to ignore adaptive card message from rendering if it contains all invisible fields
 - Add `mock` props to allow chat widget to run in `mock mode` with `DemoChatAdapter`
 
 ### Fixed

--- a/chat-widget/src/components/livechatwidget/common/ActivitySubscriber/HiddenAdaptiveCardActivitySubscriber.ts
+++ b/chat-widget/src/components/livechatwidget/common/ActivitySubscriber/HiddenAdaptiveCardActivitySubscriber.ts
@@ -1,0 +1,52 @@
+import { Constants } from "../../../../common/Constants";
+import { BroadcastEvent } from "../../../../common/telemetry/TelemetryConstants";
+import { IActivitySubscriber } from "./IActivitySubscriber";
+import { BroadcastService } from "@microsoft/omnichannel-chat-components";
+
+export class HiddenAdaptiveCardActivitySubscriber implements IActivitySubscriber {
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public observer: any;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public async apply(activity: any): Promise<void> {
+        const { attachments, attachment } = activity;
+
+        // Use `attachments` or `attachment` (whichever exists)
+        const cards = attachments || [attachment]; 
+
+        // Check if contentType is "AdaptiveCard"
+        const adaptiveCard = cards?.find(
+            (item: any) => Constants.supportedAdaptiveCardContentTypes.indexOf(item.contentType) >= 0
+        );
+
+        if (adaptiveCard && adaptiveCard.content) {
+            const { body } = adaptiveCard.content;
+
+            if (Array.isArray(body)) {
+            // Check if all elements in `body` have `isVisible: false`
+                const allInvisible = body.every((item) => item.isVisible === false);
+
+                if (allInvisible) {
+                    this.observer.next(false); 
+                    BroadcastService.postMessage( { eventName: BroadcastEvent.NewMessageReceived, payload: { attachments: cards, text: "Custom Event" }});
+                    return;
+                }
+            }
+        }
+        return activity
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    public applicable(activity: any): boolean {
+        return true;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public async next(activity: any) {
+        if (this.applicable(activity)) {
+            return await this.apply(activity);
+        }
+        return activity;
+    }
+}

--- a/chat-widget/src/components/livechatwidget/common/ActivitySubscriber/HiddenAdaptiveCardActivitySubscriber.ts
+++ b/chat-widget/src/components/livechatwidget/common/ActivitySubscriber/HiddenAdaptiveCardActivitySubscriber.ts
@@ -26,6 +26,7 @@ export class HiddenAdaptiveCardActivitySubscriber implements IActivitySubscriber
 
         // Check if contentType is "AdaptiveCard"
         const adaptiveCard = cards?.find(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (item: any) => Constants.supportedAdaptiveCardContentTypes.indexOf(item?.contentType) >= 0
         );
 

--- a/chat-widget/src/components/livechatwidget/common/createAdapter.ts
+++ b/chat-widget/src/components/livechatwidget/common/createAdapter.ts
@@ -5,6 +5,7 @@ import { defaultMiddlewareLocalizedTexts } from "../../webchatcontainerstateful/
 import { ChatAdapterShim } from "./ChatAdapterShim";
 import { PauseActivitySubscriber } from "./ActivitySubscriber/PauseActivitySubscriber";
 import { BotAuthActivitySubscriber } from "./ActivitySubscriber/BotAuthActivitySubscriber";
+import { HiddenAdaptiveCardActivitySubscriber } from "./ActivitySubscriber/HiddenAdaptiveCardActivitySubscriber";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createAdapter = async (chatSDK: any) => {
@@ -38,6 +39,8 @@ export const createAdapter = async (chatSDK: any) => {
         adapter = new ChatAdapterShim(adapter);
         adapter.addSubscriber(new PauseActivitySubscriber());
         adapter.addSubscriber(new BotAuthActivitySubscriber());
+        // Remove this code after https://portal.microsofticm.com/imp/v5/incidents/details/544623085/summary is fixed
+        adapter.addSubscriber(new HiddenAdaptiveCardActivitySubscriber());
         return adapter.chatAdapter;
     }
     return adapter;

--- a/chat-widget/src/components/livechatwidget/common/createAdapter.ts
+++ b/chat-widget/src/components/livechatwidget/common/createAdapter.ts
@@ -39,7 +39,7 @@ export const createAdapter = async (chatSDK: any) => {
         adapter = new ChatAdapterShim(adapter);
         adapter.addSubscriber(new PauseActivitySubscriber());
         adapter.addSubscriber(new BotAuthActivitySubscriber());
-        // Remove this code after https://portal.microsofticm.com/imp/v5/incidents/details/544623085/summary is fixed
+        // Remove this code after ICM ID:544623085 is fixed
         adapter.addSubscriber(new HiddenAdaptiveCardActivitySubscriber());
         return adapter.chatAdapter;
     }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
We have a requirement to handle adaptive card which contains all invisible fields. Currently those adaptive cards are rendered into an empty chat bubble. With this fix it will be ignored from rendering.

## Solution Proposed
Added to subscriber code which is used to check if all fields are invisible and if so, it will not render the adaptive card

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
With Fix
![image](https://github.com/user-attachments/assets/46abc7d5-7e1d-4eb8-b6d9-50e206ca7ba6)
![image](https://github.com/user-attachments/assets/0b5c72f0-bd8f-4bc4-9afe-da2bb27f3780)


With out fix 
![image](https://github.com/user-attachments/assets/cf8c9f34-6f5e-4ef7-a4a0-e9abd7c8abbd)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__