### PR TITLE
removing unused libs, detected by depcheck [eng]

### DIFF
--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -82,22 +82,14 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
     "@microsoft/omnichannel-chat-components": "1.1.9",
     "@microsoft/omnichannel-chat-sdk": "^1.10.17",
-    "@opentelemetry/api": "^1.9.0",
-    "abort-controller": "^3",
-    "abort-controller-es5": "^2.0.1",
     "core-js-pure": "^3.42.0",
     "dompurify": "^3.2.4",
     "markdown-it": "^12.3.2",
-    "markdown-it-attrs": "^4.1.6",
-    "markdown-it-attrs-es5": "^2.0.2",
     "markdown-it-for-inline": "^0.1.1",
     "md5-typescript": "^1.0.5",
-    "p-defer-es5": "^2.0.1",
-    "sanitize-html": "2.14.0",
     "simple-update-in": "2.2.0",
     "slack-markdown-it": "^1.0.5"
   },

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2805,11 +2805,6 @@
   dependencies:
     "@octokit/openapi-types" "^25.0.0"
 
-"@opentelemetry/api@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
-  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz#2eba163b8e7dbabb4ce3609ab5e32ab63dda3ef8"

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -151,13 +151,6 @@
   dependencies:
     tslib "^2.2.0"
 
-"@azure/core-tracing@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.2.0.tgz#7be5d53c3522d639cf19042cbcdb19f71bc35ab2"
-  integrity sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==
-  dependencies:
-    tslib "^2.6.2"
-
 "@azure/core-util@^1.0.0", "@azure/core-util@^1.1.0", "@azure/core-util@^1.3.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@azure/core-util/-/core-util-1.5.0.tgz#ffe49c3e867044da67daeb8122143fa065e1eb0e"
@@ -2598,11 +2591,6 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@opentelemetry/api@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
-  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
-
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.10"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.10.tgz#2eba163b8e7dbabb4ce3609ab5e32ab63dda3ef8"
@@ -4758,7 +4746,7 @@ abort-controller-es5@2.0.1, abort-controller-es5@^2.0.1:
     mkdirp "^1.0.4"
     read-pkg-up "^9.1.0"
 
-abort-controller@3.0.0, abort-controller@^3:
+abort-controller@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
@@ -11416,26 +11404,6 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-markdown-it-attrs-es5@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/markdown-it-attrs-es5/-/markdown-it-attrs-es5-2.0.2.tgz#4897bcee110f68a5393cce1552ad156b3f195d5f"
-  integrity sha512-VJczS1pwXA/OEyWD/30ehzBwyFwNT7V53tvwng6+S1uTLedPUGwp3nI2/HwOlKrMfRTe2L6zNb3HzmSNWUEhDA==
-  dependencies:
-    "@babel/cli" "^7.17.6"
-    "@babel/core" "^7.17.5"
-    "@babel/plugin-transform-runtime" "^7.17.0"
-    "@babel/preset-env" "^7.16.11"
-    "@babel/runtime-corejs3" "^7.17.2"
-    esbuild "^0.14.23"
-    mkdirp "^1.0.4"
-    read-pkg-up "^9.1.0"
-    terser "^5.11.0"
-
-markdown-it-attrs@^4.1.6:
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/markdown-it-attrs/-/markdown-it-attrs-4.1.6.tgz#2bc331c7649d8c6396a0613c2bba1093f3e64da9"
-  integrity sha512-O7PDKZlN8RFMyDX13JnctQompwrrILuz2y43pW2GagcwpIIElkAdfeek+erHfxUOlXWPsjFeWmZ8ch1xtRLWpA==
-
 markdown-it-for-inline@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/markdown-it-for-inline/-/markdown-it-for-inline-0.1.1.tgz#435f2316f5b5e68e1450cfa2242f2b8d59adc75f"
@@ -15740,7 +15708,7 @@ terser@^4.1.2, terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.11.0, terser@^5.16.5, terser@^5.3.4:
+terser@^5.16.5, terser@^5.3.4:
   version "5.16.6"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.6.tgz#f6c7a14a378ee0630fbe3ac8d1f41b4681109533"
   integrity sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

Cleaning the house  

Using depcheck , it was detected a list of unused libs that were part of the module 

Unused dependencies
* @azure/core-tracing
* @opentelemetry/api
* abort-controller
* abort-controller-es5
* core-js-pure
* markdown-it-attrs
* markdown-it-attrs-es5
* p-defer-es5
* sanitize-html

* core-js-pure is not going to be removed due to a direct dependency with webchat framework
I also checked for circular references in the code , the result was cero.

![image](https://github.com/user-attachments/assets/0d6524b7-da03-459e-b88f-3d316a6510ca)


## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_
![image](https://github.com/user-attachments/assets/a8aa7318-785e-4aaa-ab07-a97dd66d0b0f)

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__