### PR TITLE
Fix adaptive card citation

### DIFF
--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -2,6 +2,9 @@ import { ConversationEndEntity, ParticipantType } from "../../../common/Constant
 import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import { changeLanguageCodeFormatForWebChat, getConversationDetailsCall } from "../../../common/utils";
 
+import { BroadcastService } from "@microsoft/omnichannel-chat-components";
+import { Constants } from "../../../common/Constants";
+import { ConversationState } from "../../../contexts/common/ConversationState";
 import DOMPurify from "dompurify";
 import { Dispatch } from "react";
 import { FacadeChatSDK } from "../../../common/facades/FacadeChatSDK";
@@ -20,33 +23,30 @@ import { createActivityMiddleware } from "../../webchatcontainerstateful/webchat
 import { createAttachmentMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachmentMiddleware";
 import createAttachmentUploadValidatorMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware";
 import { createAvatarMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/avatarMiddleware";
+import createCallActionMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/callActionMiddleware";
 import { createCardActionMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/cardActionMiddleware";
+import { createCitationsMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/citationsMiddleware";
 import createConversationEndMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/conversationEndMiddleware";
+import createCustomEventMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/customEventMiddleware";
 import createDataMaskingMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/dataMaskingMiddleware";
 import { createMarkdown } from "./createMarkdown";
 import createMaxMessageSizeValidator from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/maxMessageSizeValidator";
 import { createMessageSequenceIdOverrideMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/messageSequenceIdOverrideMiddleware";
 import { createMessageTimeStampMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/messageTimestampMiddleware";
+import { createQueueOverflowMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/queueOverflowHandlerMiddleware";
 import { createStore } from "botframework-webchat";
 import { createToastMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/toastMiddleware";
 import { createWebChatTelemetry } from "../../webchatcontainerstateful/webchatcontroller/webchattelemetry/WebChatLogger";
 import { defaultAttachmentProps } from "../../webchatcontainerstateful/common/defaultProps/defaultAttachmentProps";
 import { defaultMiddlewareLocalizedTexts } from "../../webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts";
 import { defaultWebChatContainerStatefulProps } from "../../webchatcontainerstateful/common/defaultProps/defaultWebChatContainerStatefulProps";
+import { executeReducer } from "../../../contexts/createReducer";
 import { getLocaleStringFromId } from "@microsoft/omnichannel-chat-sdk";
 import gifUploadMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/gifUploadMiddleware";
 import htmlPlayerMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlPlayerMiddleware";
 import htmlTextMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/htmlTextMiddleware";
 import preProcessingMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/preProcessingMiddleware";
 import sanitizationMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/sanitizationMiddleware";
-import { Constants } from "../../../common/Constants";
-import createCallActionMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/callActionMiddleware";
-import createCustomEventMiddleware from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/customEventMiddleware";
-import { ConversationState } from "../../../contexts/common/ConversationState";
-import { executeReducer } from "../../../contexts/createReducer";
-import { createQueueOverflowMiddleware } from "../../webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/queueOverflowHandlerMiddleware";
-import { BroadcastService } from "@microsoft/omnichannel-chat-components";
-
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveChatWidgetContext, dispatch: Dispatch<ILiveChatWidgetAction>, facadeChatSDK: FacadeChatSDK, endChat: any) => {
@@ -127,12 +127,14 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
             createDataMaskingMiddleware(state.domainStates.liveChatConfig?.DataMaskingInfo as IDataMaskingInfo),
             createMessageTimeStampMiddleware,
             createMessageSequenceIdOverrideMiddleware,
+            createCitationsMiddleware,
             gifUploadMiddleware,
             htmlPlayerMiddleware,
             htmlTextMiddleware(honorsTargetInHTMLLinks),
             createMaxMessageSizeValidator(localizedTexts),
             sanitizationMiddleware,
             createCallActionMiddleware(),
+            
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ...(props.webChatContainerProps?.storeMiddlewares as any[] ?? [])
         );

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/messageSequenceIdOverrideMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/messageSequenceIdOverrideMiddleware.tsx
@@ -1,6 +1,7 @@
+import { Constants } from "../../../../../common/Constants";
 import { IWebChatAction } from "../../../interfaces/IWebChatAction";
 import { WebChatActionType } from "../../enums/WebChatActionType";
-import { Constants } from "../../../../../common/Constants";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
 export const createMessageSequenceIdOverrideMiddleware = ({ dispatch }: { dispatch: any }) => (next: any) => (action: IWebChatAction) => {
     if (isApplicable(action)) {

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/citationsMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/citationsMiddleware.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { IWebChatAction } from "../../../interfaces/IWebChatAction";
+
+export const createCitationsMiddleware = ({ dispatch }: { dispatch: any }) => (next: any) => (action: IWebChatAction) => {
+    console.log("LOPEZ :: createCitationsMiddleware :: action => ", action);
+    console.log("LOPEZ :: createCitationsMiddleware :: action.payload => ", action.payload);
+
+    if (action.payload?.activity) {
+        console.log("LOPEZ :: createCitationsMiddleware :: action.payload.activity => ", action.payload.activity);
+        if (isApplicable(action)) {
+            console.error("LOPEZ :: printing message => ", action.payload.activity.text);
+            console.error("LOPEZ :: printing activity ::=>", action.payload.activity);
+
+            try {
+                const gptFeedback = JSON.parse(action.payload.activity.channelData.metadata["pva:gpt-feedback"]);
+                console.error("LOPEZ :: printing gptFeedback => ", gptFeedback);
+
+                // Replace citations in the text
+                const updatedText = replaceCitations(action.payload.activity.text, gptFeedback.summarizationOpenAIResponse.result.textCitations);
+                action.payload.activity.text = updatedText;
+
+                console.error("LOPEZ :: updated text => ", updatedText);
+            } catch (error) {
+                console.error("LOPEZ :: Error processing citations => ", error);
+                // Keep the original text in case of issues
+                console.error("LOPEZ :: Keeping original text => ", action.payload.activity.text);
+            }
+        }
+    }
+    return next(action);
+};
+
+const isApplicable = (action: IWebChatAction): boolean => {
+    // Validate if pva:gpt-feedback exists and is not null
+    if (action?.payload?.activity?.channelData?.metadata?.["pva:gpt-feedback"]) {
+        return true;
+    }
+    return false;
+};
+
+const replaceCitations = (text: string, citations: Array<{ id: string; title: string }>): string => {
+    if (!citations || !Array.isArray(citations)) {
+        return text;
+    }
+
+    try {
+        return text.replace(/\[(\d+)\]:\s(cite:\d+)\s"([^"]+)"/g, (match, number, citeId, citationLabel) => {
+            const citation = citations.find(c => c.id === citeId);
+            if (citation) {
+                // Replace only the citation label while preserving the original format
+                return `[${number}]: ${citeId} "${citation.title}"`;
+            }
+            return match; // Keep the original match if no replacement is found
+        });
+    } catch (error) {
+        console.error("LOPEZ :: Error replacing citations => ", error);
+        // Return the original text in case of issues
+        return text;
+    }
+};

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/citationsMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/citationsMiddleware.tsx
@@ -32,9 +32,12 @@ export const createCitationsMiddleware = ({ dispatch }: { dispatch: any }) => (n
 };
 
 const isApplicable = (action: IWebChatAction): boolean => {
-    // Validate if pva:gpt-feedback exists and is not null
-    if (action?.payload?.activity?.channelData?.metadata?.["pva:gpt-feedback"]) {
-        return true;
+
+    if (action?.payload?.activity?.actionType === "DIRECT_LINE/INCOMING_ACTIVITY" && action?.payload?.activity?.channelId == "ACS_CHANNEL") {
+        // Validate if pva:gpt-feedback exists and is not null
+        if (action?.payload?.activity?.channelData?.metadata?.["pva:gpt-feedback"]) {
+            return true;
+        }
     }
     return false;
 };
@@ -45,7 +48,7 @@ const replaceCitations = (text: string, citations: Array<{ id: string; title: st
     }
 
     try {
-        return text.replace(/\[(\d+)\]:\s(cite:\d+)\s"([^"]+)"/g, (match, number, citeId, citationLabel) => {
+        return text.replace(/\[(\d+)\]:\s(cite:\d+)\s"([^"]+)"/g, (match, number, citeId) => {
             const citation = citations.find(c => c.id === citeId);
             if (citation) {
                 // Replace only the citation label while preserving the original format


### PR DESCRIPTION
## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

Miss match  of styles versus copilot tests environment, for self referenced citations, it show the citation as citation-1..Citation-N

<img width="488" height="588" alt="image" src="https://github.com/user-attachments/assets/b985a53e-bd96-452e-81e7-86317996df2c" />

Additional to this, the style of the text for citations landmark is loss in grey color, 
## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

- match citation style for self referenced
- citation label should be the same as the font

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Link Citatitons

<img width="491" height="731" alt="image" src="https://github.com/user-attachments/assets/0f1785e3-6911-4f54-a7cd-9ebb6ae39471" />

### Self referenced
<img width="507" height="734" alt="image" src="https://github.com/user-attachments/assets/406082a0-0e96-42ec-81cc-bd6242b430db" />


### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__