### PR TITLE
Added broadcast event for loading pane unmount

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added event broadcast from loading pane unmount to update ariaLiveAlert innertext.
 - Additional telemetry to identify UX start/end scenarios
 
 ## [1.7.4] - 2025-01-28

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Added event broadcast from loading pane unmount to update ariaLiveAlert innertext
 - Uptake [@microsoft/omnichannel-chat-sdk@1.10.11](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.10.11)
 
 ## [1.7.5] - 2025-02-12

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -135,6 +135,7 @@ export enum TelemetryEvent {
     ConfirmationCancelButtonClicked = "ConfirmationCancelButtonClicked",
     ConfirmationConfirmButtonClicked = "ConfirmationConfirmButtonClicked",
     LoadingPaneLoaded = "LoadingPaneLoaded",
+    LoadingPaneUnloaded = "LoadingPaneUnloaded",
     StartChatErrorPaneLoaded = "StartChatErrorPaneLoaded",
     EmailTranscriptLoaded = "EmailTranscriptLoaded",
     OutOfOfficePaneLoaded = "OutOfOfficePaneLoaded",

--- a/chat-widget/src/components/loadingpanestateful/LoadingPaneStateful.tsx
+++ b/chat-widget/src/components/loadingpanestateful/LoadingPaneStateful.tsx
@@ -71,6 +71,13 @@ export const LoadingPaneStateful = (props: any) => {
             ElapsedTimeInMilliseconds: uiTimer.milliSecondsElapsed
         });
         
+        return () => {
+            TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
+                Event: TelemetryEvent.LoadingPaneUnloaded,
+                Description: "Loading pane unmount."
+            });
+        };
+        
     }, []);
     
     return (


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
BUG 4616645

### Description
Added broadcast event for loading pane unmount

## Solution Proposed
Added broadcast event for loading pane, which will be used to update live alert text on loading pane removed, so that it will not be included in accessibility.

### Acceptance criteria
Verified with desktop screen reader and android talkback.

## Test cases and evidence
<img width="1409" alt="Screenshot 2025-02-25 at 6 22 02 PM" src="https://github.com/user-attachments/assets/7e7b798a-8669-4e33-80e9-32ba64d10973" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__