### PR TITLE
Users/mithunj/ampmissue

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Added addtional span around time part of bubble timestamp
+- Added additional span around time part of bubble timestamp
 - Removing condition preventing to close the widget during pop-out + hide header condition
 - Added conversation Id to signin card event
 - Fixed issues found in transcript download after bridge removal

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-
+- Added addtional span around time part of bubble timestamp
 - Removing condition preventing to close the widget during pop-out + hide header condition
 - Added conversation Id to signin card event
 - Fixed issues found in transcript download after bridge removal

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/timestamps/DeliveredTimestamp.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/timestamps/DeliveredTimestamp.tsx
@@ -33,6 +33,8 @@ export const DeliveredTimestamp = ({ args, role, name }: any) => {
         // make sure the "rtl" direction doesn't produce "PM 1:23", but remains "1:23 PM"
         if (dir === "rtl" && isAmPmFormat) {
             return <span dir="ltr">{getTimestampHourMinute(timestamp)}</span>;
+        } else {
+            return <span dir={dir}>{getTimestampHourMinute(timestamp)}</span>;
         }
 
         return timeString;


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

## Solution Proposed
Some reason browser is not able to properly set direction to bot timestamp , so adding a span around timestamp  solve the issue

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
When direction is rtl
![image](https://github.com/user-attachments/assets/bab763f4-00ac-459b-a11d-569163865674)
when direction is default
![image](https://github.com/user-attachments/assets/5fb3095b-79d9-4862-906a-c0bde0a10f04)
device locale
![image](https://github.com/user-attachments/assets/cc577d4d-7b74-47b8-9acf-b0d9b19ac157)


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [x] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__