### PR TITLE
Add runtimeId to telemetry payload and clean up imports in LiveChatWi…

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,9 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Adding runtimeId as part of events send to identify calls from different tabs.
+
 ## [1.8.2] - 2025-08-20
 
 ### Fixed
+
 - Fixed agent user role in mock adapter to properly display agent messages in chat interface and also links in agent and customer messages
 - Fixed startchat and endchat sychronization
 - Fixed regression in ChatButtonStateful and LiveChatWidgetStateful components affecting control props order and out-of-office state logic

--- a/chat-widget/src/common/telemetry/TelemetryHelper.ts
+++ b/chat-widget/src/common/telemetry/TelemetryHelper.ts
@@ -248,7 +248,8 @@ export class TelemetryHelper {
             eventName,
             logLevel,
             payload: {
-                ...payload
+                ...payload,
+                runtimeId : TelemetryManager.InternalTelemetryData?.lcwRuntimeId
             }
         };
         BroadcastService.postMessage(telemetryEvent);

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -1,5 +1,6 @@
 import { BroadcastEvent, LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { Constants, LiveWorkItemState, WidgetLoadTelemetryMessage } from "../../../common/Constants";
+import { TelemetryManager, TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
 import { checkContactIdError, createTimer, getConversationDetailsCall, getStateFromCache, getWidgetCacheIdfromProps, isNullOrEmptyString, isNullOrUndefined, isUndefinedOrEmpty } from "../../../common/utils";
 import { handleChatReconnect, isPersistentEnabled, isReconnectEnabled } from "./reconnectChatHelper";
 import { handleStartChatError, logWidgetLoadComplete } from "./startChatErrorHandler";
@@ -15,7 +16,6 @@ import { ILiveChatWidgetProps } from "../interfaces/ILiveChatWidgetProps";
 import { LiveChatWidgetActionType } from "../../../contexts/common/LiveChatWidgetActionType";
 import StartChatOptionalParams from "@microsoft/omnichannel-chat-sdk/lib/core/StartChatOptionalParams";
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
-import { TelemetryTimers } from "../../../common/telemetry/TelemetryManager";
 import { chatSDKStateCleanUp } from "./endChat";
 import { createAdapter } from "./createAdapter";
 import { createOnNewAdapterActivityHandler } from "../../../plugins/newMessageEventHandler";
@@ -125,7 +125,8 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
             eventName: BroadcastEvent.MaximizeChat,
             payload: {
                 height: state?.domainStates?.widgetSize?.height,
-                width: state?.domainStates?.widgetSize?.width
+                width: state?.domainStates?.widgetSize?.width,
+                runtimeId : TelemetryManager.InternalTelemetryData.lcwRuntimeId
             }
         });
     }

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -126,7 +126,7 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
             payload: {
                 height: state?.domainStates?.widgetSize?.height,
                 width: state?.domainStates?.widgetSize?.width,
-                runtimeId : TelemetryManager.InternalTelemetryData.lcwRuntimeId
+                runtimeId : TelemetryManager?.InternalTelemetryData?.lcwRuntimeId
             }
         });
     }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -21,6 +21,7 @@ import {
     isUndefinedOrEmpty,
     setOcUserAgent
 } from "../../../common/utils";
+import { customEventCallback, subscribeToSendCustomEvent } from "../common/customEventHandler";
 import { defaultClientDataStoreProvider, isCookieAllowed } from "../../../common/storage/default/defaultClientDataStoreProvider";
 import { handleChatReconnect, isPersistentEnabled, isReconnectEnabled } from "../common/reconnectChatHelper";
 import {
@@ -90,7 +91,6 @@ import { startProactiveChat } from "../common/startProactiveChat";
 import useChatAdapterStore from "../../../hooks/useChatAdapterStore";
 import useChatContextStore from "../../../hooks/useChatContextStore";
 import useFacadeSDKStore from "../../../hooks/useFacadeChatSDKStore";
-import { customEventCallback, subscribeToSendCustomEvent } from "../common/customEventHandler";
 
 let uiTimer : ITimer;
 
@@ -650,8 +650,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             return;
         }
 
-        const inMemoryState = executeReducer(state, { type: LiveChatWidgetActionType.GET_IN_MEMORY_STATE, payload: null });
-        let isConversationalSurveyEnabled = state.appStates.isConversationalSurveyEnabled;
+        const isConversationalSurveyEnabled = state.appStates.isConversationalSurveyEnabled;
 
         // In conversational survey, we need to check post chat survey logics before we set ConversationState to InActive
         // Hence setting ConversationState to InActive will be done later in the post chat flows

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -385,7 +385,17 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
          * the event is expected to be emitted from scripting layer.
          */
         BroadcastService.getMessageByEventName(BroadcastEvent.SyncMinimize).subscribe((msg: ICustomEvent) => {
+
+            console.log("LOPEZ :: SyncMinimize event received in LiveChatWidgetStateful, state is defined");
+            // if the state and the sync value is the same no need to perform any action
+            if (state.appStates?.isMinimized === msg?.payload?.minimized) {
+                console.log("LOPEZ  :: SyncMinimize event received in LiveChatWidgetStateful, but state is the same, ignoring the event");
+                return;
+            }
+
+            console.log("LOPEZ  :: SyncMinimize event received in LiveChatWidgetStateful, dispatching SET_MINIMIZED action");
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: msg?.payload?.minimized });
+
         });
 
         // Start chat from SDK Event

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -385,17 +385,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
          * the event is expected to be emitted from scripting layer.
          */
         BroadcastService.getMessageByEventName(BroadcastEvent.SyncMinimize).subscribe((msg: ICustomEvent) => {
-
-            console.log("LOPEZ :: SyncMinimize event received in LiveChatWidgetStateful, state is defined");
-            // if the state and the sync value is the same no need to perform any action
-            if (state.appStates?.isMinimized === msg?.payload?.minimized) {
-                console.log("LOPEZ  :: SyncMinimize event received in LiveChatWidgetStateful, but state is the same, ignoring the event");
-                return;
-            }
-
-            console.log("LOPEZ  :: SyncMinimize event received in LiveChatWidgetStateful, dispatching SET_MINIMIZED action");
             dispatch({ type: LiveChatWidgetActionType.SET_MINIMIZED, payload: msg?.payload?.minimized });
-
         });
 
         // Start chat from SDK Event


### PR DESCRIPTION

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_
This pull request introduces enhancements to telemetry tracking and refines state handling in the chat widget. The main focus is on ensuring that the `runtimeId` is consistently included in telemetry payloads and broadcast events, which will improve traceability and diagnostics. Additionally, there are minor optimizations to state management and import statements.

### Telemetry improvements

* Added `runtimeId` from `TelemetryManager.InternalTelemetryData.lcwRuntimeId` to telemetry event payloads in `TelemetryHelper`, ensuring consistent runtime identification in logs.
* Included `runtimeId` in the payload of the maximize chat broadcast event, further improving event traceability.

### Codebase and state management optimizations

* Removed unnecessary retrieval of `inMemoryState` in `LiveChatWidgetStateful`, simplifying state management logic.
* Cleaned up import statements in `startChat.ts` and `LiveChatWidgetStateful.tsx` to remove unused or redundant imports, improving code clarity. [[1]](diffhunk://#diff-52259d02b1fde0594e601c99e7319c24302e6907a7bd8cb1dc00ec2e714fadd8L18) [[2]](diffhunk://#diff-1011466398478ae8964e56b78a6d7b23d958093724d68315951854fe6d2210d9R24) [[3]](diffhunk://#diff-1011466398478ae8964e56b78a6d7b23d958093724d68315951854fe6d2210d9L93)
* 
### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__