### PR TITLE
Add minHeight as workaround for textarea scrollbar issue

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
 - Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
 - Convert base64url tokens into base64 for exp validation.
 
+### Added
+
+- Add sendbox textarea minHeight property as work-around for an issue on Android where some languages' placeholders are smaller than the text, creating an unnecessary scrollbar
+
 ## [1.7.6] - 2025-03-04
 
 ### Added

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
@@ -65,6 +65,11 @@ export interface ILiveChatWidgetProps {
     contextDataStore?: IContextDataStore;
     getAuthToken?: (authClientFunction?: string) => Promise<string | null>;
     scrollBarProps?: IScrollBarProps;
+    sendBoxTextBox?: {
+        // Customer can increase minHeight as a work-around to avoid bug when some languages (like Arabic, Chinese,
+        // Hebrew, etc) will show a scrollbar in the textarea element when placeholder is visible
+        minHeight?: string;
+    }
     useSessionStorage?: boolean;
     allowSdkChatSupport?: boolean; // to avoid any performance impact
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts
@@ -65,11 +65,6 @@ export interface ILiveChatWidgetProps {
     contextDataStore?: IContextDataStore;
     getAuthToken?: (authClientFunction?: string) => Promise<string | null>;
     scrollBarProps?: IScrollBarProps;
-    sendBoxTextBox?: {
-        // Customer can increase minHeight as a work-around to avoid bug when some languages (like Arabic, Chinese,
-        // Hebrew, etc) will show a scrollbar in the textarea element when placeholder is visible
-        minHeight?: string;
-    }
     useSessionStorage?: boolean;
     allowSdkChatSupport?: boolean; // to avoid any performance impact
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/livechatwidget/interfaces/ISendBox.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ISendBox.ts
@@ -1,0 +1,12 @@
+export interface ISendBox {
+    /**
+     * Target the textarea element in the send box
+     */
+    textarea?: {
+        /**
+         * Customer can increase minHeight as a work-around to avoid bug when some languages (like Arabic, Chinese,
+         * Hebrew, etc) will show a scrollbar in the textarea element when placeholder is visible
+         */
+        minHeight?: string;
+    }
+}

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -122,6 +122,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     //Scrollbar styles
     const scrollbarProps: IScrollBarProps = Object.assign({}, defaultScrollBarProps, props?.scrollBarProps);
+    const sendBoxTextBox = props?.sendBoxTextBox;
 
     // In case the broadcast channel is already initialized elsewhere; One tab can only hold 1 instance
     if (props?.controlProps?.skipBroadcastChannelInit !== true) {
@@ -795,7 +796,9 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 height: .75em;
                 margin-left: .25em;
             }
-          }
+            textarea.webchat__send-box-text-box__html-text-area {
+                min-height: ${sendBoxTextBox?.minHeight || "auto"};
+            }
             `}</style>
             <DraggableChatWidget {...chatWidgetDraggableConfig}>
                 <Composer

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -122,7 +122,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
     //Scrollbar styles
     const scrollbarProps: IScrollBarProps = Object.assign({}, defaultScrollBarProps, props?.scrollBarProps);
-    const sendBoxTextBox = props?.sendBoxTextBox;
+    const sendBoxTextArea = props?.webChatContainerProps?.sendBoxTextBox?.textarea;
 
     // In case the broadcast channel is already initialized elsewhere; One tab can only hold 1 instance
     if (props?.controlProps?.skipBroadcastChannelInit !== true) {
@@ -796,9 +796,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 height: .75em;
                 margin-left: .25em;
             }
+            ${sendBoxTextArea?.minHeight && `
             textarea.webchat__send-box-text-box__html-text-area {
-                min-height: ${sendBoxTextBox?.minHeight || "auto"};
-            }
+                min-height: ${sendBoxTextArea?.minHeight};
+            }`}
             `}</style>
             <DraggableChatWidget {...chatWidgetDraggableConfig}>
                 <Composer

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatContainerStatefulProps.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatContainerStatefulProps.ts
@@ -6,6 +6,7 @@ import { IWebChatProps } from "./IWebChatProps";
 import { StyleOptions } from "botframework-webchat-api";
 import { IAdaptiveCardStyles } from "./IAdaptiveCardStyles";
 import { IBotAuthConfig } from "./IBotAuthConfig";
+import { ISendBox } from "../../livechatwidget/interfaces/ISendBox";
 
 export interface IWebChatContainerStatefulProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,4 +25,5 @@ export interface IWebChatContainerStatefulProps {
     botAuthConfig?: IBotAuthConfig;
     hyperlinkTextOverride?: boolean;
     adaptiveCardStyles?: IAdaptiveCardStyles;
+    sendBoxTextBox?: ISendBox;
 }


### PR DESCRIPTION
Customer can increase minHeight as a work-around to avoid bug when some languages (like Arabic, Chinese, Hebrew, etc) will show a scrollbar in the textarea element when placeholder is visible

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description

On Android, some languages will display a scrollbar in the send box textarea element when the placeholder is shown.

## Solution Proposed

Allow clients to pass a minHeight for the textarea element as a workaround for the issue.

### Acceptance criteria

Passing the following `data-customization-callback` config, the send-box textarea should receive the provided height

```javascript
// data-customization-callback
function lcw() {
  return {
    webChatContainerProps: {
      sendBoxTextBox: {
        textarea: {
          minHeight: "27px",
        },
      },
    },
  };
}
```

## Test cases and evidence

Before:
![image](https://github.com/user-attachments/assets/c4ad071a-0c8a-469f-8470-50f9f026bf3d)


After:
![image](https://github.com/user-attachments/assets/9ad7d5b3-3991-4eda-81e4-2e9ef4d762d8)


Tested in browserstack on client's page

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__