### PR TITLE
property to control choice input adpative compoenent padding

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+ - Padding property to control the padding size choice input adaptive card form field
+
 ## [1.7.3] 2024-11-20
 
 ### Added

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -161,6 +161,11 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
         div[class="ac-textBlock"] *,
         div[class="ac-input-container"] * {white-space:${webChatContainerProps?.adaptiveCardStyles?.textWhiteSpace ?? defaultAdaptiveCardStyles.textWhiteSpace}}
 
+        div[class="ac-input-container"] input.ac-multichoiceInput,
+        div[class="ac-input-container"] select.ac-multichoiceInput {
+            ${webChatContainerProps?.adaptiveCardStyles?.choiceInputPadding ? `padding: ${webChatContainerProps.adaptiveCardStyles.choiceInputPadding} !important;` : ""}
+        }
+
         .ms_lcw_webchat_received_message>div.webchat__stacked-layout>div.webchat__stacked-layout__main>div.webchat__stacked-layout__content>div.webchat__stacked-layout__message-row>[class^=webchat]:not(.webchat__bubble--from-user)>.webchat__bubble__content {
             background-color: ${props.webChatContainerProps?.webChatStyles?.bubbleBackground ?? defaultWebChatContainerStatefulProps.webChatStyles?.bubbleBackground};
             color:${props.webChatContainerProps?.webChatStyles?.bubbleTextColor ?? defaultWebChatContainerStatefulProps.webChatStyles?.bubbleTextColor};

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IAdaptiveCardStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IAdaptiveCardStyles.ts
@@ -4,4 +4,5 @@ export interface IAdaptiveCardStyles {
     anchorColor?: string;
     buttonWhiteSpace?: string;
     textWhiteSpace?: string;
+    choiceInputPadding?: string;
 }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
https://portal.microsofticm.com/imp/v5/incidents/details/568327379/summary

### Description
CX complaints about the padding in adaptive card choice input


## Solution Proposed
Add a configurable property in adaptiveCardStyles to control the padding of the choice input

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

![image](https://github.com/user-attachments/assets/2e4942a2-ce06-4ebe-bee6-b2d5dd4d99c7)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__