### PR TITLE
Fix timestamp direction for right-to-left languages

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Switch to use atob instead of Buffer to decode payload token
 - Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
 - Convert base64url tokens into base64 for exp validation.
+- Fix "AM/PM" timestamp direction for RTL languages
 
 ### Added
 

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/timestamps/DeliveredTimestamp.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/timestamps/DeliveredTimestamp.tsx
@@ -25,13 +25,26 @@ export const DeliveredTimestamp = ({ args, role, name }: any) => {
         }
     } = args;
 
+    const getTimeElement = (timestamp: string): string | JSX.Element => {
+        const timeString = getTimestampHourMinute(timestamp);
+        const isAmPmFormat = timeString.toLowerCase().includes("am") || timeString.toLowerCase().includes("pm");
+
+        // For clients that use languages that are written right-to-left, but still use AM/PM time format, we need to
+        // make sure the "rtl" direction doesn't produce "PM 1:23", but remains "1:23 PM"
+        if (dir === "rtl" && isAmPmFormat) {
+            return <span dir="ltr">{getTimestampHourMinute(timestamp)}</span>;
+        } else {
+            return timeString;
+        }
+    };
+
     return (
         <Stack style={contentStyles} dir={dir}>
             {role === DirectLineSenderRole.Bot && <>
-                <span dir={dir} aria-hidden="false">{name}{" - "}{getTimestampHourMinute(timestamp)}</span>
+                <span dir={dir} aria-hidden="false">{name}{" - "}{getTimeElement(timestamp)}</span>
             </>}
             {role === DirectLineSenderRole.User && <>
-                <span aria-hidden="false" dir={dir}> {getTimestampHourMinute(timestamp)}{" - "}
+                <span aria-hidden="false" dir={dir}> {getTimeElement(timestamp)}{" - "}
                     {state.domainStates.middlewareLocalizedTexts?.MIDDLEWARE_MESSAGE_DELIVERED ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_MESSAGE_DELIVERED}</span>
             </>}
         </Stack>

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/timestamps/DeliveredTimestamp.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/timestamps/DeliveredTimestamp.tsx
@@ -33,9 +33,9 @@ export const DeliveredTimestamp = ({ args, role, name }: any) => {
         // make sure the "rtl" direction doesn't produce "PM 1:23", but remains "1:23 PM"
         if (dir === "rtl" && isAmPmFormat) {
             return <span dir="ltr">{getTimestampHourMinute(timestamp)}</span>;
-        } else {
-            return timeString;
         }
+
+        return timeString;
     };
 
     return (


### PR DESCRIPTION
For clients that use languages that are written right-to-left, but still use AM/PM time format, we need to make sure the "rtl" direction doesn't produce "PM 1:23", but remains "1:23 PM"

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

[4789417](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4789417)

### Description
RTL languages using AM/PM time format are displaying "PM 1:23" instead of "1:23 PM" on customer sent message

## Solution Proposed

Wrap the timestamp in a span with correct "ltr" direction

### Acceptance criteria

Should display timestamp with AM/PM after the time, not before the time

## Test cases and evidence

Before:
![image](https://github.com/user-attachments/assets/1557b6c3-6888-4527-b378-53f1c1724b5a)

After:
![image](https://github.com/user-attachments/assets/70807c41-8a4a-4a2b-ae64-3779e68feb7d)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__