### PR TITLE
enable webchat to send file after selected

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Enable automatic send of attachment after file is selected.
 - Switch to use atob instead of Buffer to decode payload token
 - Fixed downloadTranscript issue for persistent chat after end chat on post chat survey 
 - Convert base64url tokens into base64 for exp validation.

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultStyles/defaultWebChatStyles.ts
@@ -55,5 +55,5 @@ export const defaultWebChatStyles: StyleOptions = {
         "</3": "💔",
         "<\\3": "💔"
     },
-    uploadMultiple: false
+    sendAttachmentOn: "attach"
 };


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

After uptake webchat version, the upload attachment experience was changed, not longer allowing automatically send of the attachment file, but now requires to hit the send button.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

After researching, it was identified the new style props to send the file automatically

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

[Recording-20250328_115833.webm](https://github.com/user-attachments/assets/130b1cdb-ff6c-4a57-a0a4-865238805462)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__