### PR TITLE
fixed download transcript issue for persistent chat after endChat on post chat survey

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed issue where cx was unable to change string messages 
+- Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
 
 ### Changed
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
+
 ## [1.7.6] - 2025-03-04
 
 ### Added
@@ -15,7 +19,6 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
 - Fixed issue where cx was unable to change string messages 
 
 ### Changed

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -15,8 +15,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed issue where cx was unable to change string messages 
 - Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
+- Fixed issue where cx was unable to change string messages 
 
 ### Changed
 

--- a/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
+++ b/chat-widget/src/components/footerstateful/downloadtranscriptstateful/DownloadTranscriptStateful.tsx
@@ -12,6 +12,8 @@ import { NotificationScenarios } from "../../webchatcontainerstateful/webchatcon
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import createChatTranscript from "../../../plugins/createChatTranscript";
 import { executeReducer } from "../../../contexts/createReducer";
+import IChatToken from "@microsoft/omnichannel-chat-sdk/lib/external/IC3Adapter/IChatToken";
+import { uuidv4 } from "@microsoft/omnichannel-chat-sdk";
 
 const processDisplayName = (displayName: string): string => {
     // if displayname matches "teamsvisitor:<some alphanumeric string>", we replace it with "Customer"
@@ -177,6 +179,14 @@ export const downloadTranscript = async (facadeChatSDK: FacadeChatSDK, downloadT
     if (!liveChatContext) {
         const inMemoryState = executeReducer(state as ILiveChatWidgetContext, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
         liveChatContext = inMemoryState.domainStates.liveChatContext;
+        if (!liveChatContext) {
+            const chatToken = (state?.domainStates?.chatToken || inMemoryState.domainStates.chatToken) as IChatToken;
+            // create custom livechatcontext for persistent chat
+            liveChatContext = {
+                chatToken: chatToken,
+                requestId: chatToken.requestId || uuidv4(),
+            };
+        }
     }
 
     let data = await facadeChatSDK?.getLiveChatTranscript({liveChatContext});


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

ICM - Incident 600427003 - Transcript button is not working after the post survey chat

### Description
fixed download transcript issue for persistent chat after endChat on post chat survey

## Solution Proposed
Pass livechatcontext for persistent chat so there will be valid chatId for getLiveChatTranscript when conversation is ended by agent and chatId is cleared at oc-chat-sdk.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
Verified locally, now able to download the transcript

<img width="829" alt="Screenshot 2025-03-07 at 12 39 54 AM" src="https://github.com/user-attachments/assets/d3ea823e-be62-4247-9daf-e97d72dbbe12" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__