### PR TITLE
Expose transcript customer display name prop

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Add ability to override customer display name on downloading transcript using `downloadTranscriptProps.webChatTranscript.customerDisplayName`
+
 ### Changed
 
 - Uptake [@microsoft/omnichannel-chat-sdk@1.10.11](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.10.11)

--- a/chat-widget/src/components/footerstateful/downloadtranscriptstateful/interfaces/IWebChatTranscriptConfig.ts
+++ b/chat-widget/src/components/footerstateful/downloadtranscriptstateful/interfaces/IWebChatTranscriptConfig.ts
@@ -10,4 +10,5 @@ export interface IWebChatTranscriptConfig {
     agentAvatarFontColor?: string;
     customerAvatarBackgroundColor?: string;
     customerAvatarFontColor?: string;
+    customerDisplayName?: string;
 }

--- a/chat-widget/src/plugins/createChatTranscript.ts
+++ b/chat-widget/src/plugins/createChatTranscript.ts
@@ -16,6 +16,7 @@ class TranscriptHTMLBuilder {
     private agentAvatarFontColor = "#000";
     private customerAvatarBackgroundColor = "#2266E3";
     private customerAvatarFontColor = "#FFF";
+    private customerDisplayName = "";
     private disableMarkdownMessageFormatting = false;
     private disableNewLineMarkdownSupport = false;
     private externalScripts: TranscriptHtmlScripts = {};
@@ -61,6 +62,10 @@ class TranscriptHTMLBuilder {
 
         if (this.options?.customerAvatarFontColor) {
             this.customerAvatarFontColor = this.options.customerAvatarFontColor;
+        }
+
+        if (this.options?.customerDisplayName) {
+            this.customerDisplayName = this.options.customerDisplayName;
         }
 
         if (this.options?.disableMarkdownMessageFormatting) {
@@ -549,7 +554,12 @@ class TranscriptHTMLBuilder {
                     const avatarMiddleware = () => (next) => (...args) => {
                         const [card] = args;
                         const {fromUser, activity} = card;
-                        const initials = getIconText(activity.from.name);
+                        let displayName = getIconText(activity.from.name);
+                        let customerDisplayName = '${this.customerDisplayName}';
+
+                        if (fromUser && customerDisplayName) {
+                            displayName = customerDisplayName;
+                        }
 
                         const avatarElement = React.createElement(
                             "div",
@@ -557,7 +567,7 @@ class TranscriptHTMLBuilder {
                             React.createElement(
                                 "p",
                                 null,
-                                \`\${initials}\`
+                                \`\${displayName}\`
                             )
                         );
 


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
Task 4680790 

### Description
- Customer display name "CU" on downloading transcript can be a profanity in other languages

## Solution Proposed
- Expose `downloadTranscriptProps.webChatTranscript.customerDisplayName`

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
<img width="613" alt="Transcript" src="https://github.com/user-attachments/assets/bb66c509-eca7-4c42-a7e8-6913a076b2b4" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__