### PR TITLE
reset chat sdk internal data

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix to reset chatsdk after a conversation with post survey with prechat present.
 - Fixed resetting request id when getConversationDetails returns wrap or closed state
 - For disconnected chats, perform a soft end chat.
 - Audio button visibility state is tied to audio mute state.

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -83,7 +83,12 @@ const prepareStartChat = async (props: ILiveChatWidgetProps, chatSDK: any, state
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, isProactiveChat?: boolean | false, proactiveChatEnablePrechatState?: boolean | false, state?: ILiveChatWidgetContext, props?: ILiveChatWidgetProps) => {
-    //Handle reconnect scenario
+
+    // This reset needs to be done before to load prechat, because the conversation state changes from close to prechat
+    if (state?.appStates.conversationState === ConversationState.Closed) {
+        // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems
+        chatSDKStateCleanUp(chatSDK);
+    }
 
     // Getting prechat Survey Context
     const parseToJson = false;
@@ -121,6 +126,7 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
     //Initiate start chat
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
     const optionalParams: StartChatOptionalParams = { isProactiveChat };
+
     await initStartChat(chatSDK, dispatch, setAdapter, state, props, optionalParams);
 };
 
@@ -128,11 +134,6 @@ const setPreChatAndInitiateChat = async (chatSDK: any, dispatch: Dispatch<ILiveC
 const initStartChat = async (chatSDK: any, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, state: ILiveChatWidgetContext | undefined, props?: ILiveChatWidgetProps, params?: StartChatOptionalParams, persistedState?: any) => {
     let isStartChatSuccessful = false;
     const persistentChatEnabled = await isPersistentChatEnabled(state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode);
-
-    if (state?.appStates.conversationState === ConversationState.Closed) {
-        // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems
-        chatSDKStateCleanUp(chatSDK);
-    }
 
     try {
         // Clear disconnect state on start chat


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
### Description
_Include a description of the problem to be solved_

For widgets with prechat and post chat enabled, after ending a session , the cleanup for the sdk was not happening because the when prechat is present, the state of the conversation is changed from closed to prechat, 

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

Move up the evaluation before to check for prechat and before any change in the state of the conversation, so that the cleanup is done properly

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

For conversations in closed state , the cleanup of the conversation should always happen

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__