### PR TITLE
Fix: Network reconnect notification issue

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Fix inefficient EmailRegex causing exponential backtracking vulnerability
 - Fixed `adaptiveCardStyles.color` property not being honored for adaptive card text color
 - Fixed textarea height issue using `sendBoxTextBox.textarea.minHeight` prop.
+- Fixed Network reconnect notification issue
 
 ### Added
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Updated build tools including Babel, Webpack, and TypeScript to resolve compatibility issues
 - Fix inefficient EmailRegex causing exponential backtracking vulnerability
 - Fixed `adaptiveCardStyles.color` property not being honored for adaptive card text color
+- Fixed textarea height issue using `sendBoxTextBox.textarea.minHeight` prop.
 
 ### Added
 

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -124,8 +124,7 @@ export class Constants {
     public static readonly OpenLinkIconCssClass = "webchat__render-markdown__external-link-icon";
 
     // internet connection test
-    public static readonly internetConnectionTestUrl = "https://ocsdk-prod.azureedge.net/public/connecttest.txt";
-    public static readonly internetConnectionTestUrlText = "Omnichannel Connect Test";
+    public static readonly internetConnectionTestPath = "/livechatwidget/version.txt";
 
     public static readonly ChatWidgetStateChangedPrefix = "ChatWidgetStateChanged";
     public static readonly PostChatLoadingDurationInMs = 2000;

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -822,8 +822,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 margin-left: .25em;
             }
             ${sendBoxTextArea?.minHeight && `
-            textarea.webchat__send-box-text-box__html-text-area {
-                min-height: ${sendBoxTextArea?.minHeight};
+            .webchat__auto-resize-textarea.webchat__send-box-text-box__text-area {
+                min-height: ${sendBoxTextArea?.minHeight} !important;
             }`}
             `}</style>
             <DraggableChatWidget {...chatWidgetDraggableConfig}>


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
[Task 5344363](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/5344363): Issue with network reconnect notification

### Description
network reconnect notification not displayed on network restore.

## Solution Proposed
Updated cdn based test url to detemine if its connected to internet.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
Can see network reconnected notification on network restore:

<img width="412" height="165" alt="Screenshot 2025-07-22 at 4 30 57 PM" src="https://github.com/user-attachments/assets/1264265a-7949-4ae3-9109-6478abad8bfe" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__