### PR TITLE
Fix script tag issue for chat transcript and download transcript

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fix "AM/PM" timestamp direction for RTL languages
 - A11Y fix for keyboard auto-focus on chat restore.
 - A11Y fix - added prop to update the web chat history accessibility label for mobile.
+- Fixed script tag message issue for chat transcript and download transcript.
 
 ## [1.7.6] - 2025-03-04
 

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
@@ -63,9 +63,6 @@ const processHTMLText = (action: IWebChatAction, text: string, honorsTargetInHTM
                     }
                 }
             }
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            action = updateIn(action, [Constants.payload, Constants.activity, Constants.text], () => htmlNode.innerHTML);
         }
         catch (e) {
             let errorMessage = "Failed to apply action: ";
@@ -83,7 +80,7 @@ const processHTMLText = (action: IWebChatAction, text: string, honorsTargetInHTM
             });
         }
     }
-    
+    action = updateIn(action, [Constants.payload, Constants.activity, Constants.text], () => htmlNode.innerHTML);
     return action;
 };
 

--- a/chat-widget/src/plugins/createChatTranscript.ts
+++ b/chat-widget/src/plugins/createChatTranscript.ts
@@ -4,6 +4,7 @@ import { FacadeChatSDK } from "../common/facades/FacadeChatSDK";
 import TranscriptHtmlScripts from "../components/footerstateful/downloadtranscriptstateful/interfaces/TranscriptHtmlScripts";
 import { createFileAndDownload } from "../common/utils";
 import defaultLibraryScripts from "../components/footerstateful/downloadtranscriptstateful/common/defaultLibraryScripts";
+import DOMPurify from "dompurify";
 
 class TranscriptHTMLBuilder {
     private options: any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -26,6 +27,11 @@ class TranscriptHTMLBuilder {
 
         if (!this.options || !this.options.messages) {
             this.options.messages = [];
+        }  else {
+            this.options.messages = this.options.messages.filter((message: { content: string; }) => {
+                message.content = DOMPurify.sanitize(message.content);
+                return message.content.length > 0;
+            });
         }
 
         if (this.options?.pageTitle) {

--- a/chat-widget/src/plugins/createChatTranscript.ts
+++ b/chat-widget/src/plugins/createChatTranscript.ts
@@ -27,11 +27,6 @@ class TranscriptHTMLBuilder {
 
         if (!this.options || !this.options.messages) {
             this.options.messages = [];
-        }  else {
-            this.options.messages = this.options.messages.filter((message: { content: string; }) => {
-                message.content = DOMPurify.sanitize(message.content);
-                return message.content.length > 0;
-            });
         }
 
         if (this.options?.pageTitle) {
@@ -705,7 +700,10 @@ const createChatTranscript = async (transcript: string, facadeChatSDK: FacadeCha
         });
     };
 
-    let messages = transcriptMessages;
+    let messages = transcriptMessages.filter((message: { content: string; }) => {
+        message.content = DOMPurify.sanitize(message.content);
+        return message.content.length > 0;
+    });
 
     if (renderAttachments) {
         messages = await Promise.all(transcriptMessages.map(async (message: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
1. [BUG 4826216](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/4826216)
2. [BUG 4826237](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/4826237)

### Description
1. Script tag message gets discarded but shows as an empty message in LCW
2. Transcript does not escape script tags properly

## Solution Proposed
Add/update sanitization for script tag message

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
verified locally,
<img width="380" alt="Screenshot 2025-03-28 at 12 14 02 AM" src="https://github.com/user-attachments/assets/91c20f2f-4e0d-483b-a475-91b952060458" />

downloaded Transcript - 
<img width="911" alt="Screenshot 2025-03-28 at 12 15 23 AM" src="https://github.com/user-attachments/assets/06e2545c-010f-4611-8625-957f117a3e47" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__