### PR TITLE
allowing users to set audio notification state

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Add
-
+- Fix to set the state of audio notification button through configuration props
 - Fix to format the output when user do CTRL + COPY in transcript.html
 - Add New adapter subscriber to ignore adaptive card message from rendering if it contains all invisible fields
 - Add `mock` props to allow chat widget to run in `mock mode` with `DemoChatAdapter`

--- a/chat-widget/src/components/footerstateful/FooterStateful.tsx
+++ b/chat-widget/src/components/footerstateful/FooterStateful.tsx
@@ -1,5 +1,5 @@
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
-import React, { Dispatch } from "react";
+import React, { Dispatch, useEffect } from "react";
 
 import AudioNotificationStateful from "./audionotificationstateful/AudioNotificationStateful";
 import { Constants } from "../../common/Constants";
@@ -62,6 +62,12 @@ export const FooterStateful = (props: any) => {
             isAudioMuted: state.appStates.isAudioMuted
         },
     };
+
+    useEffect(() => {
+        if (state.appStates.isAudioMuted === null) {
+            dispatch({ type: LiveChatWidgetActionType.SET_AUDIO_NOTIFICATION, payload: footerProps?.controlProps?.audioNotificationButtonProps?.isAudioMuted ?? false });
+        }
+    }, []);
 
     return (
         <>


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
CX requested a way to control the state of audio notification initially when chat widget is loaded. 

## Solution Proposed
This pr added a useEffect hook to set the state of audio notification reducer state based on the passed footer configuration.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__