### PR TITLE
Fix adaptiveCardStyles.color not being honored

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed `adaptiveCardStyles.color` property not being honored for adaptive card text color
 - Remove `Important` from link gift , preventing new styles to be applied
 - Fixed TypeScript sample application to work with modern Node.js versions by updating all dependencies to current stable versions
 - Removed deprecated `crypto` package from TypeScript sample (now built into Node.js)

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -181,6 +181,10 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
             background: ${webChatContainerProps?.adaptiveCardStyles?.background ?? defaultAdaptiveCardStyles.background};
         }
 
+        .webchat__bubble__content>div#ms_lcw_webchat_adaptive_card .ac-textBlock {
+            color: ${webChatContainerProps?.adaptiveCardStyles?.color ?? props.webChatContainerProps?.webChatStyles?.bubbleTextColor ?? defaultAdaptiveCardStyles.color} !important;
+        }
+
         .webchat__stacked-layout__content div.webchat__stacked-layout__message-row div.webchat__bubble--from-user {
             max-width: ${webChatContainerProps?.renderingMiddlewareProps?.userMessageBoxStyles?.maxWidth ?? defaultUserMessageBoxStyles?.maxWidth}
         }


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
Fix adaptiveCardStyles.color not being honored

## Solution Proposed
Added specific CSS selector for .ac-textBlock elements within adaptive cards. Now adaptive card text properly respects the adaptiveCardStyles.color property

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
If user provides bubbleTextColor and adaptiveCardStyles?.color then adaptiveCardStyles?.color will be applied for adaptive card text:

<img width="713" height="350" alt="Screenshot 2025-07-18 at 12 28 27 PM" src="https://github.com/user-attachments/assets/6e647962-fee9-4d48-a67e-0f37acfa1807" />

Behaviour for combinations:

bubbleTextColor | adaptiveCardStyles?.color | Before Fix                                           | After Fix
----------------|---------------------------|-----------------------------------------------------|----------
Provided        | Provided                  | bubbleTextColor for both plain and adaptive card message                           | bubbleTextColor for plain msg, adaptiveCardStyles?.color for adaptive card
Provided        | Not provided              | bubbleTextColor for both                            | No change
Not provided    | Provided                  | bubbleTextColor default for plain, adaptiveCardStyles?.color for adaptive card | No change
Not provided    | Not provided              | bubbleTextColor -> default white for plain, adaptiveCardStyles?.color-> default black for adaptive card | No change

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__