### PR TITLE
Helper method for slack markdown to prevent failures with webpack5

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Added `AuthTokenAcquisition` to happen during `StartChat` by default to support `pop-out chat`
 
 ### Changed
-
+- Using default component for SlackMarkDown, to avoid problems with the code transpiled when using webpack5
 - Stopped logging the end chat exception when the conversation is disconnected or ended by the agent/bot.
 - Updated dompurify version
 - Uptake [@microsoft/omnichannel-chat-sdk@1.9.6](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.9.6)

--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -1,8 +1,8 @@
 import { Constants } from "../../../common/Constants";
 import MarkdownIt from "markdown-it";
 import MarkdownItForInline from "markdown-it-for-inline";
-import SlackMarkdownIt from "slack-markdown-it";
 import { defaultMarkdownLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMarkdownLocalizedTexts";
+import { addSlackMarkdownIt } from "./helpers/markdownHelper";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disableNewLineMarkdownSupport: boolean) => {
@@ -17,8 +17,7 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
                 breaks: (!disableNewLineMarkdownSupport)
             }
         );
-
-        markdown.use(SlackMarkdownIt.default);
+        markdown = addSlackMarkdownIt(markdown);
     } else {
         markdown = new MarkdownIt(
             Constants.Zero,
@@ -37,8 +36,8 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
         ]);
     }
 
-    markdown.disable([           
-        "strikethrough"           
+    markdown.disable([
+        "strikethrough"
     ]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,7 +67,7 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
                     tokens.splice(idx + 2, 0, ...iconTokens);
                 }
             }
-        } 
+        }
     });
 
     return markdown;

--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -1,7 +1,7 @@
 import { Constants } from "../../../common/Constants";
 import MarkdownIt from "markdown-it";
 import MarkdownItForInline from "markdown-it-for-inline";
-import MarkdownSlack from "slack-markdown-it";
+import SlackMarkdownIt from "slack-markdown-it";
 import { defaultMarkdownLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMarkdownLocalizedTexts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -17,7 +17,8 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
                 breaks: (!disableNewLineMarkdownSupport)
             }
         );
-        markdown.use(MarkdownSlack);
+        console.log("Slack MarkdownIt is used for markdown formatting.");
+        markdown.use(SlackMarkdownIt.default);
     } else {
         markdown = new MarkdownIt(
             Constants.Zero,

--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -17,7 +17,7 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
                 breaks: (!disableNewLineMarkdownSupport)
             }
         );
-        console.log("Slack MarkdownIt is used for markdown formatting.");
+
         markdown.use(SlackMarkdownIt.default);
     } else {
         markdown = new MarkdownIt(

--- a/chat-widget/src/components/livechatwidget/common/helpers/markdownHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/helpers/markdownHelper.ts
@@ -1,0 +1,14 @@
+
+import MarkdownIt from "markdown-it";
+import SlackMarkdown from "slack-markdown-it";
+
+export const addSlackMarkdownIt = (markdown: MarkdownIt) => {
+    try {
+        markdown.use(SlackMarkdown);
+    } catch (e) {
+        // this is to support the case when slack-markdown-it 
+        // transpiled code doesn't export default (webpack5)
+        markdown.use(SlackMarkdown.default);
+    }
+    return markdown;
+};

--- a/chat-widget/src/components/livechatwidget/common/helpers/markdownHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/helpers/markdownHelper.ts
@@ -1,4 +1,3 @@
-
 import MarkdownIt from "markdown-it";
 import SlackMarkdown from "slack-markdown-it";
 
@@ -8,7 +7,12 @@ export const addSlackMarkdownIt = (markdown: MarkdownIt) => {
     } catch (e) {
         // this is to support the case when slack-markdown-it 
         // transpiled code doesn't export default (webpack5)
-        markdown.use(SlackMarkdown.default);
+        if (SlackMarkdown.default.apply) {
+            markdown.use(SlackMarkdown.default);
+        } else {
+            console.error("Error while adding slackMarkdown plugin", e);
+        }
+
     }
     return markdown;
 };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

slack markdown depending of the webpack version in use, may or not may expose apply function, this is causing issues when trying to use OC-LCW with markdown enabled with webpack5

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Helper method will fallback to default when applyy function for slack markdown plugin is not found.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
### OOB webpack5 

![image](https://github.com/user-attachments/assets/0365d6da-021f-47d2-8c0c-42804ff937ea)

### OC LCW (webpack 4)
![image](https://github.com/user-attachments/assets/b37cc9d3-aec6-44fa-aa0c-ede53b89ad2e)


![image](https://github.com/user-attachments/assets/ce596331-fdab-44f5-a0e4-802a7aaaa7a6)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__