### PR TITLE
a11y fix 

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Convert base64url tokens into base64 for exp validation.
 - Fix "AM/PM" timestamp direction for RTL languages
 - A11Y fix for keyboard auto-focus on chat restore.
+- A11Y fix - added prop to update the web chat history accessibility label for mobile.
 
 ## [1.7.6] - 2025-03-04
 

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -156,6 +156,7 @@ export class HtmlIdNames {
 export class HtmlClassNames {
     public static readonly webChatBannerCloseButton = "webchat__toast__dismissButton";
     public static readonly webChatBannerExpandButton = "webchat__toaster__expandIcon";
+    public static readonly webChatHistoryContainer = "webchat__basic-transcript";
 }
 
 export class HtmlElementSelectors {

--- a/chat-widget/src/common/utils.ts
+++ b/chat-widget/src/common/utils.ts
@@ -468,3 +468,14 @@ export const setOcUserAgent = (chatSDK: any): void => { // eslint-disable-line @
         }
     }
 };
+
+export function getDeviceType(): string {
+    const userAgent = navigator.userAgent.toLowerCase();
+    if (/android/.test(userAgent)) {
+        return "android";
+    } else if (/iphone|ipad|ipod/.test(userAgent)) {
+        return "ios";
+    } else {
+        return "standard";
+    }
+}

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -3,11 +3,11 @@
 import { IRawStyle, IStackStyles, Stack } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect } from "react";
-import { createTimer, setFocusOnSendBox } from "../../common/utils";
+import { createTimer, getDeviceType, setFocusOnSendBox } from "../../common/utils";
 
 import { BotMagicCodeStore } from "./webchatcontroller/BotMagicCodeStore";
 import { Components } from "botframework-webchat";
-import { Constants } from "../../common/Constants";
+import { Constants, HtmlAttributeNames, HtmlClassNames } from "../../common/Constants";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
 import { ILiveChatWidgetContext } from "../../contexts/common/ILiveChatWidgetContext";
 import { ILiveChatWidgetProps } from "../livechatwidget/interfaces/ILiveChatWidgetProps";
@@ -79,7 +79,13 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
     };
 
     useEffect(() => {
-        setFocusOnSendBox();
+        if (getDeviceType() !== "standard" && webChatContainerProps?.webChatHistoryMobileAccessibilityLabel !== undefined) {
+            const chatHistoryElement = document.querySelector(`.${HtmlClassNames.webChatHistoryContainer}`);
+
+            if (chatHistoryElement) {
+                chatHistoryElement.setAttribute(HtmlAttributeNames.ariaLabel, webChatContainerProps.webChatHistoryMobileAccessibilityLabel);
+            }
+        }
         dispatch({ type: LiveChatWidgetActionType.SET_RENDERING_MIDDLEWARE_PROPS, payload: webChatContainerProps?.renderingMiddlewareProps });
         dispatch({ type: LiveChatWidgetActionType.SET_MIDDLEWARE_LOCALIZED_TEXTS, payload: localizedTexts });
         TelemetryHelper.logLoadingEvent(LogLevel.INFO, {

--- a/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatContainerStatefulProps.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/interfaces/IWebChatContainerStatefulProps.ts
@@ -28,4 +28,5 @@ export interface IWebChatContainerStatefulProps {
     hyperlinkTextOverride?: boolean;
     adaptiveCardStyles?: IAdaptiveCardStyles;
     sendBoxTextBox?: ISendBox;
+    webChatHistoryMobileAccessibilityLabel?: string;
 }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[BUG 4616640](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4616640)

### Description
Keyboard related information announced for android talkback

## Solution Proposed
added prop to update webchat history aria label for mobile users only to avoid announcing keyboard related information.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
verified locally

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__