### PR TITLE
Calling sendreadreceipts in omnichannel-chat-sdk for C1 messages

### DIFF
--- a/chat-widget/src/common/facades/FacadeChatSDK.ts
+++ b/chat-widget/src/common/facades/FacadeChatSDK.ts
@@ -434,4 +434,8 @@ export class FacadeChatSDK {
     public async fetchPersistentConversationHistory(getPersistentChatHistoryOptionalParams: GetPersistentChatHistoryOptionalParams = {}): Promise<GetPersistentChatHistoryResponse> {
         return this.validateAndExecuteCall("getPersistentChatHistory", () => this.chatSDK.getPersistentChatHistory(getPersistentChatHistoryOptionalParams));
     }
+
+    public async sendReadReceipt(messageId: string): Promise<void> {
+        return this.validateAndExecuteCall("sendReadReceipt", () => this.chatSDK.sendReadReceipt(messageId));
+    }
 }

--- a/chat-widget/src/components/livechatwidget/common/startChat.ts
+++ b/chat-widget/src/components/livechatwidget/common/startChat.ts
@@ -186,8 +186,8 @@ const initStartChat = async (facadeChatSDK: FacadeChatSDK, dispatch: Dispatch<IL
             await facadeChatSDK.startChat(startChatOptionalParams);
             logStartChatComplete();
             isStartChatSuccessful = true;
-
-            await createAdapterAndSubscribe(facadeChatSDK, dispatch, setAdapter, startTime, props);
+            const isPersistentChat = isPersistentEnabled(props?.chatConfig);
+            await createAdapterAndSubscribe(facadeChatSDK, dispatch, setAdapter, startTime, isPersistentChat, props);
 
         } catch (error) {
             checkContactIdError(error);
@@ -247,7 +247,7 @@ const initStartChat = async (facadeChatSDK: FacadeChatSDK, dispatch: Dispatch<IL
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const createAdapterAndSubscribe = async (facadeChatSDK: FacadeChatSDK, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, startTime: number,  props?: ILiveChatWidgetProps) => {
+const createAdapterAndSubscribe = async (facadeChatSDK: FacadeChatSDK, dispatch: Dispatch<ILiveChatWidgetAction>, setAdapter: any, startTime: number, isPersistentChat: boolean, props?: ILiveChatWidgetProps) => {
     // New adapter creation
     const newAdapter = await createAdapter(facadeChatSDK, props);
     setAdapter(newAdapter);
@@ -255,7 +255,7 @@ const createAdapterAndSubscribe = async (facadeChatSDK: FacadeChatSDK, dispatch:
     const chatToken = await facadeChatSDK?.getChatToken();
     dispatch({ type: LiveChatWidgetActionType.SET_CHAT_TOKEN, payload: chatToken });
     if (chatToken?.chatId && chatToken?.visitorId) {
-        newAdapter?.activity$?.subscribe(createOnNewAdapterActivityHandler(chatToken.chatId, chatToken.visitorId, startTime));
+        newAdapter?.activity$?.subscribe(createOnNewAdapterActivityHandler(chatToken.chatId, chatToken.visitorId, startTime, facadeChatSDK, isPersistentChat));
     }
 };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
### Id of the task, bug, story or other reference.
[Task 5851128](https://dev.azure.com/dynamicscrm/OneCRM/_workitems/edit/5851128): Implement sending read receipts to ACS - Omnichannel chat widget

### Description
We need to send read receipts to ACS to know which message is already read by customer for persistent chats.

## Solution Proposed
Added code to send read receipts on new message arrival from C1.

### Acceptance criteria
Able to send read receipts for persistent chats and ACS receiving them successfully.

## Test cases and evidence
This testing is combined testing for oc-chat-widget and oc-chat-sdk changes.

Sending read receipts for persistent chat -

<img width="1907" height="1045" alt="image" src="https://github.com/user-attachments/assets/ad4f73e1-3c90-48d4-8419-ef99f863988c" />



ACS receiving the receipt and sharing the latest timestamp -

<img width="1286" height="370" alt="image" src="https://github.com/user-attachments/assets/07c13c6e-520b-4bfa-9eff-95e5568cc7bc" />


### Sanity Tests
-   [X] You have tested all changes in Popout mode
-   [X] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues
Not applicable as no UI change done here.