### PR TITLE
disconnection after offline recovery

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Removed `PreChat Survey` rendering on loading `Persistent Chat` on an existing chat
 - Moved `AuthTokenAcquisition` to allow `auth` http calls to Omnichannel service before `StartChat`
 - Added `AuthTokenAcquisition` to happen during `StartChat` by default to support `pop-out chat`
+- When "offline" session recovers, detect if the session is active, otherwise hide send-box.
 
 ### Changed
 

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -341,6 +341,7 @@ export class WidgetLoadTelemetryMessage {
 export class WidgetLoadCustomErrorString {
     public static readonly AuthenticationFailedErrorString = "Authentication was not successful";
     public static readonly NetworkErrorString = "Network Error";
+    public static readonly CloseAdapterAfterDisconnectionErrorString = "Error trying to end/close chat adapter after the widget is back on-line, for an already disconnected session";
 }
 
 export class PrepareEndChatDescriptionConstants {

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -57,7 +57,7 @@ export enum BroadcastEvent {
     UpdateSessionDataForTelemetry = "UpdateSessionDataForTelemetry",
     UpdateConversationDataForTelemetry = "UpdateConversationDataForTelemetry",
     ContactIdNotFound = "ContactIdNotFound",
-    SyncMinimize = "SyncMinimize"    
+    SyncMinimize = "SyncMinimize"
 }
 
 // Events being logged

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -57,7 +57,7 @@ export enum BroadcastEvent {
     UpdateSessionDataForTelemetry = "UpdateSessionDataForTelemetry",
     UpdateConversationDataForTelemetry = "UpdateConversationDataForTelemetry",
     ContactIdNotFound = "ContactIdNotFound",
-    SyncMinimize = "SyncMinimize"
+    SyncMinimize = "SyncMinimize"    
 }
 
 // Events being logged

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -220,7 +220,8 @@ export enum TelemetryEvent {
     // Chat disconnected
     ChatDisconnectThreadEventReceived = "ChatDisconnectThreadEventReceived",
 
-    HiddenAdaptiveCardMessageReceived = "HiddenAdaptiveCardMessageReceived"
+    HiddenAdaptiveCardMessageReceived = "HiddenAdaptiveCardMessageReceived",
+    EndingAdapterAfterDisconnectionError = "EndingAdapterAfterDisconnectionError"
 }
 
 export interface TelemetryInput {

--- a/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
@@ -1,17 +1,19 @@
-import { StyleOptions } from "botframework-webchat";
-import { NotificationHandler } from "../../webchatcontainerstateful/webchatcontroller/notification/NotificationHandler";
-import { NotificationScenarios } from "../../webchatcontainerstateful/webchatcontroller/enums/NotificationScenarios";
-import { defaultMiddlewareLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts";
 import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
-import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
+
 import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
 import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
+import { NotificationHandler } from "../../webchatcontainerstateful/webchatcontroller/notification/NotificationHandler";
+import { NotificationScenarios } from "../../webchatcontainerstateful/webchatcontroller/enums/NotificationScenarios";
+import { StyleOptions } from "botframework-webchat";
+import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
+import { defaultMiddlewareLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handleChatDisconnect = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext, setWebChatStyles: any) => {
     const chatDisconnectState = state?.appStates?.chatDisconnectEventReceived;
     const chatDisconnectMessage = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_CHAT_DISCONNECT ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_CHAT_DISCONNECT;
     const hideSendBoxOnConversationEnd = props?.webChatContainerProps?.renderingMiddlewareProps?.hideSendboxOnConversationEnd;
+    console.log("Chat disconnect state: ", chatDisconnectState);
 
     switch (chatDisconnectState) {
         case true:

--- a/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/chatDisconnectHelper.ts
@@ -13,7 +13,6 @@ const handleChatDisconnect = (props: ILiveChatWidgetProps, state: ILiveChatWidge
     const chatDisconnectState = state?.appStates?.chatDisconnectEventReceived;
     const chatDisconnectMessage = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_CHAT_DISCONNECT ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_CHAT_DISCONNECT;
     const hideSendBoxOnConversationEnd = props?.webChatContainerProps?.renderingMiddlewareProps?.hideSendboxOnConversationEnd;
-    console.log("Chat disconnect state: ", chatDisconnectState);
 
     switch (chatDisconnectState) {
         case true:

--- a/chat-widget/src/components/livechatwidget/common/createInternetConnectionChangeHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/createInternetConnectionChangeHandler.ts
@@ -1,4 +1,4 @@
-import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
+import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { Constants } from "../../../common/Constants";
@@ -31,8 +31,7 @@ export const createInternetConnectionChangeHandler = async () => {
             });
             NotificationHandler.notifySuccess(NotificationScenarios.InternetConnection, defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_INTERNET_BACK_ONLINE as string);
             BroadcastService.postMessage({
-                eventName: "recconnection",
-                payload: { connected: true }
+                eventName: BroadcastEvent.NetworkReconnected,
             });
         }
     };

--- a/chat-widget/src/components/livechatwidget/common/createInternetConnectionChangeHandler.ts
+++ b/chat-widget/src/components/livechatwidget/common/createInternetConnectionChangeHandler.ts
@@ -1,9 +1,11 @@
+import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
+
+import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { Constants } from "../../../common/Constants";
 import { NotificationHandler } from "../../webchatcontainerstateful/webchatcontroller/notification/NotificationHandler";
 import { NotificationScenarios } from "../../webchatcontainerstateful/webchatcontroller/enums/NotificationScenarios";
-import { defaultMiddlewareLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts";
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
-import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
+import { defaultMiddlewareLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts";
 
 const isInternetConnected = async () => {
     try {
@@ -28,6 +30,10 @@ export const createInternetConnectionChangeHandler = async () => {
                 Event: TelemetryEvent.NetworkReconnected
             });
             NotificationHandler.notifySuccess(NotificationScenarios.InternetConnection, defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_INTERNET_BACK_ONLINE as string);
+            BroadcastService.postMessage({
+                eventName: "recconnection",
+                payload: { connected: true }
+            });
         }
     };
 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -627,7 +627,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             try {
                 adapter.end();
                 adapter.close();
-                setAdapter(adapter);
             } catch (e) {
                 TelemetryHelper.logWebChatEvent(LogLevel.ERROR, {
                     Event: TelemetryEvent.EndingAdapterAfterDisconnectionError,

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -1,9 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { BroadcastService, BroadcastServiceInitialize, decodeComponentString } from "@microsoft/omnichannel-chat-components";
 import { Components, StyleOptions } from "botframework-webchat";
-import { ConfirmationState, Constants, ConversationEndEntity, E2VVOptions, LiveWorkItemState, PrepareEndChatDescriptionConstants, StorageType } from "../../../common/Constants";
+import { ConfirmationState, Constants, ConversationEndEntity, E2VVOptions, LiveWorkItemState, PrepareEndChatDescriptionConstants, StorageType, WidgetLoadCustomErrorString } from "../../../common/Constants";
 import { IStackStyles, Stack } from "@fluentui/react";
 import React, { Dispatch, useEffect, useRef, useState } from "react";
 import { TelemetryManager, TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
@@ -324,7 +322,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
         });
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         BroadcastService.getMessageByEventName(BroadcastEvent.NetworkReconnected).subscribe(async () => {
             if (isThisSessionPopout(window?.location?.href)) {
                 return;
@@ -622,10 +619,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     // Handle Chat disconnect cases
     useEffect(() => {
-
         const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
         handleChatDisconnect(props, inMemoryState, setWebChatStyles);
-        console.log("End chat on disconnection");
         const chatDisconnectState = inMemoryState?.appStates?.chatDisconnectEventReceived;
 
         if (chatDisconnectState && adapter) {
@@ -634,8 +629,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 adapter.close();
                 setAdapter(adapter);
             } catch (e) {
-                console.warn("Error while disconnecting chat", e);
-            }
+                TelemetryHelper.logWebChatEvent(LogLevel.ERROR, {
+                    Event: TelemetryEvent.EndingAdapterAfterDisconnectionError,
+                    Description: WidgetLoadCustomErrorString.CloseAdapterAfterDisconnectionErrorString
+                });            }
         }
     }, [state.appStates.chatDisconnectEventReceived]);
 

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -332,7 +332,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: true });
                 TelemetryHelper.logActionEvent(LogLevel.INFO, {
                     Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
-                    Description: "Chat disconnected due to timeout, left or removed."
+                    Description: "Chat disconnected due to timeout, user went offline or blocked the device (including closing laptop)"
                 });
             }
         });

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -632,7 +632,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 TelemetryHelper.logWebChatEvent(LogLevel.ERROR, {
                     Event: TelemetryEvent.EndingAdapterAfterDisconnectionError,
                     Description: WidgetLoadCustomErrorString.CloseAdapterAfterDisconnectionErrorString
-                });            }
+                });
+            }
         }
     }, [state.appStates.chatDisconnectEventReceived]);
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

When a session goes offline for long time and the session is disconnected, the widget was not able to recognize if the session was disconnected unless the user went to anothet tab and back

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Consult the state of the conversation when session is back online.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

![image](https://github.com/user-attachments/assets/0473fe4c-c2cd-4807-9a6b-13d512c761f7)

![image](https://github.com/user-attachments/assets/301cf38d-b2e7-4602-a773-c376143b8248)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__