### PR TITLE
Added conversationId to signIncCardevent

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-
+- Added conversation Id to signin card event
 - Fixed issues found in transcript download after bridge removal
 - When a Start chat event is received, generally from LCW:SDK, if there is an existent session, it wont create  new chat unless the chat is closed.(any other state will present the widget with the session messages).
 - Fallback logic to check token from oc-chat-sdk for validity check

--- a/chat-widget/src/components/livechatwidget/common/ActivitySubscriber/BotAuthActivitySubscriber.ts
+++ b/chat-widget/src/components/livechatwidget/common/ActivitySubscriber/BotAuthActivitySubscriber.ts
@@ -6,6 +6,7 @@ import { IActivitySubscriber } from "./IActivitySubscriber";
 import { ICustomEvent } from "@microsoft/omnichannel-chat-components/lib/types/interfaces/ICustomEvent";
 import { TelemetryHelper } from "../../../../common/telemetry/TelemetryHelper";
 import { IBotAuthActivitySubscriberOptionalParams } from "../../interfaces/IBotAuthActivitySubscriberOptionalParams";
+import { TelemetryManager } from "../../../../common/telemetry/TelemetryManager";
 
 const supportedSignInCardContentTypes = ["application/vnd.microsoft.card.signin", "application/vnd.microsoft.card.oauth"];
 const botOauthUrlRegex = /[\S]+.botframework.com\/api\/oauth\/signin\?signin=([\S]+)/;
@@ -111,7 +112,7 @@ export class BotAuthActivitySubscriber implements IActivitySubscriber {
 
         this.signInCardSeen.add(signInId);
         const sasUrl = await extractSasUrl(attachment);
-        const event: ICustomEvent = { eventName: BroadcastEvent.SigninCardReceived, payload: { sasUrl } };
+        const event: ICustomEvent = { eventName: BroadcastEvent.SigninCardReceived, payload: { sasUrl, conversationId: TelemetryManager.InternalTelemetryData?.conversationId } };
 
         if (!sasUrl) {
             TelemetryHelper.logLoadingEvent(LogLevel.INFO, {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
Adding conversation id to the bot signincard event that is broadcasted. 
This is to help partner team to log the conversation id in their telemetry

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__