### PR TITLE
Patch OOH Pane and Webchat container being loaded when hide button

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix for invisible pane for OOH Pane and webchat container
 - Remove overloading calls to handleAuthentication
 - Fix to load OOH from config always
 - Enhancements to OOH scenarios

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -177,7 +177,6 @@ const initStartChat = async (facadeChatSDK: FacadeChatSDK, dispatch: Dispatch<IL
                 portalContactId: window.Microsoft?.Dynamic365?.Portal?.User?.contactId
             };
             const startChatOptionalParams: StartChatOptionalParams = Object.assign({}, params, optionalParams, defaultOptionalParams);
-            console.log("LOPEZ :: chat staRTED");
             await facadeChatSDK.startChat(startChatOptionalParams);
             isStartChatSuccessful = true;
         } catch (error) {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -83,12 +83,10 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toString().toLowerCase() === "true";
         if (isOutOfOperatingHours) {
-            console.log("LOPEZ :: prechat :: hide chat , OOH");
             state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
             return;
         } else {
-            console.log("LOPEZ :: prechat :: hide chat");
             TelemetryHelper.logLoadingEvent(LogLevel.INFO, { Event: TelemetryEvent.PrechatSurveyExpected });
 
             dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
@@ -96,7 +94,6 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
             
             // If minimized, maximize the chat, if the state is missing, consider it as minimized
             if (state?.appStates.isMinimized === undefined || state?.appStates?.isMinimized === true) {
-                console.log("LOPEZ :: set state minimized to false");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
 
                 // this event will notify the upper layer to maximize the widget, an event missing during multi-tab scenario.
@@ -108,7 +105,6 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
                     }
                 });
             }
-            console.log("LOPEZ: prechat done");
             return;
         }
     }

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -111,6 +111,21 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
 
     //Initiate start chat
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
+
+    console.log("LOPEZ :: enforcing show of the UI", state?.appStates.isMinimized);
+    if (state?.appStates.isMinimized === undefined || state?.appStates?.isMinimized === true) {
+        console.log("LOPEZ :: maxim the widget after load is complete");
+        dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+        // this event will notify the upper layer to maximize the widget, an event missing during multi-tab scenario.
+        BroadcastService.postMessage({
+            eventName: BroadcastEvent.MaximizeChat,
+            payload: {
+                height: state?.domainStates?.widgetSize?.height,
+                width: state?.domainStates?.widgetSize?.width
+            }
+        });
+    }
+
     const optionalParams: StartChatOptionalParams = { isProactiveChat };
     createTrackingForFirstMessage();
     await initStartChat(facadeChatSDK, dispatch, setAdapter, state, props, optionalParams);
@@ -158,6 +173,7 @@ const initStartChat = async (facadeChatSDK: FacadeChatSDK, dispatch: Dispatch<IL
                 portalContactId: window.Microsoft?.Dynamic365?.Portal?.User?.contactId
             };
             const startChatOptionalParams: StartChatOptionalParams = Object.assign({}, params, optionalParams, defaultOptionalParams);
+            console.log("LOPEZ :: chat staRTED");
             await facadeChatSDK.startChat(startChatOptionalParams);
             isStartChatSuccessful = true;
         } catch (error) {

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -83,18 +83,20 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toString().toLowerCase() === "true";
         if (isOutOfOperatingHours) {
+            console.log("LOPEZ :: prechat :: hide chat , OOH");
             state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
             return;
         } else {
-
+            console.log("LOPEZ :: prechat :: hide chat");
             TelemetryHelper.logLoadingEvent(LogLevel.INFO, { Event: TelemetryEvent.PrechatSurveyExpected });
 
             dispatch({ type: LiveChatWidgetActionType.SET_PRE_CHAT_SURVEY_RESPONSE, payload: preChatSurveyResponse });
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Prechat });
             
             // If minimized, maximize the chat, if the state is missing, consider it as minimized
-            if (state?.appStates.isMinimized == undefined || state?.appStates?.isMinimized === true) {
+            if (state?.appStates.isMinimized === undefined || state?.appStates?.isMinimized === true) {
+                console.log("LOPEZ :: set state minimized to false");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
 
                 // this event will notify the upper layer to maximize the widget, an event missing during multi-tab scenario.
@@ -106,6 +108,7 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
                     }
                 });
             }
+            console.log("LOPEZ: prechat done");
             return;
         }
     }

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -112,9 +112,13 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
     //Initiate start chat
     dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.Loading });
 
-    console.log("LOPEZ :: enforcing show of the UI", state?.appStates.isMinimized);
+    /**
+     * Send max event, since there is a path coming from hide button + LCW SDK that intialize the components
+     * but dont maximize it.
+     * 
+     * This is because a new change to control OOH as closed event when a widget is coming from chat.
+     */
     if (state?.appStates.isMinimized === undefined || state?.appStates?.isMinimized === true) {
-        console.log("LOPEZ :: maxim the widget after load is complete");
         dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
         // this event will notify the upper layer to maximize the widget, an event missing during multi-tab scenario.
         BroadcastService.postMessage({

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -385,17 +385,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {  
-            console.log("LOPEZ :: startChat listener ::");
             // If chat is out of operating hours chat widget sets the conversation state to OutOfOffice.
             if (state.appStates.outsideOperatingHours === true) {
-                console.log("LOPEZ :: out of Operating hours detected");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
                 return;
             }
             // If the startChat event is not initiated by the same tab. Ignore the call
             if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
-                console.log("LOPEZ :: ignore call");
                 return;
             }
 
@@ -413,10 +410,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             });
 
             const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
-
             inMemoryState.domainStates.customContext = msg?.payload?.customContext;
-
-
             /*
             * If the conversation is in closed state then we start a new chat, 
             * else if the conversation is in active state then we maximize the chat
@@ -425,7 +419,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             * To start a new chat, it needs to be called via the close button or close chat via SDK.
             **/ 
             if (inMemoryState.appStates?.conversationState === ConversationState.Closed) {
-                console.log("LOPEZ :: re-starting the chat");
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.ChatInitiated
                 });
@@ -433,10 +426,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 return;
             }
 
-            console.log("LOPEz : state min =>", inMemoryState?.appStates?.isMinimized);
             // If minimized, maximize the chat
             if (inMemoryState?.appStates?.isMinimized === true) {
-                console.log("LOPEZ :: maximize the chat");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.MaximizeChat,

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -269,8 +269,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     useEffect(() => {
         if (state?.appStates?.hideStartChatButton === true) {
             //handle OOH pane
-            if (typeof props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours === "string" &&
-                props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
+            if (state.appStates.outsideOperatingHours === true) {
+                console.log("ELOPEZANAYA :: use effect OOH : 0");
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.OnWidgetError,
@@ -417,6 +417,11 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             *  If the conversation is in inactive or postchat state then we maximize the chat.
             * 
             * To start a new chat, it needs to be called via the close button or close chat via SDK.
+            * 
+            * NOTE : Transition from OOH to business hours will follow this path, since during intialization conversation
+            * state is being set to closed.
+            * 
+            * Maximization has been added as part of the initialization chat, since it wont go further than this block.
             **/ 
             if (inMemoryState.appStates?.conversationState === ConversationState.Closed) {
                 BroadcastService.postMessage({
@@ -427,7 +432,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             }
 
             // If minimized, maximize the chat
-            if (inMemoryState?.appStates?.isMinimized === true) {
+            if (inMemoryState?.appStates?.isMinimized === true || inMemoryState?.appStates?.isMinimized === undefined) {
+                console.log("ELOPEZ :: start chat , maxim ");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.MaximizeChat,

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -385,9 +385,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
         // Start chat from SDK Event
         BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
+            console.log("LOPEZ :: StartChat :: Start chat event received from SDK OOO.=>",props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours);
+            
             // If chat is out of operating hours chat widget sets the conversation state to OutOfOffice.
             if (typeof props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours === "string" &&
                 props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
+                console.log("LOPEZ :: StartChat :: Out of operating hours pane is shown.");
                 state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
                 return;

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -270,7 +270,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         if (state?.appStates?.hideStartChatButton === true) {
             //handle OOH pane
             if (state.appStates.outsideOperatingHours === true) {
-                console.log("ELOPEZANAYA :: use effect OOH : 0");
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.OnWidgetError,
@@ -433,7 +432,6 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
 
             // If minimized, maximize the chat
             if (inMemoryState?.appStates?.isMinimized === true || inMemoryState?.appStates?.isMinimized === undefined) {
-                console.log("ELOPEZ :: start chat , maxim ");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.MaximizeChat,

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -384,16 +384,18 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         });
 
         // Start chat from SDK Event
-        BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {            
+        BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {  
+            console.log("LOPEZ :: startChat listener ::");
             // If chat is out of operating hours chat widget sets the conversation state to OutOfOffice.
-            if (typeof props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours === "string" &&
-                props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
-                state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
+            if (state.appStates.outsideOperatingHours === true) {
+                console.log("LOPEZ :: out of Operating hours detected");
+                dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
                 return;
             }
             // If the startChat event is not initiated by the same tab. Ignore the call
             if (!isNullOrUndefined(msg?.payload?.runtimeId) && msg?.payload?.runtimeId !== TelemetryManager.InternalTelemetryData.lcwRuntimeId) {
+                console.log("LOPEZ :: ignore call");
                 return;
             }
 
@@ -423,6 +425,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             * To start a new chat, it needs to be called via the close button or close chat via SDK.
             **/ 
             if (inMemoryState.appStates?.conversationState === ConversationState.Closed) {
+                console.log("LOPEZ :: re-starting the chat");
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.ChatInitiated
                 });
@@ -430,8 +433,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 return;
             }
 
+            console.log("LOPEz : state min =>", inMemoryState?.appStates?.isMinimized);
             // If minimized, maximize the chat
             if (inMemoryState?.appStates?.isMinimized === true) {
+                console.log("LOPEZ :: maximize the chat");
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 BroadcastService.postMessage({
                     eventName: BroadcastEvent.MaximizeChat,

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -384,13 +384,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         });
 
         // Start chat from SDK Event
-        BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {
-            console.log("LOPEZ :: StartChat :: Start chat event received from SDK OOO.=>",props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours);
-            
+        BroadcastService.getMessageByEventName(BroadcastEvent.StartChat).subscribe((msg: ICustomEvent) => {            
             // If chat is out of operating hours chat widget sets the conversation state to OutOfOffice.
             if (typeof props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours === "string" &&
                 props?.chatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours.toLowerCase() === "true") {
-                console.log("LOPEZ :: StartChat :: Out of operating hours pane is shown.");
                 state?.appStates.isMinimized && dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
                 dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
                 return;

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -21,6 +21,7 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
 
     if (!isNullOrUndefined(initialState)) {
         const initialStateFromCache: ILiveChatWidgetContext = JSON.parse(initialState);
+        const outsideOperatingHours = isOutsideOperatingHours();
 
         /*
         * this step is needed to avoid the pre-chat pane to be injected in the DOM when the widget is reloaded, because wont be visible
@@ -28,20 +29,17 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         * as part of the flow, the pre-chat will be detected and then it will be displayed properly 
         * this case is only and only for pre-chat pane.
         * **/
-        if (initialStateFromCache.appStates.conversationState === ConversationState.Prechat 
-            || initialStateFromCache.appStates.conversationState === ConversationState.OutOfOffice) {
+        if (initialStateFromCache.appStates.conversationState === ConversationState.Prechat
+            || initialStateFromCache.appStates.conversationState === ConversationState.OutOfOffice
+            || outsideOperatingHours) {
             initialStateFromCache.appStates.conversationState = ConversationState.Closed;
+            // if we are resetting the conversation state, there is no point to obtain minimized state from cache
+            initialStateFromCache.appStates.isMinimized = undefined;
         }
-
         // we are always setting the chatConfig from the props to avoid any issues with the cache
         initialStateFromCache.domainStates.liveChatConfig = props.chatConfig;
-
         // Cache the result of isOutsideOperatingHours() to ensure consistency
-        const outsideOperatingHours = isOutsideOperatingHours();
         initialStateFromCache.appStates.outsideOperatingHours = outsideOperatingHours;
-        if (outsideOperatingHours) {
-            initialStateFromCache.appStates.conversationState = ConversationState.Closed;
-        }
         return initialStateFromCache;
     }
 

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -68,7 +68,7 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         },
         appStates: {
             conversationState: ConversationState.Closed,
-            isMinimized: false,
+            isMinimized: true,
             previousElementIdOnFocusBeforeModalOpen: null,
             startChatFailed: false,
             outsideOperatingHours: isOutsideOperatingHours(),

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -30,7 +30,6 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         * **/
         if (initialStateFromCache.appStates.conversationState === ConversationState.Prechat 
             || initialStateFromCache.appStates.conversationState === ConversationState.OutOfOffice) {
-            console.log("ELOPEZANAYA :: reset conv :: ", initialStateFromCache.appStates.conversationState);
             initialStateFromCache.appStates.conversationState = ConversationState.Closed;
         }
 
@@ -43,8 +42,6 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         if (outsideOperatingHours) {
             initialStateFromCache.appStates.conversationState = ConversationState.Closed;
         }
-        
-        console.log("ELOPEZANAYA ::  ", initialStateFromCache.appStates.conversationState, " :: ", outsideOperatingHours);
         return initialStateFromCache;
     }
 

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -68,7 +68,7 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         },
         appStates: {
             conversationState: ConversationState.Closed,
-            isMinimized: true,
+            isMinimized: undefined,
             previousElementIdOnFocusBeforeModalOpen: null,
             startChatFailed: false,
             outsideOperatingHours: isOutsideOperatingHours(),

--- a/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
+++ b/chat-widget/src/contexts/common/LiveChatWidgetContextInitialState.ts
@@ -28,7 +28,9 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         * as part of the flow, the pre-chat will be detected and then it will be displayed properly 
         * this case is only and only for pre-chat pane.
         * **/
-        if (initialStateFromCache.appStates.conversationState === ConversationState.Prechat) {
+        if (initialStateFromCache.appStates.conversationState === ConversationState.Prechat 
+            || initialStateFromCache.appStates.conversationState === ConversationState.OutOfOffice) {
+            console.log("ELOPEZANAYA :: reset conv :: ", initialStateFromCache.appStates.conversationState);
             initialStateFromCache.appStates.conversationState = ConversationState.Closed;
         }
 
@@ -38,10 +40,11 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
         // Cache the result of isOutsideOperatingHours() to ensure consistency
         const outsideOperatingHours = isOutsideOperatingHours();
         initialStateFromCache.appStates.outsideOperatingHours = outsideOperatingHours;
-        initialStateFromCache.appStates.conversationState = outsideOperatingHours ?
-            ConversationState.OutOfOffice :
-            initialStateFromCache.appStates.conversationState;
-
+        if (outsideOperatingHours) {
+            initialStateFromCache.appStates.conversationState = ConversationState.Closed;
+        }
+        
+        console.log("ELOPEZANAYA ::  ", initialStateFromCache.appStates.conversationState, " :: ", outsideOperatingHours);
         return initialStateFromCache;
     }
 
@@ -67,10 +70,8 @@ export const getLiveChatWidgetContextInitialState = (props: ILiveChatWidgetProps
             startChatFailureType: StartChatFailureType.Generic
         },
         appStates: {
-            conversationState: isOutsideOperatingHours() ? 
-                ConversationState.OutOfOffice: 
-                ConversationState.Closed,
-            isMinimized: undefined,
+            conversationState: ConversationState.Closed,
+            isMinimized: false,
             previousElementIdOnFocusBeforeModalOpen: null,
             startChatFailed: false,
             outsideOperatingHours: isOutsideOperatingHours(),

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -13,15 +13,12 @@ export const shouldShowProactiveChatPane = (state: ILiveChatWidgetContext) => {
 };
 
 export const shouldShowHeader = (state: ILiveChatWidgetContext) => {
-    console.log("LOPEZ :: header => ", state.appStates.isMinimized, state.appStates.conversationState);
     return !state.appStates.isMinimized &&
         (state.appStates.conversationState !== ConversationState.Closed &&
             state.appStates.conversationState !== ConversationState.ProactiveChat);
 };
 
 export const shouldShowFooter = (state: ILiveChatWidgetContext) => {
-    console.log("LOPEZ :: shouldShowFooter => ", state.appStates.isMinimized, state.appStates.conversationState);
-
     return !state.appStates.isMinimized &&
         (state.appStates.conversationState === ConversationState.Active ||
             state.appStates.conversationState === ConversationState.InActive ||
@@ -33,7 +30,6 @@ export const shouldShowEmailTranscriptPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowWebChatContainer = (state: ILiveChatWidgetContext) => {
-    console.log("LOPEZ :: shouldShowWebChatContainer => ", state.appStates.isMinimized, state.appStates.conversationState);
     return ((!state.appStates.isMinimized) && state.appStates.conversationState === ConversationState.Active ||
         state.appStates.conversationState === ConversationState.InActive);
 };
@@ -59,7 +55,6 @@ export const shouldShowPostChatLoadingPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowOutOfOfficeHoursPane = (state: ILiveChatWidgetContext) => {
-    console.log("LOPEZ ::shouldShowOutOfOfficeHoursPane ", state.appStates.isMinimized , state.appStates.outsideOperatingHours, state.appStates.conversationState);
     // Show OOOH pane only when the conversation state is Closed and outside operating hours is true
     return !state.appStates.isMinimized &&
        (state.appStates.outsideOperatingHours === true) && (state.appStates.conversationState === ConversationState.OutOfOffice);

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -30,7 +30,9 @@ export const shouldShowEmailTranscriptPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowWebChatContainer = (state: ILiveChatWidgetContext) => {
-    return (state.appStates.conversationState === ConversationState.Active ||
+
+    console.log("LOPEZ :: shouldShowWebChatContainer :: ", state.appStates.conversationState, " :: ", state.appStates.isMinimized);
+    return ((!state.appStates.isMinimized) && state.appStates.conversationState === ConversationState.Active ||
         state.appStates.conversationState === ConversationState.InActive);
 };
 
@@ -55,8 +57,10 @@ export const shouldShowPostChatLoadingPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowOutOfOfficeHoursPane = (state: ILiveChatWidgetContext) => {
+    console.log("LOPEZ :: shouldShowOutOfOfficeHoursPane :: ", state.appStates.conversationState, " :: ", state.appStates.isMinimized);
+    // Show OOOH pane only when the conversation state is Closed and outside operating hours is true
     return !state.appStates.isMinimized &&
-        (state.appStates.conversationState === ConversationState.OutOfOffice);
+       (state.appStates.outsideOperatingHours === true) && (state.appStates.conversationState === ConversationState.OutOfOffice);
 };
 
 export const shouldShowPreChatSurveyPane = (state: ILiveChatWidgetContext) => {

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -30,8 +30,6 @@ export const shouldShowEmailTranscriptPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowWebChatContainer = (state: ILiveChatWidgetContext) => {
-
-    console.log("LOPEZ :: shouldShowWebChatContainer :: ", state.appStates.conversationState, " :: ", state.appStates.isMinimized);
     return ((!state.appStates.isMinimized) && state.appStates.conversationState === ConversationState.Active ||
         state.appStates.conversationState === ConversationState.InActive);
 };
@@ -57,7 +55,6 @@ export const shouldShowPostChatLoadingPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowOutOfOfficeHoursPane = (state: ILiveChatWidgetContext) => {
-    console.log("LOPEZ :: shouldShowOutOfOfficeHoursPane :: ", state.appStates.conversationState, " :: ", state.appStates.isMinimized);
     // Show OOOH pane only when the conversation state is Closed and outside operating hours is true
     return !state.appStates.isMinimized &&
        (state.appStates.outsideOperatingHours === true) && (state.appStates.conversationState === ConversationState.OutOfOffice);

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -13,12 +13,15 @@ export const shouldShowProactiveChatPane = (state: ILiveChatWidgetContext) => {
 };
 
 export const shouldShowHeader = (state: ILiveChatWidgetContext) => {
+    console.log("LOPEZ :: header => ", state.appStates.isMinimized, state.appStates.conversationState);
     return !state.appStates.isMinimized &&
         (state.appStates.conversationState !== ConversationState.Closed &&
             state.appStates.conversationState !== ConversationState.ProactiveChat);
 };
 
 export const shouldShowFooter = (state: ILiveChatWidgetContext) => {
+    console.log("LOPEZ :: shouldShowFooter => ", state.appStates.isMinimized, state.appStates.conversationState);
+
     return !state.appStates.isMinimized &&
         (state.appStates.conversationState === ConversationState.Active ||
             state.appStates.conversationState === ConversationState.InActive ||
@@ -30,6 +33,7 @@ export const shouldShowEmailTranscriptPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowWebChatContainer = (state: ILiveChatWidgetContext) => {
+    console.log("LOPEZ :: shouldShowWebChatContainer => ", state.appStates.isMinimized, state.appStates.conversationState);
     return ((!state.appStates.isMinimized) && state.appStates.conversationState === ConversationState.Active ||
         state.appStates.conversationState === ConversationState.InActive);
 };

--- a/chat-widget/src/controller/componentController.ts
+++ b/chat-widget/src/controller/componentController.ts
@@ -55,6 +55,7 @@ export const shouldShowPostChatLoadingPane = (state: ILiveChatWidgetContext) => 
 };
 
 export const shouldShowOutOfOfficeHoursPane = (state: ILiveChatWidgetContext) => {
+    console.log("LOPEZ ::shouldShowOutOfOfficeHoursPane ", state.appStates.isMinimized , state.appStates.outsideOperatingHours, state.appStates.conversationState);
     // Show OOOH pane only when the conversation state is Closed and outside operating hours is true
     return !state.appStates.isMinimized &&
        (state.appStates.outsideOperatingHours === true) && (state.appStates.conversationState === ConversationState.OutOfOffice);


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

when hide button is present in OOB, invisible panes are present blocking the content

- OOH pane when OOH is active and hide button
- WebchatContainer Pane when conversation is Active or inactive, 

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

When widget is cached and is coming from OOH, then it will set to close and minimize will be reset to undefined, to prevent clash of states.

- Adding broadcast of max event as part of prepare chat flow
- Changes were validated for OOH, normal, prechat all with hide and no hide button

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

#### OOH scenarios 
[ 😎 ] Pop out  + hide chat button (minimize and reload), no hidden panel present
[ 😎 ] Pop out + chat button
[ 😎 ] hide chat button, no hidden panel present
[ 😎 ] chat button, no hidden panel

#### Normal chat
[ 😎 ] Pop out  + hide chat button (minimize and reload), no hidden panel present
[ 😎 ] Pop out + chat button
[ 😎 ] hide chat button, no hidden panel present
[ 😎 ] chat button, no hidden panel

#### Transitions
[ 😎 ] from OOH to normal , pop out , hidden button
[ 😎 ] from normal to OOH, pop out, hidden button
[ 😎 ] from OOH to normal ,
[ 😎 ] from normal to OOH, 

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__