### PR TITLE
bug fixes around chat button

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `adaptiveCardStyles.color` property not being honored for adaptive card text color
 - Fixed textarea height issue using `sendBoxTextBox.textarea.minHeight` prop.
 - Fixed Network reconnect notification issue
+- Fixed chat button custom prop issue
 
 ### Added
 

--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.test.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.test.tsx
@@ -427,7 +427,7 @@ describe("ChatButtonStateful Component", () => {
     });
 
     describe("Props spreading and click handler precedence", () => {
-        it("should not override out-of-office onClick with props from outOfOfficeButtonProps", async () => {
+        it("should allow external onClick to override internal onClick for popup functionality", async () => {
             const mockState = createMockState({
                 appStates: {
                     conversationState: ConversationState.Closed,
@@ -440,7 +440,7 @@ describe("ChatButtonStateful Component", () => {
 
             mockUseChatContextStore.mockReturnValue([mockState, mockDispatch]);
 
-            const conflictingOnClick = jest.fn();
+            const customOnClick = jest.fn();
             const props = {
                 buttonProps: {
                     controlProps: {
@@ -452,7 +452,7 @@ describe("ChatButtonStateful Component", () => {
                     controlProps: {
                         id: "test-ooo-button",
                         titleText: "We're Offline",
-                        onClick: conflictingOnClick // This should be excluded
+                        onClick: customOnClick // This should override the internal onClick
                     }
                 },
                 startChat: mockStartChat
@@ -466,12 +466,12 @@ describe("ChatButtonStateful Component", () => {
                 button.click();
             });
 
-            // Should dispatch OutOfOffice state, not call the conflicting onClick
-            expect(mockDispatch).toHaveBeenCalledWith({
+            // Should call the custom onClick handler instead of internal logic
+            expect(customOnClick).toHaveBeenCalled();
+            expect(mockDispatch).not.toHaveBeenCalledWith({
                 type: LiveChatWidgetActionType.SET_CONVERSATION_STATE,
                 payload: ConversationState.OutOfOffice
             });
-            expect(conflictingOnClick).not.toHaveBeenCalled();
         });
 
         it("should properly spread other properties from outOfOfficeButtonProps while excluding onClick", () => {

--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
@@ -67,7 +67,6 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
     const outOfOfficeStyleProps: IChatButtonStyleProps = Object.assign({}, defaultOutOfOfficeChatButtonStyleProps, outOfOfficeButtonProps?.styleProps);
     
     const controlProps: IChatButtonControlProps = {
-        ...buttonProps?.controlProps,
         id: "oc-lcw-chat-button",
         dir: state.domainStates.globalDir,
         titleText: "Let's Chat!",
@@ -75,8 +74,9 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
         hideNotificationBubble: buttonProps?.controlProps?.hideNotificationBubble === true || state.appStates.isMinimized === false,
         unreadMessageCount: state.appStates.unreadMessageCount ? (state.appStates.unreadMessageCount > Constants.maximumUnreadMessageCount ? props.buttonProps?.controlProps?.largeUnreadMessageString : state.appStates.unreadMessageCount.toString()) : "0",
         unreadMessageString: props.buttonProps?.controlProps?.unreadMessageString,
-        // Regular chat button onClick - this will always take precedence
-        onClick: () => ref.current()
+        // Regular chat button onClick
+        onClick: () => ref.current(),
+        ...buttonProps?.controlProps
     };
 
     const outOfOfficeControlProps: IChatButtonControlProps = {
@@ -86,14 +86,14 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
         titleText: outOfOfficeButtonProps?.controlProps?.titleText || "We're Offline",
         subtitleText: outOfOfficeButtonProps?.controlProps?.subtitleText || "No agents available",
         unreadMessageString: props.buttonProps?.controlProps?.unreadMessageString,
-        ...outOfOfficeButtonProps?.controlProps,
-        // Out-of-office specific onClick - this will ALWAYS take precedence
+        // Out-of-office specific onClick
         onClick: () => {
             if (state.appStates.isMinimized) {
                 dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: false });
             }
             dispatch({ type: LiveChatWidgetActionType.SET_CONVERSATION_STATE, payload: ConversationState.OutOfOffice });
-        }
+        },
+        ...outOfOfficeButtonProps?.controlProps
     };
 
     useEffect(() => {

--- a/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
+++ b/chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx
@@ -69,8 +69,8 @@ export const ChatButtonStateful = (props: IChatButtonStatefulParams) => {
     const controlProps: IChatButtonControlProps = {
         id: "oc-lcw-chat-button",
         dir: state.domainStates.globalDir,
-        titleText: "Let's Chat!",
-        subtitleText: "We're online.",
+        titleText: buttonProps?.controlProps?.titleText || "Let's Chat!",
+        subtitleText: buttonProps?.controlProps?.subtitleText || "We're online.",
         hideNotificationBubble: buttonProps?.controlProps?.hideNotificationBubble === true || state.appStates.isMinimized === false,
         unreadMessageCount: state.appStates.unreadMessageCount ? (state.appStates.unreadMessageCount > Constants.maximumUnreadMessageCount ? props.buttonProps?.controlProps?.largeUnreadMessageString : state.appStates.unreadMessageCount.toString()) : "0",
         unreadMessageString: props.buttonProps?.controlProps?.unreadMessageString,


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.
This pull request addresses a bug fix, improves the behavior of the `ChatButtonStateful` component, and updates its tests to reflect these changes. The most important updates include fixing a custom property issue with the chat button, ensuring external `onClick` handlers can override internal logic, and enhancing the flexibility of control property handling.

### Bug Fixes:
* [Bug 5362548](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/5362548): .[7.4 PPE][Popout]] Chat widget does not open in a new window after adding data-open-in-window="true"
* [Bug 5002719](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/5002719): Incorrect position is announced of the dropdown control options by NVDA/Narrator: A11y_D365 Omnichannel - Channel Experiences_ScreenReader

### Functional Improvements:
* Updated the `ChatButtonStateful` component to allow external `onClick` handlers to override internal `onClick` logic, improving customization for popup functionality. (`chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx`, [[1]](diffhunk://#diff-0f348ff5dbd086bf8273e3b8adcb6dd5715be29abd9489065a2782e0d1b2a877L70-R79) [[2]](diffhunk://#diff-0f348ff5dbd086bf8273e3b8adcb6dd5715be29abd9489065a2782e0d1b2a877L89-R96)
* Enhanced the merging of control properties by ensuring `buttonProps` and `outOfOfficeButtonProps` are spread properly, while maintaining default values for `titleText` and `subtitleText`. (`chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.tsx`, [[1]](diffhunk://#diff-0f348ff5dbd086bf8273e3b8adcb6dd5715be29abd9489065a2782e0d1b2a877L70-R79) [[2]](diffhunk://#diff-0f348ff5dbd086bf8273e3b8adcb6dd5715be29abd9489065a2782e0d1b2a877L89-R96)

### Test Updates:
* Updated the `ChatButtonStateful` component tests to validate that external `onClick` handlers override internal logic and ensure proper behavior for control property handling. (`chat-widget/src/components/chatbuttonstateful/ChatButtonStateful.test.tsx`, [[1]](diffhunk://#diff-1f0387b0b17380a45b2a7c5cf729828aba9c625f4818f663b41584872b8cc13dL430-R430) [[2]](diffhunk://#diff-1f0387b0b17380a45b2a7c5cf729828aba9c625f4818f663b41584872b8cc13dL443-R443) [[3]](diffhunk://#diff-1f0387b0b17380a45b2a7c5cf729828aba9c625f4818f663b41584872b8cc13dL455-R455) [[4]](diffhunk://#diff-1f0387b0b17380a45b2a7c5cf729828aba9c625f4818f663b41584872b8cc13dL469-L474)

## Test cases and evidence
<img width="696" height="896" alt="Screenshot 2025-07-29 at 10 57 26 PM" src="https://github.com/user-attachments/assets/7483a1bd-a264-4707-a6b1-61023b3f7f2a" />

<img width="1218" height="865" alt="Screenshot 2025-07-29 at 8 28 19 PM" src="https://github.com/user-attachments/assets/5fb29a56-8f90-4f61-8de3-556f9d3fa430" />



### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__