### PR TITLE
adding error broadcast event for client app

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+ - New Error Event to notify CX regarding Error in widget
  - Padding property to control the padding size choice input adaptive card form field
 
 ## [1.7.3] 2024-11-20

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -57,7 +57,8 @@ export enum BroadcastEvent {
     UpdateSessionDataForTelemetry = "UpdateSessionDataForTelemetry",
     UpdateConversationDataForTelemetry = "UpdateConversationDataForTelemetry",
     ContactIdNotFound = "ContactIdNotFound",
-    SyncMinimize = "SyncMinimize"
+    SyncMinimize = "SyncMinimize",
+    OnWidgetError = "OnWidgetError"
 }
 
 // Events being logged

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -1,5 +1,5 @@
 import { ConfirmationState, Constants, ConversationEndEntity, ParticipantType, PrepareEndChatDescriptionConstants } from "../../../common/Constants";
-import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
+import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { getConversationDetailsCall, getWidgetEndChatEventName } from "../../../common/utils";
 import { getPostChatContext, initiatePostChat } from "./renderSurveyHelpers";
 
@@ -54,6 +54,14 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
         const postchatContext: any = await getPostChatContext(chatSDK, state, dispatch) ?? state?.domainStates?.postChatContext;
 
         if (postchatContext === undefined) {
+
+            BroadcastService.postMessage({
+                eventName: BroadcastEvent.OnWidgetError,
+                payload: {
+                    errorMessage: "Widget closed as getPostChatContext returned undefined."
+                }
+            });
+            
             // For Customer intiated conversations, just close chat widget
             if (state?.appStates?.conversationEndedBy === ConversationEndEntity.Customer) {
                 TelemetryHelper.logSDKEvent(LogLevel.INFO, {

--- a/chat-widget/src/components/livechatwidget/common/endChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/endChat.ts
@@ -58,7 +58,7 @@ const prepareEndChat = async (props: ILiveChatWidgetProps, chatSDK: any, state: 
             BroadcastService.postMessage({
                 eventName: BroadcastEvent.OnWidgetError,
                 payload: {
-                    errorMessage: "Widget closed as getPostChatContext returned undefined."
+                    errorMessage: "Widget did not display post chat survey as getPostChatContext returned undefined."
                 }
             });
             

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -179,6 +179,13 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
                     exception: `Failed to setup startChat: ${error}`
                 }
             });
+            BroadcastService.postMessage({
+                eventName: BroadcastEvent.OnWidgetError,
+                payload: {
+                    errorMessage: error,
+                }
+            });
+
             isStartChatSuccessful = false;
             throw error;
         }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -168,6 +168,13 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 }
                 return;
             }
+
+            BroadcastService.postMessage({
+                eventName: BroadcastEvent.OnWidgetError,
+                payload: {
+                    errorMessage: "Chat found in cache but invalid as the conversation status is inactive."
+                }
+            });
         }
 
         if (isChatValid === false) {
@@ -249,6 +256,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             //handle OOH pane
             if (props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
+                BroadcastService.postMessage({
+                    eventName: BroadcastEvent.OnWidgetError,
+                    payload: {
+                        errorMessage: "Out-of-office hours status is shown."
+                    }
+                });
                 return;
             }
 
@@ -330,9 +343,17 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
             if (conversationDetails?.state === LiveWorkItemState.WrapUp || conversationDetails?.state === LiveWorkItemState.Closed) {
                 dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: true });
+                const desc = "Chat disconnected due to timeout, user went offline or blocked the device (including closing laptop)"
                 TelemetryHelper.logActionEvent(LogLevel.INFO, {
                     Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
-                    Description: "Chat disconnected due to timeout, user went offline or blocked the device (including closing laptop)"
+                    Description: desc
+                });
+
+                BroadcastService.postMessage({
+                    eventName: BroadcastEvent.OnWidgetError,
+                    payload: {
+                        errorMessage: desc
+                    }
                 });
             }
         });

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -343,7 +343,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
             if (conversationDetails?.state === LiveWorkItemState.WrapUp || conversationDetails?.state === LiveWorkItemState.Closed) {
                 dispatch({ type: LiveChatWidgetActionType.SET_CHAT_DISCONNECT_EVENT_RECEIVED, payload: true });
-                const desc = "Chat disconnected due to timeout, user went offline or blocked the device (including closing laptop)"
+                const desc = "Chat disconnected due to timeout, user went offline or blocked the device (including closing laptop)";
                 TelemetryHelper.logActionEvent(LogLevel.INFO, {
                     Event: TelemetryEvent.ChatDisconnectThreadEventReceived,
                     Description: desc

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/notification/NotificationHandler.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/notification/NotificationHandler.ts
@@ -4,7 +4,7 @@ import { NotificationLevel } from "../enums/NotificationLevel";
 import { WebChatActionType } from "../enums/WebChatActionType";
 import { WebChatStoreLoader } from "../WebChatStoreLoader";
 import { setFocusOnSendBox } from "../../../../common/utils";
-import { BroadcastService } from "@microsoft/omnichannel-chat-components/lib/types/services/BroadcastService";
+import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { BroadcastEvent } from "../../../../common/telemetry/TelemetryConstants";
 
 export class NotificationHandler {

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/notification/NotificationHandler.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/notification/NotificationHandler.ts
@@ -4,6 +4,8 @@ import { NotificationLevel } from "../enums/NotificationLevel";
 import { WebChatActionType } from "../enums/WebChatActionType";
 import { WebChatStoreLoader } from "../WebChatStoreLoader";
 import { setFocusOnSendBox } from "../../../../common/utils";
+import { BroadcastService } from "@microsoft/omnichannel-chat-components/lib/types/services/BroadcastService";
+import { BroadcastEvent } from "../../../../common/telemetry/TelemetryConstants";
 
 export class NotificationHandler {
     private static notify(id: string, level: NotificationLevel, message: string) {
@@ -32,6 +34,13 @@ export class NotificationHandler {
     }
 
     public static notifyError(id: string, message: string) {
+        BroadcastService.postMessage({
+            eventName: BroadcastEvent.OnWidgetError,
+            payload: {
+                errorMessage: message
+            }
+        });
+        
         this.notify(id, NotificationLevel.Error, message);
     }
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
CPS team have a requirement to know about the various error scenarios in the chat widget.

## Solution Proposed
Created a new broadcast event and posted it in various code blocks like start chat error handler etc

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__