### PR TITLE
fix- adaptive card error color issue

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed adaptive card error color issue
+
 ## [1.8.2] - 2025-08-20
 
 ### Fixed
@@ -34,7 +37,6 @@ All notable changes to this project will be documented in this file.
 - Fixed Network reconnect notification issue
 - Fixed markdown numbered list formatting to handle double line breaks and ensure proper continuous numbering
 - Fixed transcript download issue for messages containing <br/> tags
-- Fixed adaptive card error color issue
 
 ### Added
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Fixed textarea height issue using `sendBoxTextBox.textarea.minHeight` prop.
 - Fixed Network reconnect notification issue
 - Fixed markdown numbered list formatting to handle double line breaks and ensure proper continuous numbering
+- Fixed adaptive card error color issue
 
 ### Added
 

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -182,7 +182,7 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
         }
 
         .webchat__bubble__content>div#ms_lcw_webchat_adaptive_card .ac-textBlock {
-            color: ${webChatContainerProps?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color} !important;
+            color: ${webChatContainerProps?.adaptiveCardStyles?.color ?? defaultAdaptiveCardStyles.color};
         }
 
         .webchat__stacked-layout__content div.webchat__stacked-layout__message-row div.webchat__bubble--from-user {


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
Adaptive card error color was also defaulting to black due to !important tag to text color

## Solution Proposed
removed !important tag honoring error text color.

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
Before:
<img width="396" height="600" alt="Screenshot 2025-08-21 at 7 55 09 PM" src="https://github.com/user-attachments/assets/5bdd750c-9305-49a6-86b1-5be64c88be6a" />

After:
<img width="457" height="652" alt="Screenshot 2025-08-21 at 7 54 50 PM" src="https://github.com/user-attachments/assets/f89921b3-8028-42ef-aa7a-6e4b9aab37d9" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__