### PR TITLE
Updated NetworkReconnected 

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Refactored NetWorkReconnected to call only when there is an active chat
 - Fix to reset chatsdk after a conversation with post survey with prechat present.
 - Adding input element to the blocked list of html rendered elements.
 - Fixed resetting request id when getConversationDetails returns wrap or closed state

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -338,7 +338,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         });
 
         BroadcastService.getMessageByEventName(BroadcastEvent.NetworkReconnected).subscribe(async () => {
-            if (isThisSessionPopout(window?.location?.href)) {
+            const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
+            if (isThisSessionPopout(window?.location?.href) || inMemoryState?.appStates?.conversationState !== ConversationState.Active) {
                 return;
             }
             const conversationDetails = await getConversationDetailsCall(facadeChatSDK);


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
This is to fix the icm that are generated from getConversationDetails SDK failure monitor. 

## Solution Proposed
NetworkReconnected event handler is called even after chat is not active, Updated code to call getConversationDetails only when conversationState is active

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [x] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__