### PR TITLE
added proper event contract for logSDKEvent in widget

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- Added correct OCChatSDKTelemetryData type when telemetry event builder is alled for logSDKEvent 
 - Added Event broadcast from OOH pane when minimized so that iframe width height is adjusted
 - Padding property to control the padding size choice input adaptive card form field
 

--- a/chat-widget/src/common/telemetry/TelemetryHelper.ts
+++ b/chat-widget/src/common/telemetry/TelemetryHelper.ts
@@ -31,7 +31,8 @@ export class TelemetryHelper {
             case ScenarioType.LOAD: return TelemetryHelper.conformToLoadContract(level, input);
             case ScenarioType.IC3_CLIENT: return TelemetryHelper.conformToIC3ClientContract(level, input);
             case ScenarioType.WEBCHAT: return TelemetryHelper.conformToWebChatContract(level, input);
-            case ScenarioType.OCCHATSDK: return TelemetryHelper.conformToOCChatSDKContract(level, input);
+            case ScenarioType.OCCHATSDK:
+            case ScenarioType.SDK: return TelemetryHelper.conformToOCChatSDKContract(level, input);
             case ScenarioType.ACTIONS: return TelemetryHelper.conformToActionsContract(level, input);
             case ScenarioType.CALLING: return TelemetryHelper.conformToCallingContract(level, input);
             case ScenarioType.ACS_ADAPTER: return TelemetryHelper.conformToACSAdapterContract(level, input);
@@ -191,6 +192,7 @@ export class TelemetryHelper {
                 event.TransactionId = payload.TransactionId;
                 event.ElapsedTimeInMilliseconds = payload.ElapsedTimeInMilliseconds;
                 event.ExceptionDetails = JSON.stringify(payload.ExceptionDetails);
+                event.Description = payload.Description;
             });
     }
 

--- a/chat-widget/src/common/telemetry/definitions/Payload.ts
+++ b/chat-widget/src/common/telemetry/definitions/Payload.ts
@@ -39,6 +39,7 @@ export interface OCChatSDKTelemetryData extends BaseTelemetryData {
     ElapsedTimeInMilliseconds?: number;
     TransactionId: string;
     ExceptionDetails?: object;
+    Description?: string;
 }
 
 export interface IC3ClientTelemetryData extends BaseTelemetryData {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
logSDKEvent is having telemetry payload of type OCChatSDKTelemetryData. but the TelemetryManager which construct the telemetryInput uses conformToConfigValidationContract instead of conformToOCChatSDKContract

Because the telemetry payload is of type OCChatSDKTelemetryData, it should be conforming to OCChatSDKContract.

Because of above but logSDKEvent is not send Description in the payload as it was getting ignored in  conformToConfigValidationContract

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/user-attachments/assets/4c0c3f95-d02d-47a0-b421-9613d394e23d)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__