### PR TITLE
added support for font family in prechat texts block

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-
+- Add support fpr Font Family config property in prechatpane 
 - Add sendbox textarea minHeight property as work-around for an issue on Android where some languages' placeholders are smaller than the text, creating an unnecessary scrollbar
 - Added `opensMarkdownLinksInSameTab` and `honorsTargetInHTMLLinks` props to open hyperlinks in same tab or new tab
 - Added documentation for few properties - opensMarkdownLinksInSameTab, honorsTargetInHTMLLinks, minHeight

--- a/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
+++ b/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
@@ -75,6 +75,7 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
                 font-size: ${props.styleProps?.customTextStyleProps?.fontSize} !important;
                 height: ${props.styleProps?.customTextStyleProps?.height};
                 padding-top: ${props.styleProps?.customTextStyleProps?.paddingTop};
+                font-family: ${props.styleProps?.customTextStyleProps?.fontFamily};
                 overflow-wrap: break-word;
                 white-space: normal !important;
             }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
customTextStyleProps for prechatPane already mentioned the support for fontFamily but was not coded 

## Solution Proposed
Added support for fontFamily in prechatPane ac-textBlock class

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/user-attachments/assets/a6ef9764-092e-47f2-8c1c-9b9a2da5b4b3)

![image](https://github.com/user-attachments/assets/ad25f021-2fb5-4984-9ae7-cb2157387deb)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__