### PR TITLE
postChatImprovement

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/renderSurveyHelpers.ts
+++ b/chat-widget/src/components/livechatwidget/common/renderSurveyHelpers.ts
@@ -79,9 +79,7 @@ const embedModePostChatWorkflow = async (postChatContext: any, dispatch: Dispatc
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const initiatePostChat = async (props: ILiveChatWidgetProps, conversationDetailsParam: any, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, postchatContext: any) => {
-    conversationDetails = conversationDetailsParam;
-    const participantType = conversationDetails?.participantType ?? postchatContext.participantType;
+const initiatePostChat = async (props: ILiveChatWidgetProps, participantType: string, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, postchatContext: any) => {
     await setSurveyMode(props, participantType, state, dispatch);
 
     await renderSurvey(postchatContext, dispatch);

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -203,8 +203,6 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         if (persistedState) {
             dispatch({ type: LiveChatWidgetActionType.SET_WIDGET_STATE, payload: persistedState });
             logWidgetLoadComplete(WidgetLoadTelemetryMessage.PersistedStateRetrievedMessage);
-            // Set post chat context in state, load in background to do not block the load
-            setPostChatContextAndLoadSurvey(chatSDK, dispatch, true);
             return;
         }
 
@@ -217,8 +215,7 @@ const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAct
         }
 
         logWidgetLoadComplete();
-        // Set post chat context in state, load in background to do not block the load
-        setPostChatContextAndLoadSurvey(chatSDK, dispatch);
+
         // Updating chat session detail for telemetry
         await updateTelemetryData(chatSDK, dispatch);
     } catch (ex) {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
Adding a performance improvement for post-chat loading: the postChatContext API in omnichannel-chat-sdk internally invokes getConversationDetails. Therefore, we can optimize by skipping the getConversationDetails call in endChat and directly using the postChatContext API instead.

Which will save 3 api calls from making to get the postchatContext

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_
![image](https://github.com/user-attachments/assets/3246c890-b056-4f78-a090-08fef4cef2a9)
![image](https://github.com/user-attachments/assets/5001d61f-f69d-444c-96b9-a601d7552cfb)

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__