### PR TITLE
Hyperlink support in same tab

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added `opensMarkdownLinksInSameTab` and `honorsTargetInHTMLLinks` props to open hyperlinks in same tab or new tab
+
 ### Changed
 
 - Uptake [@microsoft/omnichannel-chat-sdk@1.10.14](https://www.npmjs.com/package/@microsoft/omnichannel-chat-sdk/v/1.10.14)

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -115,6 +115,7 @@ export class Constants {
     public static readonly Target = "target";
     public static readonly Blank = "_blank";
     public static readonly TargetSelf = "_self";
+    public static readonly TargetTop = "_top";
     public static readonly TargetRelationship = "rel";
     public static readonly TargetRelationshipAttributes = "noopener noreferrer";
 

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -114,6 +114,7 @@ export class Constants {
     public static readonly Title = "title";
     public static readonly Target = "target";
     public static readonly Blank = "_blank";
+    public static readonly TargetSelf = "_self";
     public static readonly TargetRelationship = "rel";
     public static readonly TargetRelationshipAttributes = "noopener noreferrer";
 

--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -5,7 +5,7 @@ import { defaultMarkdownLocalizedTexts } from "../../webchatcontainerstateful/co
 import { addSlackMarkdownIt } from "./helpers/markdownHelper";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disableNewLineMarkdownSupport: boolean, opensMarkdownLinksInSameTab: boolean) => {
+export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disableNewLineMarkdownSupport: boolean, opensMarkdownLinksInSameTab?: boolean) => {
     let markdown: MarkdownIt;
 
     if (!disableMarkdownMessageFormatting) {

--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -46,7 +46,7 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
         // Put a transparent pixel instead of the "open in new window" icon, so developers can easily modify the icon in CSS.
         const TRANSPARENT_GIF = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
-        const targetValue = opensMarkdownLinksInSameTab ? Constants.TargetSelf : Constants.Blank;
+        const targetValue = opensMarkdownLinksInSameTab ? Constants.TargetTop : Constants.Blank;
         if (~targetAttrIndex) {
             tokens[idx].attrs[targetAttrIndex][1] = targetValue;  
         } else {

--- a/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
+++ b/chat-widget/src/components/livechatwidget/common/createMarkdown.ts
@@ -5,7 +5,7 @@ import { defaultMarkdownLocalizedTexts } from "../../webchatcontainerstateful/co
 import { addSlackMarkdownIt } from "./helpers/markdownHelper";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disableNewLineMarkdownSupport: boolean) => {
+export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disableNewLineMarkdownSupport: boolean, opensMarkdownLinksInSameTab: boolean) => {
     let markdown: MarkdownIt;
 
     if (!disableMarkdownMessageFormatting) {
@@ -46,11 +46,13 @@ export const createMarkdown = (disableMarkdownMessageFormatting: boolean, disabl
         // Put a transparent pixel instead of the "open in new window" icon, so developers can easily modify the icon in CSS.
         const TRANSPARENT_GIF = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
 
+        const targetValue = opensMarkdownLinksInSameTab ? Constants.TargetSelf : Constants.Blank;
         if (~targetAttrIndex) {
-            tokens[idx].attrs[targetAttrIndex][1] = Constants.Blank;
+            tokens[idx].attrs[targetAttrIndex][1] = targetValue;  
         } else {
-            tokens[idx].attrPush([Constants.Target, Constants.Blank]);
+            tokens[idx].attrPush([Constants.Target, targetValue]);
         }
+
         const relAttrIndex = tokens[idx].attrIndex(Constants.TargetRelationship);
         if (~relAttrIndex) {
             tokens[idx].attrs[relAttrIndex][1] = Constants.TargetRelationshipAttributes;

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -54,10 +54,10 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
     
     const disableNewLineMarkdownSupport = props.webChatContainerProps?.disableNewLineMarkdownSupport ?? defaultWebChatContainerStatefulProps.disableNewLineMarkdownSupport;
     const disableMarkdownMessageFormatting = props.webChatContainerProps?.disableMarkdownMessageFormatting ?? defaultWebChatContainerStatefulProps.disableMarkdownMessageFormatting;
-    const opensMarkdownLinksInSameTab = props.webChatContainerProps?.opensMarkdownLinksInSameTab ?? defaultWebChatContainerStatefulProps.opensMarkdownLinksInSameTab;
-    const honorsTargetInHTMLLinks = props.webChatContainerProps?.honorsTargetInHTMLLinks ?? defaultWebChatContainerStatefulProps.honorsTargetInHTMLLinks ?? false;
+    const opensMarkdownLinksInSameTab = props.webChatContainerProps?.opensMarkdownLinksInSameTab ?? false;
+    const honorsTargetInHTMLLinks = props.webChatContainerProps?.honorsTargetInHTMLLinks ?? false;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const markdown = createMarkdown(disableMarkdownMessageFormatting!, disableNewLineMarkdownSupport!, opensMarkdownLinksInSameTab!);
+    const markdown = createMarkdown(disableMarkdownMessageFormatting!, disableNewLineMarkdownSupport!, opensMarkdownLinksInSameTab);
     // Initialize Web Chat's redux store
     let webChatStore = WebChatStoreLoader.store;
 

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -136,9 +136,11 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
 
     function postDomPurifyActivities() {
         DOMPurify.addHook("afterSanitizeAttributes", function (node) {
-            const target = node.getAttribute("target");
-            if (target && target !== Constants.Blank && target !== Constants.TargetSelf) {
-                node.setAttribute("target", Constants.Blank);
+            const target = node.getAttribute(Constants.Target);
+            if (target === Constants.TargetSelf) {
+                node.setAttribute(Constants.Target, Constants.TargetTop);
+            } else if (!target) {
+                node.setAttribute(Constants.Target, Constants.Blank);
             }
         });
     }

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -54,8 +54,8 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
     
     const disableNewLineMarkdownSupport = props.webChatContainerProps?.disableNewLineMarkdownSupport ?? defaultWebChatContainerStatefulProps.disableNewLineMarkdownSupport;
     const disableMarkdownMessageFormatting = props.webChatContainerProps?.disableMarkdownMessageFormatting ?? defaultWebChatContainerStatefulProps.disableMarkdownMessageFormatting;
-    const opensMarkdownLinksInSameTab = props.webChatContainerProps?.opensMarkdownLinksInSameTab ?? false;
-    const honorsTargetInHTMLLinks = props.webChatContainerProps?.honorsTargetInHTMLLinks ?? false;
+    const opensMarkdownLinksInSameTab = props.webChatContainerProps?.opensMarkdownLinksInSameTab;
+    const honorsTargetInHTMLLinks = props.webChatContainerProps?.honorsTargetInHTMLLinks;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const markdown = createMarkdown(disableMarkdownMessageFormatting!, disableNewLineMarkdownSupport!, opensMarkdownLinksInSameTab);
     // Initialize Web Chat's redux store

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -39,6 +39,7 @@ import htmlPlayerMiddleware from "../../webchatcontainerstateful/webchatcontroll
 import htmlTextMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware";
 import preProcessingMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/preProcessingMiddleware";
 import sanitizationMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/sanitizationMiddleware";
+import { Constants } from "../../../common/Constants";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, facadeChatSDK: FacadeChatSDK, endChat: any) => {
@@ -53,8 +54,10 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
     
     const disableNewLineMarkdownSupport = props.webChatContainerProps?.disableNewLineMarkdownSupport ?? defaultWebChatContainerStatefulProps.disableNewLineMarkdownSupport;
     const disableMarkdownMessageFormatting = props.webChatContainerProps?.disableMarkdownMessageFormatting ?? defaultWebChatContainerStatefulProps.disableMarkdownMessageFormatting;
+    const opensMarkdownLinksInSameTab = props.webChatContainerProps?.opensMarkdownLinksInSameTab ?? defaultWebChatContainerStatefulProps.opensMarkdownLinksInSameTab;
+    const honorsTargetInHTMLLinks = props.webChatContainerProps?.honorsTargetInHTMLLinks ?? defaultWebChatContainerStatefulProps.honorsTargetInHTMLLinks ?? false;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const markdown = createMarkdown(disableMarkdownMessageFormatting!, disableNewLineMarkdownSupport!);
+    const markdown = createMarkdown(disableMarkdownMessageFormatting!, disableNewLineMarkdownSupport!, opensMarkdownLinksInSameTab!);
     // Initialize Web Chat's redux store
     let webChatStore = WebChatStoreLoader.store;
 
@@ -98,7 +101,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
             createMessageSequenceIdOverrideMiddleware,
             gifUploadMiddleware,
             htmlPlayerMiddleware,
-            htmlTextMiddleware,
+            htmlTextMiddleware(honorsTargetInHTMLLinks),
             createMaxMessageSizeValidator(localizedTexts),
             sanitizationMiddleware,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -124,7 +127,8 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
 
         const config = {
             FORBID_TAGS: ["form", "button", "script", "div", "input"],
-            FORBID_ATTR: ["action"]
+            FORBID_ATTR: ["action"],
+            ADD_ATTR: ["target"]
         };
         text = DOMPurify.sanitize(text, config);
         return text;
@@ -132,8 +136,10 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
 
     function postDomPurifyActivities() {
         DOMPurify.addHook("afterSanitizeAttributes", function (node) {
-            // set all elements owning target to target=_blank
-            if ("target" in node) { node.setAttribute("target", "_blank"); }
+            const target = node.getAttribute("target");
+            if (target && target !== Constants.Blank && target !== Constants.TargetSelf) {
+                node.setAttribute("target", Constants.Blank);
+            }
         });
     }
     // Initialize the remaining Web Chat props

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultWebChatContainerStatefulProps.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultWebChatContainerStatefulProps.ts
@@ -11,6 +11,8 @@ export const defaultWebChatContainerStatefulProps: IWebChatContainerStatefulProp
     containerStyles: defaultWebChatStatefulContainerStyles,
     disableNewLineMarkdownSupport: false,
     disableMarkdownMessageFormatting: false,
+    opensMarkdownLinksInSameTab: false,
+    honorsTargetInHTMLLinks: false,
     hyperlinkTextOverride: false,
     directLine: new MockAdapter(),
     adaptiveCardStyles: defaultAdaptiveCardStyles

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatContainerStatefulProps.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatContainerStatefulProps.ts
@@ -12,6 +12,8 @@ export interface IWebChatContainerStatefulProps {
     containerStyles?: IStyle;
     disableNewLineMarkdownSupport?: boolean;
     disableMarkdownMessageFormatting?: boolean;
+    opensMarkdownLinksInSameTab?: boolean;
+    honorsTargetInHTMLLinks?: boolean;
     webChatStyles?: StyleOptions;
     webChatProps?: IWebChatProps;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer.ts
@@ -11,7 +11,7 @@ class HyperlinkTextOverrideRenderer {
         const htmlNode = document.createElement(HtmlAttributeNames.div);
 
         try {
-            text = DOMPurify.sanitize(text); // eslint-disable-line @typescript-eslint/no-explicit-any
+            text = DOMPurify.sanitize(text, {ADD_ATTR: ["target"]}); // eslint-disable-line @typescript-eslint/no-explicit-any
             htmlNode.innerHTML = text;
         } catch {
             return htmlNode;

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer.ts
@@ -11,7 +11,7 @@ class HyperlinkTextOverrideRenderer {
         const htmlNode = document.createElement(HtmlAttributeNames.div);
 
         try {
-            text = DOMPurify.sanitize(text, {ADD_ATTR: ["target"]}); // eslint-disable-line @typescript-eslint/no-explicit-any
+            text = DOMPurify.sanitize(text, {ADD_ATTR: ["target"]});
             htmlNode.innerHTML = text;
         } catch {
             return htmlNode;

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
@@ -88,12 +88,12 @@ const processHTMLText = (action: IWebChatAction, text: string, honorsTargetInHTM
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-const htmlTextMiddleware = (honorsTargetInHTMLLinks: boolean) => ({ dispatch }: { dispatch: any}) => (next: any) => (action: IWebChatAction) => {
+const htmlTextMiddleware = (honorsTargetInHTMLLinks?: boolean) => ({ dispatch }: { dispatch: any}) => (next: any) => (action: IWebChatAction) => {
     if (action.type === WebChatActionType.DIRECT_LINE_INCOMING_ACTIVITY) {
         try {
             const text = action.payload?.activity?.text;
             if (text) {
-                action = processHTMLText(action, text, honorsTargetInHTMLLinks);
+                action = processHTMLText(action, text, honorsTargetInHTMLLinks ?? false);
             }
         } catch (e) {
             let errorMessage = "Failed to validate action.";

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
@@ -18,7 +18,6 @@ const convertTextToHtmlNode = (text: string): any => {
     if (!text) return "";
     const element = document.createElement(HtmlAttributeNames.div);
     try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         text = DOMPurify.sanitize(text, {ADD_ATTR: ["target"]});
         element.innerHTML = text;
     } catch (e) {

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/sanitizationMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/sanitizationMiddleware.ts
@@ -16,7 +16,7 @@ const sanitizationMiddleware = ({ dispatch }: { dispatch: any }) => (next: any) 
         try {
             let text = action.payload?.text;
             if (text) {
-                text = DOMPurify.sanitize(text) ?? " ";
+                text = DOMPurify.sanitize(text, {ADD_ATTR: ["target"]}) ?? " ";
             }
         } catch (e) {
             const copyDataForTelemetry = {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[USER STORY 4697670](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4697670)

### Description
LCW Support HyperLinks that open in new tab

## Solution Proposed
​Add method to enable sending links that open in the same tab. Ideally this would include both:
Add new LCW general config prop, "opensMarkdownLinksInSameTab", defaults to false
When "opensMarkdownLinksInSameTab" is set to true, open markdown link in same tab
Add new LCW general config prop, "honorsTargetInHTMLLinks", defaults to false
When "honorsTargetInHTMLLinks" is set to true, do not overwrite the target attribute in an HTML link

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
Verified hyperlinks and markdown link with these props -"opensMarkdownLinksInSameTab" and "honorsTargetInHTMLLinks"

<img width="1300" alt="Screenshot 2025-03-15 at 11 47 53 AM" src="https://github.com/user-attachments/assets/40ff5521-5164-4f3c-8ce6-1bbcf0a1daf0" />

<img width="1240" alt="Screenshot 2025-03-15 at 11 48 31 AM" src="https://github.com/user-attachments/assets/9d2c6488-2497-4b4c-932e-a9774b904744" />

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__