### PR TITLE
ctrl copy shows in transcript file contains text from aria hidden element

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Add
-
+- Fix to format the output when user do CTRL + COPY in transcript.html
 - Add New adapter subscriber to ignore adaptive card message from rendering if it contains all invisible fields
 - Add `mock` props to allow chat widget to run in `mock mode` with `DemoChatAdapter`
 - Expose `IBotAuthConfig` to support configuration of `fetchBotAuthConfigRetries` and `fetchBotAuthConfigRetryInterval`

--- a/chat-widget/src/plugins/createChatTranscript.ts
+++ b/chat-widget/src/plugins/createChatTranscript.ts
@@ -401,7 +401,6 @@ class TranscriptHTMLBuilder {
                         const clonedSelectedContent = window.getSelection().getRangeAt(0).cloneContents();
                         const copiedContent = document.createElement("div");
                         copiedContent.appendChild(clonedSelectedContent);
-                        console.log(copiedContent)
         
                         event.clipboardData.setData("text/plain", getAllText(copiedContent));
                         event.preventDefault();

--- a/chat-widget/src/plugins/createChatTranscript.ts
+++ b/chat-widget/src/plugins/createChatTranscript.ts
@@ -410,7 +410,7 @@ class TranscriptHTMLBuilder {
                     getAllText = (element) => {
                         let plainText = "";
                         Array.from(element.childNodes).forEach((node) => {
-                            // ignore aria-hidden elements and avartars
+                            // ignore aria-hidden elements and keyboard help text
                             const ariaHiddenAttr = node.attributes ? node.attributes.getNamedItem("aria-hidden") : null;
                             if ((ariaHiddenAttr && ariaHiddenAttr.value === "true") || node.classList && node.classList.contains("webchat__keyboard-help")) {
                                 return;


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
Today after copy and paste transcript, before each messages, there is a title "You said: " or "Bot CU said:". This is confusing. Users don't know what You and Bot CU refer to. Also, agent messages are too crowded. We need an empty line to improve readability.

## Solution Proposed
Created Event handler to handle COPY event

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/user-attachments/assets/1e7589a7-7666-4722-af93-28ab8aaaf5bd)
![image](https://github.com/user-attachments/assets/2e6738a1-45a0-4196-bdb2-904585478d97)



### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__