### PR TITLE
Fixed postchat survey link space issue

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Fixed transcript with attachments issue and blockquote issue
 - Sanitize `OutOfOfficeHoursPaneStateful`'s `TitleText`
 - Add domain restrictions on post-chat survey URLs
+- Fixed post chat survey invite link space issue
 
 ## [1.7.7] - 2025-04-16
 

--- a/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/postchatsurveypanestateful/PostChatSurveyPaneStateful.tsx
@@ -18,12 +18,13 @@ import useChatContextStore from "../../hooks/useChatContextStore";
 import isValidSurveyUrl from "./common/isValidSurveyUrl";
 
 const generateSurveyInviteLink = (surveyInviteLink: string, isEmbed: boolean, locale: string, compact: boolean, showMultiLingual = false) => {
-    const surveyLink = `${surveyInviteLink}
-            &embed=${isEmbed.toString()}
-            &compact=${compact.toString() ?? "true"}
-            &lang=${locale ?? "en-us"}
-            &showmultilingual=${showMultiLingual.toString() ?? "false"}`;
-    return surveyLink;
+    const surveyLinkParams = new URLSearchParams({
+        embed: isEmbed.toString(),
+        compact: (compact ?? true).toString(),
+        lang: locale ?? "en-us",
+        showmultilingual: (showMultiLingual ?? false).toString(),
+    });
+    return `${surveyInviteLink}&${surveyLinkParams.toString()}`;
 };
 
 export const PostChatSurveyPaneStateful = (props: IPostChatSurveyPaneStatefulProps) => {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 5044454](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/5044454): LCW configured with Arabic language displays "Loading" in English for Post conversation survey.

### Description
During analysis, we discovered that there are white spaces being added in surveylink while adding few parameters in original survey invitation link. which was causing "Loading" text coversion
https://customervoice.microsoft.com/Pages/ResponsePage.aspx?id=6mHONWkqckyDfPON4UOno2_4TXMakFxLidnqVbmZcXxUQ08xSFpPRzFJVzkxN01JSUUzV0tCNTNINy4u&vt=35ce61ea-2a69-4c72-837c-f38de143a7a3_d5acd75b-3fe4-4c49-a0ac-de0666317c53_638817629810000000_EUR_Hash_K2nX1o%2fuNa9AFOrf3JnhtSb2nnlNBCnXUQoAqxuLVkk%3d%20%20%20%20%20%20%20%20%20%20%20%20&embed=true%20%20%20%20%20%20%20%20%20%20%20%20&compact=true%20%20%20%20%20%20%20%20%20%20%20%20&lang=ar%20%20%20%20%20%20%20%20%20%20%20%20&showmultilingual=false


## Solution Proposed
Remove extra white spaces from survey link params to work link as expected and "Loading" text would be converted.
https://customervoice.microsoft.com/Pages/ResponsePage.aspx?id=6mHONWkqckyDfPON4UOno2_4TXMakFxLidnqVbmZcXxUQ08xSFpPRzFJVzkxN01JSUUzV0tCNTNINy4u&vt=35ce61ea-2a69-4c72-837c-f38de143a7a3_d5acd75b-3fe4-4c49-a0ac-de0666317c53_638817629810000000_EUR_Hash_K2nX1o%2fuNa9AFOrf3JnhtSb2nnlNBCnXUQoAqxuLVkk%3d&embed=true&compact=true&lang=ar&showmultilingual=false

extra spaces were getting added due to linebreaks in between link query params. Fixed it now.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
verified locally:
<img width="324" alt="Screenshot 2025-05-02 at 2 08 14 PM" src="https://github.com/user-attachments/assets/7678713f-ae83-4161-b0c7-c8ebe29fe3f7" />

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__