### PR TITLE
Fixed downloadTranscript with attachments issue and blockquote issue

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed transcript with attachments issue
+- Fixed transcript with attachments issue and blockquote issue
 - Fixed missing payload in new message recieved telemetry
 - No internet connect message override fix
 - Enable automatic send of attachment after file is selected.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed transcript with attachments issue
 - Fixed missing payload in new message recieved telemetry
 - No internet connect message override fix
 - Enable automatic send of attachment after file is selected.

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
@@ -84,7 +84,7 @@ const processHTMLText = (action: IWebChatAction, text: string, honorsTargetInHTM
    
     // if empty div tag after sanitization
     if (htmlNode.tagName?.toLowerCase() === HtmlAttributeNames.div && htmlNode.children.length === 0 && htmlNode.innerHTML.trim() === "") {
-        action = updateIn(action, [Constants.payload, Constants.activity, Constants.text], () => htmlNode.innerHTML);
+        action = updateIn(action, [Constants.payload, Constants.activity, Constants.text], () => "");
     }
    
     return action;

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
@@ -63,6 +63,7 @@ const processHTMLText = (action: IWebChatAction, text: string, honorsTargetInHTM
                     }
                 }
             }
+            action = updateIn(action, [Constants.payload, Constants.activity, Constants.text], () => htmlNode.innerHTML);
         }
         catch (e) {
             let errorMessage = "Failed to apply action: ";
@@ -80,7 +81,12 @@ const processHTMLText = (action: IWebChatAction, text: string, honorsTargetInHTM
             });
         }
     }
-    action = updateIn(action, [Constants.payload, Constants.activity, Constants.text], () => htmlNode.innerHTML);
+   
+    // if empty div tag after sanitization
+    if (htmlNode.tagName?.toLowerCase() === HtmlAttributeNames.div && htmlNode.children.length === 0 && htmlNode.innerHTML.trim() === "") {
+        action = updateIn(action, [Constants.payload, Constants.activity, Constants.text], () => htmlNode.innerHTML);
+    }
+   
     return action;
 };
 
@@ -91,6 +97,7 @@ const htmlTextMiddleware = (honorsTargetInHTMLLinks?: boolean) => ({ dispatch }:
             const text = action.payload?.activity?.text;
             if (text) {
                 action = processHTMLText(action, text, honorsTargetInHTMLLinks ?? false);
+                console.log("processed HTMLText: ", text);
             }
         } catch (e) {
             let errorMessage = "Failed to validate action.";

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware.ts
@@ -97,7 +97,6 @@ const htmlTextMiddleware = (honorsTargetInHTMLLinks?: boolean) => ({ dispatch }:
             const text = action.payload?.activity?.text;
             if (text) {
                 action = processHTMLText(action, text, honorsTargetInHTMLLinks ?? false);
-                console.log("processed HTMLText: ", text);
             }
         } catch (e) {
             let errorMessage = "Failed to validate action.";

--- a/chat-widget/src/plugins/createChatTranscript.ts
+++ b/chat-widget/src/plugins/createChatTranscript.ts
@@ -702,7 +702,7 @@ const createChatTranscript = async (transcript: string, facadeChatSDK: FacadeCha
 
     let messages = transcriptMessages.filter((message: { content: string; }) => {
         message.content = DOMPurify.sanitize(message.content);
-        return message.content.length > 0;
+        return message;
     });
 
     if (renderAttachments) {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 4784746](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/4784746): .[3.3 PPE][Bridge-removal] [Blocker] Attachments sent by the agent are missing in the C2 transcript
[Bug 4916653](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/4916653): [4.2] [PPE]- Blockquote markdown formatting not rendering correctly from C1 to C2

### Description
Attachments sent by the agent are missing in the C2 transcript
Blockquote markdown formatting not rendering correctly from C1 to C2

## Solution Proposed
removed content length check while sanitizing the messages
handled script tag message differently where empty div added in transcript and reverted previous changes.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence

For issue1, performed tests with:
1. Attachments from agent
2. Attachments from customer
3. Transcript containing adaptive cards, image cards, video cards, suggested actions
4. message with script tag

<img width="1741" alt="Screenshot 2025-04-17 at 10 54 01 AM" src="https://github.com/user-attachments/assets/026faa64-ffef-4ac0-94dd-793c74952524" />

<img width="1738" alt="Screenshot 2025-04-17 at 10 53 33 AM" src="https://github.com/user-attachments/assets/e3275411-9741-4238-9c9c-dbc2648a503b" />


For issue2, performed tests with 
1. blockquote test
2. other markdown formats
3. message with script tag

<img width="412" alt="Screenshot 2025-04-17 at 4 55 21 PM" src="https://github.com/user-attachments/assets/65af63a6-a6e0-4dc4-b688-af15226c9f73" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__