### PR TITLE
ci: use npx npm@11.12.1 for publish to fix OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -38,9 +38,6 @@ jobs:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11.12.1
-
       - name: Update package version from git
         if: ${{ github.ref == 'refs/heads/main' }}
         working-directory: chat-widget
@@ -71,7 +68,7 @@ jobs:
 
       - name: Publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
         working-directory: chat-widget
-        run: npm publish --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
+        run: npx npm@11.12.1 publish --provenance --tag ${{ steps.dist-tag.outputs.tag }} --access public
 
   publish-chat-components:
     if: ${{ github.repository == 'microsoft/omnichannel-chat-widget' && (startsWith(github.ref, 'refs/tags/c-v') || github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.package == 'chat-components')) }}
@@ -88,9 +85,6 @@ jobs:
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@11.12.1
 
       - name: Update package version from git
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -113,4 +107,4 @@ jobs:
 
       - name: Publish ${{ steps.read-package-json.outputs.name }}@${{ steps.read-package-json.outputs.version }}
         working-directory: chat-components
-        run: npm publish --provenance --tag latest --access public
+        run: npx npm@11.12.1 publish --provenance --tag latest --access public

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Updated OC SDK package that has new ACS adapter for beta.6 w/ botframework
 - Update GitHub Actions (checkout, setup-node) from v2/v3 to v4 and Node.js from 20.x to 22.x across chat-widget workflows to address Node.js 20 deprecation in GitHub Actions
-- Pin npm upgrade to `npm@11.12.1` in npm-release workflow to fix OIDC trusted publishing (unpinned `npm@latest` caused self-upgrade crash and E404 on publish)
+- Use `npx npm@11.12.1` for publish step to fix OIDC trusted publishing (npm 10.9.7 can't do OIDC, and `npm install -g` crashes during self-upgrade)
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- Use `npx npm@11.12.1 publish` instead of global npm for the publish step in npm-release.yml
- Supersedes PR #903 — the global install approach (`npm install -g npm@11.12.1`) also crashes because npm 10.9.7 corrupts itself during the self-upgrade (`Cannot find module 'promise-retry'`)
- `npx` downloads npm 11.12.1 to a temp cache and runs it directly, avoiding the self-upgrade entirely
- npm 11.12.1 is the last known working version for OIDC trusted publishing (successful publish April 1)

### Why each approach failed
| Approach | Result |
|----------|--------|
| `npm@latest` (original) | Self-upgrade crash since April 3 |
| Remove upgrade (PR #901) | E404 — npm 10.9.7 can't do OIDC |
| `npm install -g npm@11.12.1` (PR #903) | Same self-upgrade crash |
| **`npx npm@11.12.1 publish`** (this PR) | No self-upgrade, uses npm 11.12.1 directly |

## Test plan
- [ ] Merge and verify npm-release workflow succeeds on the resulting main push
- [ ] Confirm published package appears on npmjs.com with provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)