### PR TITLE
A11Y fix for keyboard focus on chat restore

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add sendbox textarea minHeight property as work-around for an issue on Android where some languages' placeholders are smaller than the text, creating an unnecessary scrollbar
 - Added `opensMarkdownLinksInSameTab` and `honorsTargetInHTMLLinks` props to open hyperlinks in same tab or new tab
 
 ### Changed
@@ -21,10 +22,7 @@ All notable changes to this project will be documented in this file.
 - Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
 - Convert base64url tokens into base64 for exp validation.
 - Fix "AM/PM" timestamp direction for RTL languages
-
-### Added
-
-- Add sendbox textarea minHeight property as work-around for an issue on Android where some languages' placeholders are smaller than the text, creating an unnecessary scrollbar
+- A11Y fix for keyboard auto-focus on chat restore.
 
 ## [1.7.6] - 2025-03-04
 

--- a/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
@@ -148,11 +148,7 @@ export const PreChatSurveyPaneStateful = (props: IPreChatSurveyPaneStatefulParam
                 }
             }
         }
-        // Move focus to the first button
-        const firstElement: HTMLElement[] | null = findAllFocusableElement(`#${controlProps.id}`);
-        if (firstElement && firstElement[0]) {
-            firstElement[0].focus();
-        }
+
         TelemetryHelper.logLoadingEvent(LogLevel.INFO, { Event: TelemetryEvent.PrechatSurveyLoaded });
         TelemetryHelper.logLoadingEvent(LogLevel.INFO, {
             Event: TelemetryEvent.UXPrechatPaneCompleted,
@@ -160,6 +156,16 @@ export const PreChatSurveyPaneStateful = (props: IPreChatSurveyPaneStatefulParam
         });
     }, []);
 
+    // Set focus to the first element
+    useEffect(() => {
+        if (!state.appStates.isMinimized) {
+            const firstElement: HTMLElement[] | null = findAllFocusableElement(`#${controlProps.id}`);
+            if (firstElement && firstElement[0]) {
+                firstElement[0].focus();
+            }
+        }
+    }, [state.appStates.isMinimized]);
+    
     return (
         <PreChatSurveyPane
             controlProps={controlProps}

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -158,6 +158,13 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
         });
     }, []);
 
+    // Set focus to the sendbox
+    useEffect(() => {
+        if (!state.appStates.isMinimized) {
+            setFocusOnSendBox();
+        }
+    }, [state.appStates.isMinimized]);
+
     return (
         <><style>{`
         .webchat__stacked-layout__content .ac-pushButton {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
BUG 4783065

### Description
[Clipchamp-Help button-Support chat]: After activating support chart keyboard focus not moving to support chat popup.

## Solution Proposed
set focus when chat restored for pre-chat pane and sendbox

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
verified locally

https://github.com/user-attachments/assets/55d0fdb6-8ff4-4ad7-84fa-afd408596d44



### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__