### PR TITLE
Bum w 1.8.4-0

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 # Chat-Widget
 
-## [1.8.3]
+## [Unreleased]
+
+## [1.8.3] - 2025-10-07
 
 ### Fixed
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 # Chat-Widget
 
-## [Unreleased]
+## [1.8.3]
 
 ### Fixed
 

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-widget",
-  "version": "1.8.3",
+  "version": "1.8.4-0",
   "description": "Microsoft Omnichannel Chat Widget",
   "main": "lib/cjs/index.js",
   "types": "lib/types/index.d.ts",

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-widget",
-  "version": "1.8.3-0",
+  "version": "1.8.3",
   "description": "Microsoft Omnichannel Chat Widget",
   "main": "lib/cjs/index.js",
   "types": "lib/types/index.d.ts",


### PR DESCRIPTION
This pull request includes a version bump for the chat widget package and an update to the changelog to document the latest release. The most important changes are:

Release management:

* Updated the version in `chat-widget/package.json` from `1.8.3-0` to `1.8.4-0` to prepare for the next release.
* Added a new section for version `1.8.3` dated 2025-10-07 in `CHANGE_LOG.md` to record release notes.