### PR TITLE
bug fix to clean up previous request id if there is no conversation a…

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Padding property to control the padding size choice input adaptive card form field
 
 ### Fixed
-
+- Fixed resetting request id when getConversationDetails returns wrap or closed state
 - For disconnected chats, perform a soft end chat.
 - Audio button visibility state is tied to audio mute state.
 - Restriction of the elements allowed to be render in the UI, to avoid security vulnerabilities.

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -358,10 +358,6 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
     }
 };
 
-const resetChatState = (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, state: ILiveChatWidgetContext) => {
-   
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getInitContextParamsForPopout = async (): Promise<any> => {
     return window.opener ? await getInitContextParamForPopoutFromOuterScope(window.opener) : null;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -344,6 +344,11 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
 
         if (conversationDetails.state === LiveWorkItemState.Closed || conversationDetails.state === LiveWorkItemState.WrapUp) {
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
+            // reset the requestId to current initial requestId in sdk
+            if (state?.domainStates?.initialChatSdkRequestId) {
+                chatSDK.requestId = state?.domainStates?.initialChatSdkRequestId;
+            }
+
             return false;
         }
         return true;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -1,6 +1,6 @@
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { Constants, LiveWorkItemState, WidgetLoadCustomErrorString, WidgetLoadTelemetryMessage } from "../../../common/Constants";
-import { checkContactIdError, createTimer, getConversationDetailsCall, getStateFromCache, getWidgetCacheIdfromProps, isNullOrEmptyString, isUndefinedOrEmpty } from "../../../common/utils";
+import { checkContactIdError, createTimer, getConversationDetailsCall, getStateFromCache, getWidgetCacheIdfromProps, isNullOrEmptyString, isNullOrUndefined, isUndefinedOrEmpty } from "../../../common/utils";
 import { getAuthClientFunction, handleAuthentication } from "./authHelper";
 import { handleChatReconnect, isPersistentEnabled, isReconnectEnabled } from "./reconnectChatHelper";
 import { handleStartChatError, logWidgetLoadComplete } from "./startChatErrorHandler";
@@ -338,7 +338,7 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
         chatSDK.requestId = requestIdFromCache;
         conversationDetails = await getConversationDetailsCall(chatSDK, liveChatContext);
 
-        if (Object.keys(conversationDetails).length === 0 || conversationDetails.state === LiveWorkItemState.Closed || conversationDetails.state === LiveWorkItemState.WrapUp) {           
+        if (Object.keys(conversationDetails).length === 0 || isNullOrUndefined(conversationDetails.state) || conversationDetails.state === LiveWorkItemState.Closed || conversationDetails.state === LiveWorkItemState.WrapUp) {           
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
             if (currentRequestId) {
                 chatSDK.requestId = currentRequestId;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -338,17 +338,11 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
         chatSDK.requestId = requestIdFromCache;
         conversationDetails = await getConversationDetailsCall(chatSDK, liveChatContext);
 
-        if (Object.keys(conversationDetails).length === 0) {
-            return false;
-        }
-
-        if (conversationDetails.state === LiveWorkItemState.Closed || conversationDetails.state === LiveWorkItemState.WrapUp) {
+        if (Object.keys(conversationDetails).length === 0 || conversationDetails.state === LiveWorkItemState.Closed || conversationDetails.state === LiveWorkItemState.WrapUp) {           
             dispatch({ type: LiveChatWidgetActionType.SET_LIVE_CHAT_CONTEXT, payload: undefined });
-            // reset the requestId to current initial requestId in sdk
-            if (state?.domainStates?.initialChatSdkRequestId) {
-                chatSDK.requestId = state?.domainStates?.initialChatSdkRequestId;
+            if (currentRequestId) {
+                chatSDK.requestId = currentRequestId;
             }
-
             return false;
         }
         return true;
@@ -363,6 +357,10 @@ const checkIfConversationStillValid = async (chatSDK: any, dispatch: Dispatch<IL
         return false;
     }
 };
+
+const resetChatState = (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, state: ILiveChatWidgetContext) => {
+   
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getInitContextParamsForPopout = async (): Promise<any> => {


### PR DESCRIPTION
…ctive

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/4500149

### Description
When the chat is reconnecting, if liveWorkItemDetails returns a wrap-up state, we need to clear the request ID set in the Chat SDK from the liveChatContext.
If request id from a wrapped up conversation is used in a new conversation, it will fail to create a new conversation in backend
https://portal.microsofticm.com/imp/v5/incidents/details/574816606/summary

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__