### PR TITLE
rewiring to enforce getReconnectableChat goes via Facade

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix to ensure getRecconnetableChat always include a valid token
+- Fix to ensure getReconnectableChat always include a valid token
 - Adding missing closure success telemetry for GetChatReconnectContextSDKCallStarted
 - Cleanup OOH Pane title obtained from props.
 - Handling participant added/deleted in thread as system message

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix to ensure getRecconnetableChat always include a valid token
 - Adding missing closure success telemetry for GetChatReconnectContextSDKCallStarted
 - Cleanup OOH Pane title obtained from props.
 - Handling participant added/deleted in thread as system message

--- a/chat-widget/src/common/facades/FacadeChatSDK.ts
+++ b/chat-widget/src/common/facades/FacadeChatSDK.ts
@@ -387,4 +387,8 @@ export class FacadeChatSDK {
     public async getAgentAvailability(optionalParams: GetAgentAvailabilityOptionalParams = {}): Promise<GetAgentAvailabilityResponse> {
         return this.validateAndExecuteCall("getAgentAvailability", () => this.chatSDK.getAgentAvailability(optionalParams));
     }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    public async getReconnectableChats(reconnectableChatsParams: any = {}): Promise<any> {
+        return this.validateAndExecuteCall("getReconnectableChats", () => this.chatSDK.OCClient.getReconnectableChats(reconnectableChatsParams));
+    }
 }

--- a/chat-widget/src/common/facades/FacadeChatSDK.ts
+++ b/chat-widget/src/common/facades/FacadeChatSDK.ts
@@ -391,10 +391,9 @@ export class FacadeChatSDK {
     public async getReconnectableChats(reconnectableChatsParams: any = {}): Promise<any> {
 
         if (this.token === null || this.token === "") {
-
+            // If token is not set, try to get it using tokenRing
             const pingResponse = await this.tokenRing();
             if (pingResponse.result === false) {
-
                 const errorMessage = `Authentication failed: Process to get a token failed for getReconnectableChats, ${pingResponse.message}`;
                 //telemetry is already logged in tokenRing, so no need to log again, just return the error and communicate to the console
                 console.error(errorMessage);
@@ -407,9 +406,11 @@ export class FacadeChatSDK {
                 throw new Error(errorMessage);
             }
         }
-        console.log("getReconnectableChats: authenticatedUserToken is already set to", this.token);
-        reconnectableChatsParams.authenticatedUserToken = this.token;
+        
+        // Always override the token in params regardless of how getReconnectableChats was called
         console.log("getReconnectableChats: authenticatedUserToken is set to", this.token);
+        reconnectableChatsParams.authenticatedUserToken = this.token;
+        
         return this.validateAndExecuteCall("getReconnectableChats", () => this.chatSDK.OCClient.getReconnectableChats(reconnectableChatsParams));
 
     }

--- a/chat-widget/src/common/facades/FacadeChatSDK.ts
+++ b/chat-widget/src/common/facades/FacadeChatSDK.ts
@@ -424,7 +424,6 @@ export class FacadeChatSDK {
         }
         
         // Always override the token in params regardless of how getReconnectableChats was called
-        console.log("getReconnectableChats: authenticatedUserToken is set to", this.token);
         reconnectableChatsParams.authenticatedUserToken = this.token;
         
         return this.validateAndExecuteCall("getReconnectableChats", () => this.chatSDK.OCClient.getReconnectableChats(reconnectableChatsParams));

--- a/chat-widget/src/common/facades/FacadeChatSDK.ts
+++ b/chat-widget/src/common/facades/FacadeChatSDK.ts
@@ -390,6 +390,22 @@ export class FacadeChatSDK {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public async getReconnectableChats(reconnectableChatsParams: any = {}): Promise<any> {
 
+        /**
+         * 
+         * This is a particular case, we dont expose getReconnectableChats in the SDK,
+         * The only way to use is by tunneling directly from the SDK to OCSDK,
+         * 
+         * In case of prechat, the function is called before any formal authentication is made, 
+         * this is an specific case for persistent chats, to prevent the survey be loaded again for an on going chat,
+         * 
+         * In this case, we check for existance of the token , otherwise we perform the authentication, error is propagated in case of issues.
+         * 
+         * Once the token is obtained , this will be added to the params to call the function.
+         * 
+         * This is a particular case, should not be taken as pattern.
+         *
+         */
+
         if (this.token === null || this.token === "") {
             // If token is not set, try to get it using tokenRing
             const pingResponse = await this.tokenRing();

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -41,8 +41,6 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const isAuthenticatedChat = !!((props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction) ||  isPersistentChatEnabled(props.chatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode);
 
-    console.log("LiveChatWidget props:", props);
-
     if (!facadeChatSDK) {
         setFacadeChatSDK(new FacadeChatSDK(
             {

--- a/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
+++ b/chat-widget/src/components/livechatwidget/LiveChatWidget.tsx
@@ -14,9 +14,10 @@ import { createReducer } from "../../contexts/createReducer";
 import { getLiveChatWidgetContextInitialState } from "../../contexts/common/LiveChatWidgetContextInitialState";
 import { getMockChatSDKIfApplicable } from "./common/getMockChatSDKIfApplicable";
 import { isNullOrUndefined } from "../../common/utils";
+import { isPersistentChatEnabled } from "./common/liveChatConfigUtils";
+import { logWidgetLoadWithUnexpectedError } from "./common/startChatErrorHandler";
 import overridePropsOnMockIfApplicable from "./common/overridePropsOnMockIfApplicable";
 import { registerTelemetryLoggers } from "./common/registerTelemetryLoggers";
-import { logWidgetLoadWithUnexpectedError } from "./common/startChatErrorHandler";
 
 export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
 
@@ -38,7 +39,9 @@ export const LiveChatWidget = (props: ILiveChatWidgetProps) => {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const isAuthenticatedChat = !!((props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction);
+    const isAuthenticatedChat = !!((props.chatConfig?.LiveChatConfigAuthSettings as any)?.msdyn_javascriptclientfunction) ||  isPersistentChatEnabled(props.chatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode);
+
+    console.log("LiveChatWidget props:", props);
 
     if (!facadeChatSDK) {
         setFacadeChatSDK(new FacadeChatSDK(

--- a/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
+++ b/chat-widget/src/components/livechatwidget/common/liveChatConfigUtils.ts
@@ -9,7 +9,7 @@ export const isPostChatSurveyEnabled = async (facadeChatSDK: FacadeChatSDK) : Pr
     return postChatEnabled === "true";
 };
 
-export const isPersistentChatEnabled = async (conversationMode: string | undefined): Promise<boolean> => {
+export const isPersistentChatEnabled = (conversationMode: string | undefined): boolean => {
     if (isNullOrUndefined(conversationMode)) {
         return false;
     }

--- a/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
@@ -5,7 +5,7 @@ import { isPersistentChatEnabled } from "./liveChatConfigUtils";
 export const shouldSetPreChatIfPersistentChat = async (facadeChatSDK: FacadeChatSDK, conversationMode: string, showPreChat: boolean) => {
     const persistentEnabled = isPersistentChatEnabled(conversationMode);
     let skipPreChat = false;
-    console.log("******* Checking if persistent chat is enabled: ", persistentEnabled);
+    
     if (persistentEnabled) {
         // Access private properties using type assertions
         const chatSDK = facadeChatSDK.getChatSDK();
@@ -13,15 +13,13 @@ export const shouldSetPreChatIfPersistentChat = async (facadeChatSDK: FacadeChat
         // Use type assertion to bypass private access restriction
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const sdkAsAny = chatSDK as any;
-        
+        // most likely this is not set , the facade will take care of it
         const reconnectableChatsParams = {
             authenticatedUserToken: sdkAsAny.authenticatedUserToken as string,
             requestId: sdkAsAny.requestId as string,
         };
 
         try {
-
-            console.log("******* Checking for reconnectable chats with params");
             const reconnectableChatsResponse = await facadeChatSDK.getReconnectableChats(reconnectableChatsParams);
             if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) { // Skip rendering prechat on existing persistent chat session
                 skipPreChat = true;

--- a/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
+++ b/chat-widget/src/components/livechatwidget/common/persistentChatHelper.ts
@@ -5,6 +5,7 @@ import { isPersistentChatEnabled } from "./liveChatConfigUtils";
 export const shouldSetPreChatIfPersistentChat = async (facadeChatSDK: FacadeChatSDK, conversationMode: string, showPreChat: boolean) => {
     const persistentEnabled = isPersistentChatEnabled(conversationMode);
     let skipPreChat = false;
+    console.log("******* Checking if persistent chat is enabled: ", persistentEnabled);
     if (persistentEnabled) {
         // Access private properties using type assertions
         const chatSDK = facadeChatSDK.getChatSDK();
@@ -20,11 +21,7 @@ export const shouldSetPreChatIfPersistentChat = async (facadeChatSDK: FacadeChat
 
         try {
 
-            if (reconnectableChatsParams.authenticatedUserToken === undefined || reconnectableChatsParams.authenticatedUserToken.length === 0) {
-                console.error("Authenticated user token is not available. Cannot check for reconnectable chats.");
-                return false;
-            }
-
+            console.log("******* Checking for reconnectable chats with params");
             const reconnectableChatsResponse = await facadeChatSDK.getReconnectableChats(reconnectableChatsParams);
             if (reconnectableChatsResponse && reconnectableChatsResponse.reconnectid) { // Skip rendering prechat on existing persistent chat session
                 skipPreChat = true;

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -78,7 +78,9 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
     const parseToJson = false;
     const preChatSurveyResponse: string = props?.preChatSurveyPaneProps?.controlProps?.payload ?? await facadeChatSDK.getPreChatSurvey(parseToJson);
     let showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
+    console.log("******* Prechat survey response: ", preChatSurveyResponse);
     showPrechat = await shouldSetPreChatIfPersistentChat(facadeChatSDK, state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode, showPrechat as boolean);
+    console.log("******* Should show prechat: ", showPrechat);
 
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toString().toLowerCase() === "true";

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -78,7 +78,7 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
     const parseToJson = false;
     const preChatSurveyResponse: string = props?.preChatSurveyPaneProps?.controlProps?.payload ?? await facadeChatSDK.getPreChatSurvey(parseToJson);
     let showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
-    showPrechat = await shouldSetPreChatIfPersistentChat(facadeChatSDK.getChatSDK(), state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode, showPrechat as boolean);
+    showPrechat = await shouldSetPreChatIfPersistentChat(facadeChatSDK, state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode, showPrechat as boolean);
 
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toString().toLowerCase() === "true";
@@ -138,7 +138,7 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const initStartChat = async (facadeChatSDK: FacadeChatSDK, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, state: ILiveChatWidgetContext | undefined, props?: ILiveChatWidgetProps, params?: StartChatOptionalParams, persistedState?: any) => {
     let isStartChatSuccessful = false;
-    const persistentChatEnabled = await isPersistentChatEnabled(state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode);
+    const persistentChatEnabled = isPersistentChatEnabled(state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode);
 
     if (state?.appStates.conversationState === ConversationState.Closed) {
         // Preventive reset to avoid starting chat with previous requestId which could potentially cause problems

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -78,9 +78,7 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
     const parseToJson = false;
     const preChatSurveyResponse: string = props?.preChatSurveyPaneProps?.controlProps?.payload ?? await facadeChatSDK.getPreChatSurvey(parseToJson);
     let showPrechat = isProactiveChat ? preChatSurveyResponse && proactiveChatEnablePrechatState : (preChatSurveyResponse && !props?.controlProps?.hidePreChatSurveyPane);
-    console.log("******* Prechat survey response: ", preChatSurveyResponse);
     showPrechat = await shouldSetPreChatIfPersistentChat(facadeChatSDK, state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.msdyn_conversationmode, showPrechat as boolean);
-    console.log("******* Should show prechat: ", showPrechat);
 
     if (showPrechat) {
         const isOutOfOperatingHours = state?.domainStates?.liveChatConfig?.LiveWSAndLiveChatEngJoin?.OutOfOperatingHours?.toString().toLowerCase() === "true";


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

Persistent chat with preload workflow does a precheck to validate if the token has already a session started, to prevent showing the prechat again, 

the problem is that the call is made with an empty token, since at the moment of the call, the authentatication has not being enforced, as result the call to `getReconnectableChat` has an empty token, returning a 403.

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

The fix will be made at OCW level, while is validate possibilities to expose a new method in the SDK.

In this case, the Facade component will replace the token in the params for the call to the SDK.


### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

#### Tests made with OOB

[ 😎 ]  persistent chat loads
[ 😎 ] persistent chat with missing token should fail
[  😎 ] persistent chat with pre chat , checks for recconnectable chats first , if present should not show prechat
[  😎 ] persistent chat with pre chat , checks for recconnectable chats first , if NOT present should presetn prechat
[  😎 ]  persistent chat starts in browser 1 , then open same chat in browser 2, should load same conversation
[  😎 ]  persistent chat with prechat starts in browser 1 answer questions and start session , then open same chat in browser 2, should not ask for prechat and load session from prechat 1
