### PR TITLE
fixing audio playing issue when button is hidden

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - Padding property to control the padding size choice input adaptive card form field
 
 ### Fixed
-
+- Audio button visibility state is tied to audio mute state 
 - Restriction of the elements allowed to be render in the UI, to avoid security vulnerabilities.
 - New Error Event to notify CX regarding Error in widget
 - Padding property to control the padding size choice input adaptive card form field

--- a/chat-widget/src/components/footerstateful/FooterStateful.tsx
+++ b/chat-widget/src/components/footerstateful/FooterStateful.tsx
@@ -15,6 +15,7 @@ import { TelemetryHelper } from "../../common/telemetry/TelemetryHelper";
 import { downloadTranscript } from "./downloadtranscriptstateful/DownloadTranscriptStateful";
 import useChatContextStore from "../../hooks/useChatContextStore";
 import useChatSDKStore from "../../hooks/useChatSDKStore";
+import { ConversationState } from "../../contexts/common/ConversationState";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const FooterStateful = (props: any) => {
@@ -64,10 +65,12 @@ export const FooterStateful = (props: any) => {
     };
 
     useEffect(() => {
-        if (state.appStates.isAudioMuted === null) {
-            dispatch({ type: LiveChatWidgetActionType.SET_AUDIO_NOTIFICATION, payload: footerProps?.controlProps?.hideAudioNotificationButton ? true : footerProps?.controlProps?.audioNotificationButtonProps?.isAudioMuted ?? false  });
+        if (state.appStates.conversationState === ConversationState.Active) {
+            if (state.appStates.isAudioMuted === null) {
+                dispatch({ type: LiveChatWidgetActionType.SET_AUDIO_NOTIFICATION, payload: footerProps?.controlProps?.hideAudioNotificationButton ? true : footerProps?.controlProps?.audioNotificationButtonProps?.isAudioMuted ?? false  });
+            }
         }
-    }, []);
+    }, [state.appStates.conversationState]);
 
     return (
         <>

--- a/chat-widget/src/components/footerstateful/FooterStateful.tsx
+++ b/chat-widget/src/components/footerstateful/FooterStateful.tsx
@@ -65,7 +65,7 @@ export const FooterStateful = (props: any) => {
 
     useEffect(() => {
         if (state.appStates.isAudioMuted === null) {
-            dispatch({ type: LiveChatWidgetActionType.SET_AUDIO_NOTIFICATION, payload: footerProps?.controlProps?.audioNotificationButtonProps?.isAudioMuted ?? false });
+            dispatch({ type: LiveChatWidgetActionType.SET_AUDIO_NOTIFICATION, payload: footerProps?.controlProps?.hideAudioNotificationButton ? true : footerProps?.controlProps?.audioNotificationButtonProps?.isAudioMuted ?? false  });
         }
     }, []);
 
@@ -80,9 +80,7 @@ export const FooterStateful = (props: any) => {
             }
             <AudioNotificationStateful
                 audioSrc={audioNotificationProps?.audioSrc ?? NewMessageNotificationSoundBase64}
-                isAudioMuted={state.appStates.isAudioMuted === null ?
-                    footerProps?.controlProps?.hideAudioNotificationButton ?? false :
-                    state.appStates.isAudioMuted ?? false}
+                isAudioMuted={state.appStates.isAudioMuted ?? false}
             />
         </>
     );


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
audio is still played even though the button is hidden through the hideAudioNotificationButton prop.

## Solution Proposed
added the hideAudioNotificationButton check when setting the default value of audio muted property
added the conversationState into useEffect dependency array to set the audio muted state only when conversation state is active

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

footerProps: {
          controlProps: {
            hideAudioNotificationButton: true,
          },
        }



https://github.com/user-attachments/assets/088dbd5a-a088-48d7-a917-1bc63afd6dce


 footerProps: {
          controlProps: {
            audioNotificationButtonProps: {
              isAudioMuted: true,
            }
          },
        }

https://github.com/user-attachments/assets/b3feade1-edc5-472a-9d29-c05755d6f388



### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__