### PR TITLE
Adding RuntimeId to Max events

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,7 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Adding lcwRuntimeId field to the payload for Maximize events
+
 ### Added
+
 - Double check conversation state before handling end conversation
 - Enhance support for customization  for citation pane
 - Adding Citation Handler to support citation pane rendering in chat widget.
@@ -20,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Fixed scrollbar thumb visibility in Windows High Contrast mode
 
 ### Changed
+
 - make citation props optional
 - Uptake [@microsoft/omnichannel-chat-components@1.1.14](https://www.npmjs.com/package/@microsoft/omnichannel-chat-components/v/1.1.14)
 

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -101,7 +101,8 @@ const setPreChatAndInitiateChat = async (facadeChatSDK: FacadeChatSDK, dispatch:
                     eventName: BroadcastEvent.MaximizeChat,
                     payload: {
                         height: state?.domainStates?.widgetSize?.height,
-                        width: state?.domainStates?.widgetSize?.width
+                        width: state?.domainStates?.widgetSize?.width,
+                        runtimeId : TelemetryManager?.InternalTelemetryData?.lcwRuntimeId
                     }
                 });
             }

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -409,6 +409,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                 dispatch({ type: LiveChatWidgetActionType.SET_CUSTOM_CONTEXT, payload: msg?.payload?.customContext });
             }
 
+
             TelemetryHelper.logActionEventToAllTelemetry(LogLevel.INFO, {
                 Event: TelemetryEvent.StartChatEventReceived,
                 Description: "Start chat event received."
@@ -443,7 +444,8 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
                     eventName: BroadcastEvent.MaximizeChat,
                     payload: {
                         height: inMemoryState?.domainStates?.widgetSize?.height,
-                        width: inMemoryState?.domainStates?.widgetSize?.width
+                        width: inMemoryState?.domainStates?.widgetSize?.width,
+                        lcwRuntimeId: TelemetryManager.InternalTelemetryData.lcwRuntimeId
                     }
                 });
                 return;


### PR DESCRIPTION
This pull request primarily addresses a bug fix related to maximize events in the chat widget, ensuring that the `lcwRuntimeId` field is included in the event payload. This change improves telemetry and event tracking for chat maximization. The changelog has also been updated to reflect this fix and other recent enhancements.

Bug Fixes:

* Added the `lcwRuntimeId` field to the payload for Maximize events in both `startChat.ts` and `LiveChatWidgetStateful.tsx`, ensuring correct telemetry data is sent when the chat widget is maximized. [[1]](diffhunk://#diff-52259d02b1fde0594e601c99e7319c24302e6907a7bd8cb1dc00ec2e714fadd8L104-R105) [[2]](diffhunk://#diff-1011466398478ae8964e56b78a6d7b23d958093724d68315951854fe6d2210d9L446-R448)

Documentation Updates:

* Updated `CHANGE_LOG.md` to document the addition of the `lcwRuntimeId` field for Maximize events under the "Fixed" section.

Other minor changes:

* Added a newline in `LiveChatWidgetStateful.tsx` for code clarity.
* Updated the changelog to reflect other recent additions and changes, such as citation pane enhancements and dependency updates.

[24_09_2025, 5_40_44 PM - Screen - Video Project 32.webm](https://github.com/user-attachments/assets/b9c8f357-efd7-4bda-9079-c96ccabf0190)



https://github.com/user-attachments/assets/98c3ec7d-8d9d-4962-9e4d-341082167557




