### PR TITLE
LCW Designer - Update mock chat, prevent API call

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Add
+
+- Change LCW Designer default custom chat. Disable survey from LCW Designer mock.
 - Fix to set the state of audio notification button through configuration props
 - Fix to format the output when user do CTRL + COPY in transcript.html
 - Add New adapter subscriber to ignore adaptive card message from rendering if it contains all invisible fields

--- a/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatAdapter.ts
@@ -8,11 +8,11 @@ export class DesignerChatAdapter extends MockAdapter {
         super();
 
         setTimeout(() => {
-            postBotMessageActivity(this.activityObserver, "Id venenatis a condimentum vitae?", undefined, 0);
-            this.postUserActivity("Diam donec adipiscing tristique risus nec feugiat in fermentum", 0);
-            postSystemMessageActivity(this.activityObserver, "We are finding the best agent for your inquiry, please hold ...", 100);
+            postBotMessageActivity(this.activityObserver, "Thank you for contacting us! How can I help you today?", undefined, 0);
+            this.postUserActivity("I need to change my address.", 0);
+            postBotMessageActivity(this.activityObserver, "Okay, let me connect you with a live agent.", undefined, 100);
             postSystemMessageActivity(this.activityObserver, "John has joined the chat", 100);
-            postBotMessageActivity(this.activityObserver, "Neque viverra justo nec ultrices dui sapien eget mi proin", undefined, 100);
+            postBotMessageActivity(this.activityObserver, "I'd be happy to help you update your account.", undefined, 100);
         }, 1000);
     }
 

--- a/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatSDK.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/DesignerChatSDK.ts
@@ -9,4 +9,13 @@ export class DesignerChatSDK extends MockChatSDK {
     public createChatAdapter() {
         return new DesignerChatAdapter();
     }
+
+    public getLiveChatConfig() {
+        return {
+            LiveWSAndLiveChatEngJoin: {
+                msdyn_postconversationsurveyenable: "false",
+                msdyn_conversationmode: "192350000"
+            }
+        };
+    }
 }

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
@@ -71,7 +71,7 @@ export class MockChatSDK {
     public getLiveChatConfig() {      
         return {
             LiveWSAndLiveChatEngJoin: {
-                msdyn_postconversationsurveyenable: "true",
+                msdyn_postconversationsurveyenable: "false",
                 msdyn_conversationmode: "192350000"
             }
         };

--- a/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/mockchatsdk.ts
@@ -68,10 +68,10 @@ export class MockChatSDK {
         return null;
     }
 
-    public getLiveChatConfig() {      
+    public getLiveChatConfig() {
         return {
             LiveWSAndLiveChatEngJoin: {
-                msdyn_postconversationsurveyenable: "false",
+                msdyn_postconversationsurveyenable: "true",
                 msdyn_conversationmode: "192350000"
             }
         };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

4413750

### Description

When loading chat widget in designer mode, we need to prevent calls to the backend, and we need to display a custom chat already in progress.

## Solution Proposed

Update custom mock chat according to requirements.
Declare not to load survey so that we don't make the backend call to load the survey.

### Acceptance criteria

See evidence

## Test cases and evidence

![image](https://github.com/user-attachments/assets/a4bec41d-04e7-4f28-9b5c-cece23b2bfa4)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__