### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chat-widget-release.yml
+++ b/.github/workflows/chat-widget-release.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: chat-widget-release
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/omnichannel-chat-widget/security/code-scanning/21](https://github.com/microsoft/omnichannel-chat-widget/security/code-scanning/21)

To address the issue, add an explicit `permissions` block to the workflow. It is best to place the block at the root level of the workflow to apply it to all jobs unless specific jobs require custom permissions. For this workflow, the permissions can be set to `contents: read` since it primarily reads repository contents, builds packages, and publishes them but does not directly modify repository files.

Changes to be made:
1. Add the `permissions` block at the root level of the workflow, immediately after the `name` field.
2. Set the permissions to `contents: read` as a minimal starting point. If any steps require write permissions (e.g., publishing actions), explicitly define them (e.g., `contents: write`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
