### PR TITLE
scroll jump fix on close chat

### DIFF
--- a/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.tsx
+++ b/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.tsx
@@ -71,9 +71,11 @@ export const ConfirmationPaneStateful = (props: IConfirmationPaneStatefulParams)
     useEffect(() => {
         preventFocusToMoveOutOfElement(controlProps.id as string);
         const focusableElements: HTMLElement[] | null = findAllFocusableElement(`#${controlProps.id}`);
-        if (focusableElements) {
-            focusableElements[0].focus();
-        }
+        const timer = setTimeout(() => {
+            if (focusableElements) {
+                focusableElements[0].focus({ preventScroll: true });
+            }
+        }, 0);
 
         elements = findParentFocusableElementsWithoutChildContainer(controlProps.id as string);
         setTabIndices(elements, initialTabIndexMap, false);
@@ -83,6 +85,9 @@ export const ConfirmationPaneStateful = (props: IConfirmationPaneStatefulParams)
             ElapsedTimeInMilliseconds: uiTimer.milliSecondsElapsed
         });
 
+        return () => {
+            clearTimeout(timer);
+        };
     }, []);
 
     return (

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -115,6 +115,10 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const [voiceVideoCallingSDK, setVoiceVideoCallingSDK] = useState<any>(undefined);
     const { Composer } = Components;
     const canStartProactiveChat = useRef(true);
+    const bubbleBackground = props.webChatContainerProps?.webChatStyles?.bubbleBackground ??
+        (props.webChatContainerProps?.adaptiveCardStyles?.background ?? defaultAdaptiveCardStyles.background);
+    const bubbleTextColor = props.webChatContainerProps?.webChatStyles?.bubbleTextColor ??
+        (props.webChatContainerProps?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color);
 
     // Process general styles
     const generalStyles: IStackStyles = {
@@ -770,6 +774,12 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     const directLine = livechatProps.webChatContainerProps?.directLine ?? adapter ?? defaultWebChatContainerStatefulProps.directLine;
     const userID = directLine.getState ? directLine?.getState("acs.userId") : "teamsvisitor";
 
+    const styleOptions = React.useMemo(() => ({
+        ...webChatStyles,
+        bubbleBackground,
+        bubbleTextColor
+    }), [webChatStyles, bubbleBackground, bubbleTextColor]);
+
     // WebChat's Composer can only be rendered if a directLine object is defined
     return directLine && (
         <>
@@ -812,11 +822,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 <Composer
                     {...webChatProps}
                     userID={userID}
-                    styleOptions={{
-                        ...webChatStyles,
-                        bubbleBackground: props.webChatContainerProps?.webChatStyles?.bubbleBackground ?? ( props.webChatContainerProps?.adaptiveCardStyles?.background ?? defaultAdaptiveCardStyles.background),
-                        bubbleTextColor: props.webChatContainerProps?.webChatStyles?.bubbleTextColor ?? (props.webChatContainerProps?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color)
-                    }}
+                    styleOptions={styleOptions}
                     directLine={directLine}>
                     <Stack
                         id={widgetElementId}


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Bug 4898265](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/4898265): Scroll position jumps when Close confirmation prompt is opened


### Description
Scroll position jumps when Close confirmation prompt is opened

## Solution Proposed
memoized style options and added setTimeout to defer the focus until after the overlay confirmation pane is rendered, which prevents the scrolling. 

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
Issue:

https://github.com/user-attachments/assets/1bcd9967-86a2-46ab-ad61-c81b12547b4a


With Fix:

https://github.com/user-attachments/assets/312ed788-c15c-451a-af62-cdd3469b1f4f


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__