### PR TITLE
retry to get conversation details when not returned very first time

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Add
-
+- Added retries to the call to retrieve conversation id immediately after the start chat is executed
 - Add New adapter subscriber to ignore adaptive card message from rendering if it contains all invisible fields
 - Add `mock` props to allow chat widget to run in `mock mode` with `DemoChatAdapter`
 

--- a/chat-widget/src/components/livechatwidget/common/updateSessionDataForTelemetry.ts
+++ b/chat-widget/src/components/livechatwidget/common/updateSessionDataForTelemetry.ts
@@ -38,7 +38,7 @@ const updateConversationDataForTelemetry = async (chatSDK: any, dispatch: Dispat
             // If liveWorkItem is empty and retry attempts remain, try again
             setTimeout(async () => {
                 await updateConversationDataForTelemetry(chatSDK, dispatch, maxAttempts, attempt + 1);
-            }, 2000); // Retry after 2 seconds
+            }, 1000); // Retry after 2 seconds
         }
     }
 };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### 4394941

### Description
Since getConversationDetails call is made at the end of the startChat causing backend to return empty response or not found. This is because this call is made too soon after the start chat.


## Solution Proposed
Added a retry logic so that it gets the conversation id in one of the retries 

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__