### PR TITLE
 Minimizing the chat in OOH pane does not close the iframe layer properly

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-
+- Added Event broadcast from OOH pane when minimized so that iframe width height is adjusted
 - Padding property to control the padding size choice input adaptive card form field
 
 ### Fixed

--- a/chat-widget/src/components/headerstateful/HeaderStateful.tsx
+++ b/chat-widget/src/components/headerstateful/HeaderStateful.tsx
@@ -67,6 +67,7 @@ export const HeaderStateful = (props: IHeaderStatefulParams) => {
             text: "We're Offline"
         },
         onMinimizeClick: () => {
+            TelemetryHelper.logActionEvent(LogLevel.INFO, { Event: TelemetryEvent.HeaderMinimizeButtonClicked, Description: "Header Minimize button clicked." });
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: true });
         },
         ...outOfOfficeHeaderProps?.controlProps,


### PR DESCRIPTION
… minimize handler

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
https://portal.microsofticm.com/imp/v5/incidents/details/569406467/summary

### Description
Need to add event broad cast when header is minimized from ooh pane, which will then send to parent to handle iframe width and height

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4511663
![image](https://github.com/user-attachments/assets/87f46e9f-a310-413a-bd04-28f1909f8ab2)
![image](https://github.com/user-attachments/assets/a14cf293-389a-4e4d-ae42-6e2167999a9e)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__