### PR TITLE
Reset attachment error notification

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Fixed post chat survey invite link space issue
 - Added dynamic loading for app insights lib
 - Reset `unreadMessageCount` on attempt to reconnect to conversation that's already been closed
+- Reset `attachment` notification error on uploading new attachment
 
 ### Added
 

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
@@ -29,6 +29,8 @@ const validateAttachment = (action: IWebChatAction, allowedFileExtensions: strin
     }
 
     if (attachments) {
+        NotificationHandler.dismissNotification(NotificationScenarios.AttachmentError); // Dismiss any previous attachment error notification
+
         for (let i = 0; i < attachments.length; i++) {
             const maxUploadFileSize = getMaxUploadFileSize(maxFileSizeSupportedByDynamics, attachments[i].contentType);
             const fileExtensionValid = validateFileExtension(attachments[i], allowedFileExtensions);


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
Bug 4543403

### Description
- `attachment` notification error does not get reset on upload new attachment which adds confusion

## Solution Proposed
- Dismissing `attachment` notification error on new attachment upload

### Acceptance criteria
- Bug is resolved

## Test cases and evidence
- Manual valdiation

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__