### PR TITLE
feat: Add monitor-only HTML sanitization with telemetry (Phase 1)

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - [A11y] E2E Playwright tests for 5 accessibility defects: focus trap, bot initials alt text, adaptive card radio count, attachment upload announcement, email notification aria-live regions
-
+- [Security] Added monitor-only HTML sanitization to gather telemetry before enforcing stricter allowlist rules (Phase 1). Tracks OrganizationId, ConversationId, RemovedTags, RemovedAttributes, and ExecutionTimeMs when content would be blocked by strict allowlist. Runs asynchronously to avoid message latency. Includes 27 unit tests.
 - [iOS] Added `inputFontSize` property to `IAdaptiveCardStyles` (default `16px`) to prevent iOS Safari auto-zoom on input focus. Applies to adaptive card inputs and the send box textarea. Clients can override via `adaptiveCardStyles.inputFontSize` (minimum 16px enforced).
 - [Mid-Auth] Added mid-conversation authentication support: users can start chat unauthenticated and upgrade to authenticated when they sign in
 - [Mid-Auth] Added `FacadeChatSDK` methods: `configureMidAuthState`, `handlePendingUnauthenticatedState`, `handleAuthenticatedState`, `setMidAuthUnauthenticatedState`, `clearAuthState`, `migrateConversationToAuthenticated`

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -193,6 +193,7 @@ export enum TelemetryEvent {
     //WebChat Middleware Events
     ProcessingHTMLTextMiddlewareFailed = "ProcessingHTMLTextMiddlewareFailed",
     ProcessingSanitizationMiddlewareFailed = "ProcessingSanitizationMiddlewareFailed",
+    HTMLSanitized = "HTMLSanitized",
     FormatTagsMiddlewareJSONStringifyFailed = "FormatTagsMiddlewareJSONStringifyFailed",
     AttachmentUploadValidatorMiddlewareFailed = "AttachmentUploadValidatorMiddlewareFailed",
     CitationMiddlewareFailed = "CitationMiddlewareFailed",

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.test.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.test.ts
@@ -1,0 +1,692 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import "@testing-library/jest-dom";
+
+import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
+import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
+import DOMPurify from "dompurify";
+
+// Mock TelemetryHelper
+jest.mock("../../../common/telemetry/TelemetryHelper");
+
+// Mock console.warn to suppress development logs in tests
+const originalWarn = console.warn;
+beforeAll(() => {
+    console.warn = jest.fn();
+});
+
+afterAll(() => {
+    console.warn = originalWarn;
+});
+
+describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
+    let mockState: any;
+    let logActionEventSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        // Reset mocks
+        jest.clearAllMocks();
+
+        // Mock state with orgId and chatId
+        mockState = {
+            domainStates: {
+                telemetryInternalData: {
+                    orgId: "test-org-123"
+                },
+                chatToken: {
+                    chatId: "test-chat-456"
+                }
+            }
+        };
+
+        // Spy on TelemetryHelper.logActionEvent
+        logActionEventSpy = jest.spyOn(TelemetryHelper, "logActionEvent");
+    });
+
+    describe("Content that would be blocked by strict allowlist", () => {
+        it("should log telemetry when img tag would be removed", () => {
+            const htmlWithImage = '<p>Hello <img src="test.jpg" /> world</p>';
+
+            // Sanitize with current config (allows img through existing config)
+            const result = DOMPurify.sanitize(htmlWithImage, {
+                FORBID_TAGS: ["form", "button", "script", "div", "input"],
+                FORBID_ATTR: ["action"],
+                ADD_ATTR: ["target"]
+            });
+
+            // Simulate monitor function behavior
+            const strictConfig = {
+                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
+                ALLOWED_ATTR: ["href", "target", "rel"],
+                FORBID_TAGS: ["img", "video", "audio", "iframe", "object", "embed", "script", "style", "form", "input", "textarea", "button", "link", "meta", "base", "div", "span"],
+                FORBID_ATTR: ["style", /^on/i],
+                ALLOWED_URI_REGEXP: /^https?:/i,
+                ALLOW_DATA_ATTR: false,
+                ALLOW_UNKNOWN_PROTOCOLS: false
+            };
+
+            const removedTags: string[] = [];
+
+            // Add hook to track removed tags (filter out body tag which is DOMPurify wrapper)
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlWithImage, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toContain("img");
+        });
+
+        it("should log telemetry when span tag would be removed", () => {
+            const htmlWithSpan = '<p>Hello <span style="color: red;">world</span></p>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
+                ALLOWED_ATTR: ["href", "target", "rel"],
+                FORBID_TAGS: ["img", "video", "audio", "iframe", "object", "embed", "script", "style", "form", "input", "textarea", "button", "link", "meta", "base", "div", "span"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlWithSpan, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toContain("span");
+        });
+
+        it("should log telemetry when div tag would be removed", () => {
+            const htmlWithDiv = '<div><p>Hello world</p></div>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
+                FORBID_TAGS: ["div", "span"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlWithDiv, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toContain("div");
+        });
+
+        it("should log telemetry when style attribute would be removed", () => {
+            const htmlWithStyle = '<p style="color: red;">Hello world</p>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"],
+                ALLOWED_ATTR: ["href", "target", "rel"],
+                FORBID_ATTR: ["style"]
+            };
+
+            const removedAttrs: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
+                const attrName = data.attrName.toLowerCase();
+                if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
+                    removedAttrs.push(attrName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlWithStyle, strictConfig);
+            DOMPurify.removeHook("uponSanitizeAttribute");
+
+            expect(removedAttrs).toContain("style");
+        });
+
+        it("should log telemetry when onclick attribute would be removed", () => {
+            const htmlWithOnClick = '<p onclick="alert(\'xss\')">Hello world</p>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"],
+                ALLOWED_ATTR: ["href", "target", "rel"],
+                FORBID_ATTR: [/^on/i]
+            };
+
+            const removedAttrs: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
+                const attrName = data.attrName.toLowerCase();
+                if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
+                    removedAttrs.push(attrName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlWithOnClick, strictConfig);
+            DOMPurify.removeHook("uponSanitizeAttribute");
+
+            expect(removedAttrs.length).toBeGreaterThan(0);
+        });
+
+        it("should track multiple removed tags in one pass", () => {
+            const htmlComplex = '<div><p>Hello <img src="test.jpg" /> <span>world</span></p></div>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"],
+                FORBID_TAGS: ["div", "span", "img"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlComplex, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toContain("div");
+            expect(removedTags).toContain("span");
+            expect(removedTags).toContain("img");
+        });
+
+        it("should deduplicate removed tags", () => {
+            const htmlMultipleDivs = '<div><p>Test1</p></div><div><p>Test2</p></div>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"],
+                FORBID_TAGS: ["div"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlMultipleDivs, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            // Should have multiple div entries before deduplication
+            expect(removedTags.filter(tag => tag === "div").length).toBeGreaterThan(1);
+
+            // After deduplication
+            const uniqueTags = [...new Set(removedTags)];
+            expect(uniqueTags).toEqual(["div"]);
+        });
+    });
+
+    describe("Content that passes strict allowlist", () => {
+        it("should not log telemetry for allowed tags", () => {
+            const cleanHtml = '<p>Hello <b>world</b></p>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
+                ALLOWED_ATTR: ["href", "target", "rel"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(cleanHtml, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toEqual([]);
+        });
+
+        it("should not log telemetry for allowed formatting tags", () => {
+            const formattedHtml = '<p><b>Bold</b> <i>Italic</i> <u>Underline</u> <em>Emphasis</em> <strong>Strong</strong></p>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(formattedHtml, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toEqual([]);
+        });
+
+        it("should not log telemetry for allowed lists", () => {
+            const listHtml = '<ul><li>Item 1</li><li>Item 2</li></ul><ol><li>First</li></ol>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(listHtml, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toEqual([]);
+        });
+
+        it("should not log telemetry for allowed links with safe attributes", () => {
+            const linkHtml = '<a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["a"],
+                ALLOWED_ATTR: ["href", "target", "rel"],
+                ALLOWED_URI_REGEXP: /^https?:/i
+            };
+
+            const removedTags: string[] = [];
+            const removedAttrs: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
+                const attrName = data.attrName.toLowerCase();
+                if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
+                    removedAttrs.push(attrName);
+                }
+            });
+
+            DOMPurify.sanitize(linkHtml, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+            DOMPurify.removeHook("uponSanitizeAttribute");
+
+            expect(removedTags).toEqual([]);
+            expect(removedAttrs).toEqual([]);
+        });
+    });
+
+    describe("Edge cases", () => {
+        it("should handle empty string", () => {
+            const emptyHtml = "";
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            const result = DOMPurify.sanitize(emptyHtml, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(result).toBe("");
+            expect(removedTags).toEqual([]);
+        });
+
+        it("should handle plain text without HTML tags", () => {
+            const plainText = "Hello world";
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            const result = DOMPurify.sanitize(plainText, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(result).toBe("Hello world");
+            expect(removedTags).toEqual([]);
+        });
+
+        it("should handle malformed HTML", () => {
+            const malformedHtml = '<p>Unclosed paragraph<div>Nested without closing';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"],
+                FORBID_TAGS: ["div"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(malformedHtml, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toContain("div");
+        });
+
+        it("should handle nested allowed tags", () => {
+            const nestedHtml = '<p><b><i>Bold italic</i></b></p>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p", "b", "i"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(nestedHtml, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toEqual([]);
+        });
+
+        it("should handle XSS attempts - script tags", () => {
+            const xss = '<script>alert("xss")</script>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["a", "p"],
+                FORBID_TAGS: ["script"]
+            };
+
+            const result = DOMPurify.sanitize(xss, strictConfig);
+
+            // DOMPurify removes script tags completely
+            expect(result).not.toContain("<script>");
+            expect(result).not.toContain("alert");
+        });
+
+        it("should handle XSS attempts - img with onerror", () => {
+            const xss = '<img src=x onerror="alert(\'xss\')">';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["a", "p"],
+                FORBID_TAGS: ["img"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(xss, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toContain("img");
+        });
+
+        it("should handle XSS attempts - javascript URL", () => {
+            const xss = '<a href="javascript:alert(\'xss\')">Click</a>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["a"],
+                ALLOWED_ATTR: ["href"],
+                ALLOWED_URI_REGEXP: /^https?:/i
+            };
+
+            const result = DOMPurify.sanitize(xss, strictConfig);
+
+            // DOMPurify removes javascript: URLs
+            expect(result).not.toContain("javascript:");
+        });
+
+        it("should handle XSS attempts - iframe", () => {
+            const xss = '<iframe src="http://evil.com"></iframe>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["a", "p"],
+                FORBID_TAGS: ["iframe"]
+            };
+
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(xss, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            expect(removedTags).toContain("iframe");
+        });
+    });
+
+    describe("Existing sanitization preservation", () => {
+        it("should continue blocking script tags with existing config", () => {
+            const htmlWithScript = '<p>Hello <script>alert("xss")</script> world</p>';
+
+            const existingConfig = {
+                FORBID_TAGS: ["form", "button", "script", "div", "input"],
+                FORBID_ATTR: ["action"],
+                ADD_ATTR: ["target"]
+            };
+
+            const result = DOMPurify.sanitize(htmlWithScript, existingConfig);
+
+            expect(result).not.toContain("<script>");
+            expect(result).not.toContain("alert");
+            expect(result).toContain("Hello");
+            expect(result).toContain("world");
+        });
+
+        it("should continue blocking form tags with existing config", () => {
+            const htmlWithForm = '<p>Test</p><form><input type="text" /></form>';
+
+            const existingConfig = {
+                FORBID_TAGS: ["form", "button", "script", "div", "input"],
+                FORBID_ATTR: ["action"]
+            };
+
+            const result = DOMPurify.sanitize(htmlWithForm, existingConfig);
+
+            expect(result).not.toContain("<form>");
+            expect(result).not.toContain("<input>");
+            expect(result).toContain("Test");
+        });
+
+        it("should continue blocking div tags with existing config", () => {
+            const htmlWithDiv = '<div><p>Hello world</p></div>';
+
+            const existingConfig = {
+                FORBID_TAGS: ["form", "button", "script", "div", "input"]
+            };
+
+            const result = DOMPurify.sanitize(htmlWithDiv, existingConfig);
+
+            expect(result).not.toContain("<div>");
+            expect(result).toContain("<p>");
+            expect(result).toContain("Hello world");
+        });
+
+        it("should continue allowing img tags with existing config (but monitor would flag it)", () => {
+            const htmlWithImg = '<p>Hello <img src="test.jpg" /> world</p>';
+
+            const existingConfig = {
+                FORBID_TAGS: ["form", "button", "script", "div", "input"]
+            };
+
+            const result = DOMPurify.sanitize(htmlWithImg, existingConfig);
+
+            // Existing config allows img (not in FORBID_TAGS)
+            expect(result).toContain("<img");
+
+            // But strict config would remove it
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"],
+                FORBID_TAGS: ["img"]
+            };
+
+            const strictResult = DOMPurify.sanitize(htmlWithImg, strictConfig);
+            expect(strictResult).not.toContain("<img");
+        });
+    });
+
+    describe("Hook management", () => {
+        it("should remove hooks after monitoring", () => {
+            const html = '<p>Test</p>';
+
+            // Add a hook
+            DOMPurify.addHook("uponSanitizeElement", () => {});
+
+            // Simulate monitor adding and removing hooks
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            // Verify hooks can be added again (no conflicts)
+            const hookAdded = () => {
+                DOMPurify.addHook("uponSanitizeElement", () => {});
+            };
+
+            expect(hookAdded).not.toThrow();
+
+            // Cleanup
+            DOMPurify.removeHook("uponSanitizeElement");
+        });
+
+        it("should not interfere with other hooks", () => {
+            const html = '<p>Test</p>';
+            let otherHookCalled = false;
+
+            // Add a different hook (simulating postDomPurifyActivities)
+            DOMPurify.addHook("afterSanitizeAttributes", () => {
+                otherHookCalled = true;
+            });
+
+            // Add and remove monitor hooks
+            DOMPurify.addHook("uponSanitizeElement", () => {});
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            // Run sanitization
+            DOMPurify.sanitize(html, {});
+
+            // Other hook should still work
+            expect(otherHookCalled).toBe(true);
+
+            // Cleanup
+            DOMPurify.removeHook("afterSanitizeAttributes");
+        });
+    });
+
+    describe("Performance monitoring", () => {
+        it("should track execution time in telemetry", (done) => {
+            const htmlWithUnsafeTags = '<p>Hello <img src="test.jpg" /> <div>world</div></p>';
+            const mockState = {
+                domainStates: {
+                    telemetryInternalData: { orgId: "test-org" },
+                    chatToken: { chatId: "test-chat" }
+                }
+            };
+
+            // Mock TelemetryHelper to capture the call
+            const logSpy = jest.spyOn(TelemetryHelper, "logActionEvent");
+
+            // Simulate the monitor function call (inline to verify timing)
+            const startTime = performance.now();
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
+                FORBID_TAGS: ["img", "div"]
+            };
+
+            const removedTags: string[] = [];
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlWithUnsafeTags, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            const endTime = performance.now();
+            const executionTimeMs = Math.round((endTime - startTime) * 100) / 100;
+
+            // Verify execution time is a positive number
+            expect(executionTimeMs).toBeGreaterThanOrEqual(0);
+            expect(typeof executionTimeMs).toBe("number");
+            expect(isNaN(executionTimeMs)).toBe(false);
+
+            done();
+        });
+
+        it("should include execution time in telemetry when unsafe content is detected", () => {
+            const htmlWithImg = '<p>Test <img src="test.jpg" /></p>';
+
+            const strictConfig = {
+                ALLOWED_TAGS: ["p"],
+                FORBID_TAGS: ["img"]
+            };
+
+            const startTime = performance.now();
+            const removedTags: string[] = [];
+
+            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                const tagName = data.tagName.toLowerCase();
+                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                    removedTags.push(tagName);
+                }
+            });
+
+            DOMPurify.sanitize(htmlWithImg, strictConfig);
+            DOMPurify.removeHook("uponSanitizeElement");
+
+            const endTime = performance.now();
+            const executionTimeMs = Math.round((endTime - startTime) * 100) / 100;
+
+            // Verify timing is captured
+            expect(removedTags.length).toBeGreaterThan(0);
+            expect(executionTimeMs).toBeGreaterThanOrEqual(0);
+        });
+    });
+});

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.test.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.test.ts
@@ -2,12 +2,7 @@
 
 import "@testing-library/jest-dom";
 
-import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
-import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
 import DOMPurify from "dompurify";
-
-// Mock TelemetryHelper
-jest.mock("../../../common/telemetry/TelemetryHelper");
 
 // Mock console.warn to suppress development logs in tests
 const originalWarn = console.warn;
@@ -20,35 +15,17 @@ afterAll(() => {
 });
 
 describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
-    let mockState: any;
-    let logActionEventSpy: jest.SpyInstance;
-
     beforeEach(() => {
         // Reset mocks
         jest.clearAllMocks();
-
-        // Mock state with orgId and chatId
-        mockState = {
-            domainStates: {
-                telemetryInternalData: {
-                    orgId: "test-org-123"
-                },
-                chatToken: {
-                    chatId: "test-chat-456"
-                }
-            }
-        };
-
-        // Spy on TelemetryHelper.logActionEvent
-        logActionEventSpy = jest.spyOn(TelemetryHelper, "logActionEvent");
     });
 
     describe("Content that would be blocked by strict allowlist", () => {
         it("should log telemetry when img tag would be removed", () => {
-            const htmlWithImage = '<p>Hello <img src="test.jpg" /> world</p>';
+            const htmlWithImage = "<p>Hello <img src=\"test.jpg\" /> world</p>";
 
             // Sanitize with current config (allows img through existing config)
-            const result = DOMPurify.sanitize(htmlWithImage, {
+            DOMPurify.sanitize(htmlWithImage, {
                 FORBID_TAGS: ["form", "button", "script", "div", "input"],
                 FORBID_ATTR: ["action"],
                 ADD_ATTR: ["target"]
@@ -82,7 +59,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should log telemetry when span tag would be removed", () => {
-            const htmlWithSpan = '<p>Hello <span style="color: red;">world</span></p>';
+            const htmlWithSpan = "<p>Hello <span style=\"color: red;\">world</span></p>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
@@ -106,7 +83,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should log telemetry when div tag would be removed", () => {
-            const htmlWithDiv = '<div><p>Hello world</p></div>';
+            const htmlWithDiv = "<div><p>Hello world</p></div>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
@@ -129,7 +106,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should log telemetry when style attribute would be removed", () => {
-            const htmlWithStyle = '<p style="color: red;">Hello world</p>';
+            const htmlWithStyle = "<p style=\"color: red;\">Hello world</p>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["p"],
@@ -153,7 +130,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should log telemetry when onclick attribute would be removed", () => {
-            const htmlWithOnClick = '<p onclick="alert(\'xss\')">Hello world</p>';
+            const htmlWithOnClick = "<p onclick=\"alert('xss')\">Hello world</p>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["p"],
@@ -177,7 +154,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should track multiple removed tags in one pass", () => {
-            const htmlComplex = '<div><p>Hello <img src="test.jpg" /> <span>world</span></p></div>';
+            const htmlComplex = "<div><p>Hello <img src=\"test.jpg\" /> <span>world</span></p></div>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["p"],
@@ -202,7 +179,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should deduplicate removed tags", () => {
-            const htmlMultipleDivs = '<div><p>Test1</p></div><div><p>Test2</p></div>';
+            const htmlMultipleDivs = "<div><p>Test1</p></div><div><p>Test2</p></div>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["p"],
@@ -232,7 +209,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
 
     describe("Content that passes strict allowlist", () => {
         it("should not log telemetry for allowed tags", () => {
-            const cleanHtml = '<p>Hello <b>world</b></p>';
+            const cleanHtml = "<p>Hello <b>world</b></p>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
@@ -255,7 +232,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should not log telemetry for allowed formatting tags", () => {
-            const formattedHtml = '<p><b>Bold</b> <i>Italic</i> <u>Underline</u> <em>Emphasis</em> <strong>Strong</strong></p>';
+            const formattedHtml = "<p><b>Bold</b> <i>Italic</i> <u>Underline</u> <em>Emphasis</em> <strong>Strong</strong></p>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"]
@@ -277,7 +254,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should not log telemetry for allowed lists", () => {
-            const listHtml = '<ul><li>Item 1</li><li>Item 2</li></ul><ol><li>First</li></ol>';
+            const listHtml = "<ul><li>Item 1</li><li>Item 2</li></ul><ol><li>First</li></ol>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"]
@@ -299,7 +276,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should not log telemetry for allowed links with safe attributes", () => {
-            const linkHtml = '<a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a>';
+            const linkHtml = "<a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">Link</a>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["a"],
@@ -381,7 +358,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should handle malformed HTML", () => {
-            const malformedHtml = '<p>Unclosed paragraph<div>Nested without closing';
+            const malformedHtml = "<p>Unclosed paragraph<div>Nested without closing";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["p"],
@@ -404,7 +381,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should handle nested allowed tags", () => {
-            const nestedHtml = '<p><b><i>Bold italic</i></b></p>';
+            const nestedHtml = "<p><b><i>Bold italic</i></b></p>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["p", "b", "i"]
@@ -426,7 +403,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should handle XSS attempts - script tags", () => {
-            const xss = '<script>alert("xss")</script>';
+            const xss = "<script>alert(\"xss\")</script>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["a", "p"],
@@ -441,7 +418,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should handle XSS attempts - img with onerror", () => {
-            const xss = '<img src=x onerror="alert(\'xss\')">';
+            const xss = "<img src=x onerror=\"alert('xss')\">";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["a", "p"],
@@ -464,7 +441,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should handle XSS attempts - javascript URL", () => {
-            const xss = '<a href="javascript:alert(\'xss\')">Click</a>';
+            const xss = "<a href=\"javascript:alert('xss')\">Click</a>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["a"],
@@ -479,7 +456,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should handle XSS attempts - iframe", () => {
-            const xss = '<iframe src="http://evil.com"></iframe>';
+            const xss = "<iframe src=\"http://evil.com\"></iframe>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["a", "p"],
@@ -504,7 +481,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
 
     describe("Existing sanitization preservation", () => {
         it("should continue blocking script tags with existing config", () => {
-            const htmlWithScript = '<p>Hello <script>alert("xss")</script> world</p>';
+            const htmlWithScript = "<p>Hello <script>alert(\"xss\")</script> world</p>";
 
             const existingConfig = {
                 FORBID_TAGS: ["form", "button", "script", "div", "input"],
@@ -521,7 +498,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should continue blocking form tags with existing config", () => {
-            const htmlWithForm = '<p>Test</p><form><input type="text" /></form>';
+            const htmlWithForm = "<p>Test</p><form><input type=\"text\" /></form>";
 
             const existingConfig = {
                 FORBID_TAGS: ["form", "button", "script", "div", "input"],
@@ -536,7 +513,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should continue blocking div tags with existing config", () => {
-            const htmlWithDiv = '<div><p>Hello world</p></div>';
+            const htmlWithDiv = "<div><p>Hello world</p></div>";
 
             const existingConfig = {
                 FORBID_TAGS: ["form", "button", "script", "div", "input"]
@@ -550,7 +527,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should continue allowing img tags with existing config (but monitor would flag it)", () => {
-            const htmlWithImg = '<p>Hello <img src="test.jpg" /> world</p>';
+            const htmlWithImg = "<p>Hello <img src=\"test.jpg\" /> world</p>";
 
             const existingConfig = {
                 FORBID_TAGS: ["form", "button", "script", "div", "input"]
@@ -574,17 +551,15 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
 
     describe("Hook management", () => {
         it("should remove hooks after monitoring", () => {
-            const html = '<p>Test</p>';
-
-            // Add a hook
-            DOMPurify.addHook("uponSanitizeElement", () => {});
+            // Add a hook with empty implementation
+            DOMPurify.addHook("uponSanitizeElement", () => { /* empty hook for testing */ });
 
             // Simulate monitor adding and removing hooks
             DOMPurify.removeHook("uponSanitizeElement");
 
             // Verify hooks can be added again (no conflicts)
             const hookAdded = () => {
-                DOMPurify.addHook("uponSanitizeElement", () => {});
+                DOMPurify.addHook("uponSanitizeElement", () => { /* empty hook for testing */ });
             };
 
             expect(hookAdded).not.toThrow();
@@ -594,7 +569,6 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should not interfere with other hooks", () => {
-            const html = '<p>Test</p>';
             let otherHookCalled = false;
 
             // Add a different hook (simulating postDomPurifyActivities)
@@ -602,12 +576,12 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
                 otherHookCalled = true;
             });
 
-            // Add and remove monitor hooks
-            DOMPurify.addHook("uponSanitizeElement", () => {});
+            // Add and remove monitor hooks with empty implementation
+            DOMPurify.addHook("uponSanitizeElement", () => { /* empty hook for testing */ });
             DOMPurify.removeHook("uponSanitizeElement");
 
             // Run sanitization
-            DOMPurify.sanitize(html, {});
+            DOMPurify.sanitize("<p>Test</p>", {});
 
             // Other hook should still work
             expect(otherHookCalled).toBe(true);
@@ -619,16 +593,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
 
     describe("Performance monitoring", () => {
         it("should track execution time in telemetry", (done) => {
-            const htmlWithUnsafeTags = '<p>Hello <img src="test.jpg" /> <div>world</div></p>';
-            const mockState = {
-                domainStates: {
-                    telemetryInternalData: { orgId: "test-org" },
-                    chatToken: { chatId: "test-chat" }
-                }
-            };
-
-            // Mock TelemetryHelper to capture the call
-            const logSpy = jest.spyOn(TelemetryHelper, "logActionEvent");
+            const htmlWithUnsafeTags = "<p>Hello <img src=\"test.jpg\" /> <div>world</div></p>";
 
             // Simulate the monitor function call (inline to verify timing)
             const startTime = performance.now();
@@ -661,7 +626,7 @@ describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
         });
 
         it("should include execution time in telemetry when unsafe content is detected", () => {
-            const htmlWithImg = '<p>Test <img src="test.jpg" /></p>';
+            const htmlWithImg = "<p>Test <img src=\"test.jpg\" /></p>";
 
             const strictConfig = {
                 ALLOWED_TAGS: ["p"],

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.test.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.test.ts
@@ -2,656 +2,356 @@
 
 import "@testing-library/jest-dom";
 
-import DOMPurify from "dompurify";
+import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
+import { LogLevel, TelemetryEvent } from "../../../common/telemetry/TelemetryConstants";
+import { initWebChatComposer } from "./initWebChatComposer";
+
+// Mock TelemetryHelper
+jest.mock("../../../common/telemetry/TelemetryHelper");
+
+// Mock other dependencies
+jest.mock("../../../common/utils", () => ({
+    changeLanguageCodeFormatForWebChat: jest.fn((locale) => locale),
+    getConversationDetailsCall: jest.fn(),
+    getLocaleStringFromId: jest.fn(() => "en-US"),
+    createTimer: jest.fn(() => ({
+        milliSecondsElapsed: 0
+    }))
+}));
+
+jest.mock("@microsoft/omnichannel-chat-components", () => ({
+    BroadcastService: {
+        postMessage: jest.fn(),
+        getMessageByEventName: jest.fn(() => ({
+            subscribe: jest.fn()
+        }))
+    },
+    BroadcastEvent: {
+        PersistentConversationReset: "PersistentConversationReset"
+    }
+}));
 
 // Mock console.warn to suppress development logs in tests
 const originalWarn = console.warn;
+const originalError = console.error;
 beforeAll(() => {
     console.warn = jest.fn();
+    console.error = jest.fn();
 });
 
 afterAll(() => {
     console.warn = originalWarn;
+    console.error = originalError;
 });
 
-describe("initWebChatComposer - Monitor-Only HTML Sanitization", () => {
+describe("initWebChatComposer - HTML Sanitization Monitoring", () => {
+    let mockProps: any;
+    let mockState: any;
+    let mockDispatch: any;
+    let mockFacadeChatSDK: any;
+    let mockEndChat: any;
+    let logActionEventSpy: jest.SpyInstance;
+
+    // Mock requestIdleCallback for tests
+    let requestIdleCallbackSpy: jest.SpyInstance;
+    let setTimeoutSpy: jest.SpyInstance;
+
     beforeEach(() => {
         // Reset mocks
         jest.clearAllMocks();
+
+        // Mock requestIdleCallback (doesn't exist in jsdom)
+        (window as any).requestIdleCallback = jest.fn((callback: any) => {
+            callback(); // Execute immediately in tests
+            return 1;
+        });
+        requestIdleCallbackSpy = window.requestIdleCallback as any;
+
+        setTimeoutSpy = jest.spyOn(window, "setTimeout");
+
+        // Mock state with orgId and chatId
+        mockState = {
+            domainStates: {
+                telemetryInternalData: {
+                    orgId: "test-org-123"
+                },
+                chatToken: {
+                    chatId: "test-chat-456"
+                },
+                liveChatConfig: {
+                    ChatWidgetLanguage: {
+                        msdyn_localeid: 1033
+                    }
+                }
+            }
+        };
+
+        mockProps = {
+            webChatContainerProps: {}
+        };
+
+        mockDispatch = jest.fn();
+        mockFacadeChatSDK = {};
+        mockEndChat = jest.fn();
+
+        // Spy on TelemetryHelper.logActionEvent
+        logActionEventSpy = jest.spyOn(TelemetryHelper, "logActionEvent");
     });
 
-    describe("Content that would be blocked by strict allowlist", () => {
-        it("should log telemetry when img tag would be removed", () => {
-            const htmlWithImage = "<p>Hello <img src=\"test.jpg\" /> world</p>";
-
-            // Sanitize with current config (allows img through existing config)
-            DOMPurify.sanitize(htmlWithImage, {
-                FORBID_TAGS: ["form", "button", "script", "div", "input"],
-                FORBID_ATTR: ["action"],
-                ADD_ATTR: ["target"]
-            });
-
-            // Simulate monitor function behavior
-            const strictConfig = {
-                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
-                ALLOWED_ATTR: ["href", "target", "rel"],
-                FORBID_TAGS: ["img", "video", "audio", "iframe", "object", "embed", "script", "style", "form", "input", "textarea", "button", "link", "meta", "base", "div", "span"],
-                FORBID_ATTR: ["style", /^on/i],
-                ALLOWED_URI_REGEXP: /^https?:/i,
-                ALLOW_DATA_ATTR: false,
-                ALLOW_UNKNOWN_PROTOCOLS: false
-            };
-
-            const removedTags: string[] = [];
-
-            // Add hook to track removed tags (filter out body tag which is DOMPurify wrapper)
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(htmlWithImage, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toContain("img");
-        });
-
-        it("should log telemetry when span tag would be removed", () => {
-            const htmlWithSpan = "<p>Hello <span style=\"color: red;\">world</span></p>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
-                ALLOWED_ATTR: ["href", "target", "rel"],
-                FORBID_TAGS: ["img", "video", "audio", "iframe", "object", "embed", "script", "style", "form", "input", "textarea", "button", "link", "meta", "base", "div", "span"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(htmlWithSpan, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toContain("span");
-        });
-
-        it("should log telemetry when div tag would be removed", () => {
-            const htmlWithDiv = "<div><p>Hello world</p></div>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
-                FORBID_TAGS: ["div", "span"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(htmlWithDiv, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toContain("div");
-        });
-
-        it("should log telemetry when style attribute would be removed", () => {
-            const htmlWithStyle = "<p style=\"color: red;\">Hello world</p>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"],
-                ALLOWED_ATTR: ["href", "target", "rel"],
-                FORBID_ATTR: ["style"]
-            };
-
-            const removedAttrs: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-                const attrName = data.attrName.toLowerCase();
-                if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
-                    removedAttrs.push(attrName);
-                }
-            });
-
-            DOMPurify.sanitize(htmlWithStyle, strictConfig);
-            DOMPurify.removeHook("uponSanitizeAttribute");
-
-            expect(removedAttrs).toContain("style");
-        });
-
-        it("should log telemetry when onclick attribute would be removed", () => {
-            const htmlWithOnClick = "<p onclick=\"alert('xss')\">Hello world</p>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"],
-                ALLOWED_ATTR: ["href", "target", "rel"],
-                FORBID_ATTR: [/^on/i]
-            };
-
-            const removedAttrs: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-                const attrName = data.attrName.toLowerCase();
-                if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
-                    removedAttrs.push(attrName);
-                }
-            });
-
-            DOMPurify.sanitize(htmlWithOnClick, strictConfig);
-            DOMPurify.removeHook("uponSanitizeAttribute");
-
-            expect(removedAttrs.length).toBeGreaterThan(0);
-        });
-
-        it("should track multiple removed tags in one pass", () => {
-            const htmlComplex = "<div><p>Hello <img src=\"test.jpg\" /> <span>world</span></p></div>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"],
-                FORBID_TAGS: ["div", "span", "img"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(htmlComplex, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toContain("div");
-            expect(removedTags).toContain("span");
-            expect(removedTags).toContain("img");
-        });
-
-        it("should deduplicate removed tags", () => {
-            const htmlMultipleDivs = "<div><p>Test1</p></div><div><p>Test2</p></div>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"],
-                FORBID_TAGS: ["div"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(htmlMultipleDivs, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            // Should have multiple div entries before deduplication
-            expect(removedTags.filter(tag => tag === "div").length).toBeGreaterThan(1);
-
-            // After deduplication
-            const uniqueTags = [...new Set(removedTags)];
-            expect(uniqueTags).toEqual(["div"]);
-        });
+    afterEach(() => {
+        if (setTimeoutSpy && setTimeoutSpy.mockRestore) {
+            setTimeoutSpy.mockRestore();
+        }
+        // Clean up requestIdleCallback mock
+        delete (window as any).requestIdleCallback;
     });
 
-    describe("Content that passes strict allowlist", () => {
-        it("should not log telemetry for allowed tags", () => {
-            const cleanHtml = "<p>Hello <b>world</b></p>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
-                ALLOWED_ATTR: ["href", "target", "rel"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(cleanHtml, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toEqual([]);
-        });
-
-        it("should not log telemetry for allowed formatting tags", () => {
-            const formattedHtml = "<p><b>Bold</b> <i>Italic</i> <u>Underline</u> <em>Emphasis</em> <strong>Strong</strong></p>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(formattedHtml, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toEqual([]);
-        });
-
-        it("should not log telemetry for allowed lists", () => {
-            const listHtml = "<ul><li>Item 1</li><li>Item 2</li></ul><ol><li>First</li></ol>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(listHtml, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toEqual([]);
-        });
-
-        it("should not log telemetry for allowed links with safe attributes", () => {
-            const linkHtml = "<a href=\"https://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">Link</a>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["a"],
-                ALLOWED_ATTR: ["href", "target", "rel"],
-                ALLOWED_URI_REGEXP: /^https?:/i
-            };
-
-            const removedTags: string[] = [];
-            const removedAttrs: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-                const attrName = data.attrName.toLowerCase();
-                if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
-                    removedAttrs.push(attrName);
-                }
-            });
-
-            DOMPurify.sanitize(linkHtml, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-            DOMPurify.removeHook("uponSanitizeAttribute");
-
-            expect(removedTags).toEqual([]);
-            expect(removedAttrs).toEqual([]);
-        });
-    });
-
-    describe("Edge cases", () => {
-        it("should handle empty string", () => {
-            const emptyHtml = "";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            const result = DOMPurify.sanitize(emptyHtml, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(result).toBe("");
-            expect(removedTags).toEqual([]);
-        });
-
-        it("should handle plain text without HTML tags", () => {
-            const plainText = "Hello world";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            const result = DOMPurify.sanitize(plainText, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(result).toBe("Hello world");
-            expect(removedTags).toEqual([]);
-        });
-
-        it("should handle malformed HTML", () => {
-            const malformedHtml = "<p>Unclosed paragraph<div>Nested without closing";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"],
-                FORBID_TAGS: ["div"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(malformedHtml, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toContain("div");
-        });
-
-        it("should handle nested allowed tags", () => {
-            const nestedHtml = "<p><b><i>Bold italic</i></b></p>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["p", "b", "i"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(nestedHtml, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toEqual([]);
-        });
-
-        it("should handle XSS attempts - script tags", () => {
-            const xss = "<script>alert(\"xss\")</script>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["a", "p"],
-                FORBID_TAGS: ["script"]
-            };
-
-            const result = DOMPurify.sanitize(xss, strictConfig);
-
-            // DOMPurify removes script tags completely
-            expect(result).not.toContain("<script>");
-            expect(result).not.toContain("alert");
-        });
-
-        it("should handle XSS attempts - img with onerror", () => {
-            const xss = "<img src=x onerror=\"alert('xss')\">";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["a", "p"],
-                FORBID_TAGS: ["img"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(xss, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toContain("img");
-        });
-
-        it("should handle XSS attempts - javascript URL", () => {
-            const xss = "<a href=\"javascript:alert('xss')\">Click</a>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["a"],
-                ALLOWED_ATTR: ["href"],
-                ALLOWED_URI_REGEXP: /^https?:/i
-            };
-
-            const result = DOMPurify.sanitize(xss, strictConfig);
-
-            // DOMPurify removes javascript: URLs
-            expect(result).not.toContain("javascript:");
-        });
-
-        it("should handle XSS attempts - iframe", () => {
-            const xss = "<iframe src=\"http://evil.com\"></iframe>";
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["a", "p"],
-                FORBID_TAGS: ["iframe"]
-            };
-
-            const removedTags: string[] = [];
-
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
-
-            DOMPurify.sanitize(xss, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
-
-            expect(removedTags).toContain("iframe");
-        });
-    });
-
-    describe("Existing sanitization preservation", () => {
-        it("should continue blocking script tags with existing config", () => {
-            const htmlWithScript = "<p>Hello <script>alert(\"xss\")</script> world</p>";
-
-            const existingConfig = {
-                FORBID_TAGS: ["form", "button", "script", "div", "input"],
-                FORBID_ATTR: ["action"],
-                ADD_ATTR: ["target"]
-            };
-
-            const result = DOMPurify.sanitize(htmlWithScript, existingConfig);
-
+    describe("renderMarkdown function", () => {
+        it("should sanitize HTML and return sanitized text", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            const htmlWithScript = "Hello <script>alert('xss')</script> world";
+            const result = renderMarkdown(htmlWithScript);
+
+            // Existing sanitization should block script tags
             expect(result).not.toContain("<script>");
             expect(result).not.toContain("alert");
             expect(result).toContain("Hello");
             expect(result).toContain("world");
         });
 
-        it("should continue blocking form tags with existing config", () => {
-            const htmlWithForm = "<p>Test</p><form><input type=\"text\" /></form>";
+        it("should sanitize forbidden tags from existing config", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            const existingConfig = {
-                FORBID_TAGS: ["form", "button", "script", "div", "input"],
-                FORBID_ATTR: ["action"]
-            };
+            const htmlWithDiv = "Hello <div>test</div> world";
+            const result = renderMarkdown(htmlWithDiv);
 
-            const result = DOMPurify.sanitize(htmlWithForm, existingConfig);
-
-            expect(result).not.toContain("<form>");
-            expect(result).not.toContain("<input>");
-            expect(result).toContain("Test");
-        });
-
-        it("should continue blocking div tags with existing config", () => {
-            const htmlWithDiv = "<div><p>Hello world</p></div>";
-
-            const existingConfig = {
-                FORBID_TAGS: ["form", "button", "script", "div", "input"]
-            };
-
-            const result = DOMPurify.sanitize(htmlWithDiv, existingConfig);
-
+            // Existing config forbids div tags
             expect(result).not.toContain("<div>");
-            expect(result).toContain("<p>");
-            expect(result).toContain("Hello world");
         });
 
-        it("should continue allowing img tags with existing config (but monitor would flag it)", () => {
-            const htmlWithImg = "<p>Hello <img src=\"test.jpg\" /> world</p>";
+        it("should allow safe HTML tags through existing sanitization", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            const existingConfig = {
-                FORBID_TAGS: ["form", "button", "script", "div", "input"]
-            };
+            const htmlWithAllowed = "Hello <p><b>bold</b> <i>italic</i></p>";
+            const result = renderMarkdown(htmlWithAllowed);
 
-            const result = DOMPurify.sanitize(htmlWithImg, existingConfig);
+            // These tags are allowed by existing config
+            // Note: target="_blank" is added by ADD_ATTR config
+            expect(result).toContain("bold");
+            expect(result).toContain("italic");
+            expect(result).toContain("<b");
+            expect(result).toContain("<i");
+        });
 
-            // Existing config allows img (not in FORBID_TAGS)
+        it("should schedule monitoring via requestIdleCallback", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            renderMarkdown("Hello <img src='test.jpg' /> world");
+
+            // Should call requestIdleCallback to schedule monitoring
+            expect(requestIdleCallbackSpy).toHaveBeenCalled();
+        });
+
+        it("should fallback to setTimeout when requestIdleCallback is not available", () => {
+            // Remove requestIdleCallback
+            requestIdleCallbackSpy.mockRestore();
+            delete (window as any).requestIdleCallback;
+
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            renderMarkdown("Hello world");
+
+            // Should fallback to setTimeout
+            expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+        });
+
+        it("should not modify the returned text (monitor-only)", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            // HTML with img tag (allowed by existing config, but monitored by strict config)
+            const htmlWithImg = "<p>Hello <img src='test.jpg' /> world</p>";
+            const result = renderMarkdown(htmlWithImg);
+
+            // Existing config allows img through
             expect(result).toContain("<img");
-
-            // But strict config would remove it
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"],
-                FORBID_TAGS: ["img"]
-            };
-
-            const strictResult = DOMPurify.sanitize(htmlWithImg, strictConfig);
-            expect(strictResult).not.toContain("<img");
         });
     });
 
-    describe("Hook management", () => {
-        it("should remove hooks after monitoring", () => {
-            // Add a hook with empty implementation
-            DOMPurify.addHook("uponSanitizeElement", () => { /* empty hook for testing */ });
+    describe("Telemetry logging for strict monitoring", () => {
+        it("should log telemetry when img tag would be removed by strict allowlist", (done) => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            // Simulate monitor adding and removing hooks
-            DOMPurify.removeHook("uponSanitizeElement");
+            renderMarkdown("<p>Hello <img src='test.jpg' /> world</p>");
 
-            // Verify hooks can be added again (no conflicts)
-            const hookAdded = () => {
-                DOMPurify.addHook("uponSanitizeElement", () => { /* empty hook for testing */ });
-            };
-
-            expect(hookAdded).not.toThrow();
-
-            // Cleanup
-            DOMPurify.removeHook("uponSanitizeElement");
+            // Wait for async monitoring to complete
+            setTimeout(() => {
+                expect(logActionEventSpy).toHaveBeenCalledWith(
+                    LogLevel.INFO,
+                    expect.objectContaining({
+                        Event: TelemetryEvent.HTMLSanitized,
+                        Description: "HTML content would be sanitized by stricter allowlist (monitor-only)",
+                        CustomProperties: expect.objectContaining({
+                            OrganizationId: "test-org-123",
+                            ConversationId: "test-chat-456",
+                            RemovedTags: expect.stringContaining("img"),
+                            Phase: "Monitor"
+                        })
+                    })
+                );
+                done();
+            }, 100);
         });
 
-        it("should not interfere with other hooks", () => {
-            let otherHookCalled = false;
+        it("should log telemetry when div and span tags would be removed", (done) => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            // Add a different hook (simulating postDomPurifyActivities)
-            DOMPurify.addHook("afterSanitizeAttributes", () => {
-                otherHookCalled = true;
-            });
+            // div is blocked by existing config, but span is allowed
+            renderMarkdown("<p>Hello <span style='color:red'>test</span></p>");
 
-            // Add and remove monitor hooks with empty implementation
-            DOMPurify.addHook("uponSanitizeElement", () => { /* empty hook for testing */ });
-            DOMPurify.removeHook("uponSanitizeElement");
+            setTimeout(() => {
+                expect(logActionEventSpy).toHaveBeenCalled();
+                const call = logActionEventSpy.mock.calls[0];
+                expect(call[1].CustomProperties.RemovedTags).toContain("span");
+                expect(call[1].CustomProperties.RemovedAttributes).toContain("style");
+                done();
+            }, 100);
+        });
 
-            // Run sanitization
-            DOMPurify.sanitize("<p>Test</p>", {});
+        it("should NOT log telemetry for allowed tags", (done) => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            // Other hook should still work
-            expect(otherHookCalled).toBe(true);
+            renderMarkdown("<p>Hello <b>bold</b> <i>italic</i></p>");
 
-            // Cleanup
-            DOMPurify.removeHook("afterSanitizeAttributes");
+            setTimeout(() => {
+                // Should not log telemetry for safe HTML
+                expect(logActionEventSpy).not.toHaveBeenCalled();
+                done();
+            }, 100);
+        });
+
+        it("should include execution time in telemetry", (done) => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            renderMarkdown("<p><img src='test.jpg' /></p>");
+
+            setTimeout(() => {
+                expect(logActionEventSpy).toHaveBeenCalled();
+                const call = logActionEventSpy.mock.calls[0];
+                expect(call[1].ElapsedTimeInMilliseconds).toBeGreaterThanOrEqual(0);
+                expect(typeof call[1].ElapsedTimeInMilliseconds).toBe("number");
+                done();
+            }, 100);
+        });
+
+        it("should use 'unknown' fallback for missing orgId", (done) => {
+            // State without orgId
+            const stateWithoutOrgId = {
+                domainStates: {
+                    chatToken: {
+                        chatId: "test-chat-456"
+                    },
+                    liveChatConfig: {
+                        ChatWidgetLanguage: {
+                            msdyn_localeid: 1033
+                        }
+                    }
+                }
+            };
+
+            const webChatProps = initWebChatComposer(mockProps, stateWithoutOrgId, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            renderMarkdown("<p><img src='test.jpg' /></p>");
+
+            setTimeout(() => {
+                expect(logActionEventSpy).toHaveBeenCalled();
+                const call = logActionEventSpy.mock.calls[0];
+                expect(call[1].CustomProperties.OrganizationId).toBe("unknown");
+                done();
+            }, 100);
         });
     });
 
-    describe("Performance monitoring", () => {
-        it("should track execution time in telemetry", (done) => {
-            const htmlWithUnsafeTags = "<p>Hello <img src=\"test.jpg\" /> <div>world</div></p>";
-
-            // Simulate the monitor function call (inline to verify timing)
-            const startTime = performance.now();
-
-            const strictConfig = {
-                ALLOWED_TAGS: ["b", "strong", "i", "em", "u", "br", "p", "ul", "ol", "li", "a"],
-                FORBID_TAGS: ["img", "div"]
-            };
-
-            const removedTags: string[] = [];
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
+    describe("Error handling", () => {
+        it("should not break message flow if monitoring throws an error", () => {
+            // Force monitoring to throw an error
+            logActionEventSpy.mockImplementation(() => {
+                throw new Error("Telemetry error");
             });
 
-            DOMPurify.sanitize(htmlWithUnsafeTags, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            const endTime = performance.now();
-            const executionTimeMs = Math.round((endTime - startTime) * 100) / 100;
-
-            // Verify execution time is a positive number
-            expect(executionTimeMs).toBeGreaterThanOrEqual(0);
-            expect(typeof executionTimeMs).toBe("number");
-            expect(isNaN(executionTimeMs)).toBe(false);
-
-            done();
+            // Should not throw - error should be caught
+            expect(() => {
+                const result = renderMarkdown("<p>Hello <img src='test.jpg' /></p>");
+                expect(result).toBeDefined();
+                expect(result).toContain("Hello");
+            }).not.toThrow();
         });
 
-        it("should include execution time in telemetry when unsafe content is detected", () => {
-            const htmlWithImg = "<p>Test <img src=\"test.jpg\" /></p>";
+        it("should handle empty HTML gracefully", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            const strictConfig = {
-                ALLOWED_TAGS: ["p"],
-                FORBID_TAGS: ["img"]
-            };
+            const result = renderMarkdown("");
+            expect(result).toBeDefined();
+        });
 
-            const startTime = performance.now();
-            const removedTags: string[] = [];
+        it("should handle plain text without HTML", (done) => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                const tagName = data.tagName.toLowerCase();
-                if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                    removedTags.push(tagName);
-                }
-            });
+            renderMarkdown("Plain text message");
 
-            DOMPurify.sanitize(htmlWithImg, strictConfig);
-            DOMPurify.removeHook("uponSanitizeElement");
+            setTimeout(() => {
+                // Should not log telemetry for plain text
+                expect(logActionEventSpy).not.toHaveBeenCalled();
+                done();
+            }, 100);
+        });
+    });
 
-            const endTime = performance.now();
-            const executionTimeMs = Math.round((endTime - startTime) * 100) / 100;
+    describe("XSS Prevention", () => {
+        it("should block javascript: URLs", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
 
-            // Verify timing is captured
-            expect(removedTags.length).toBeGreaterThan(0);
-            expect(executionTimeMs).toBeGreaterThanOrEqual(0);
+            const xss = "<a href=\"javascript:alert('xss')\">Click</a>";
+            const result = renderMarkdown(xss);
+
+            expect(result).not.toContain("javascript:");
+        });
+
+        it("should block event handlers", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            const xss = "<p onclick=\"alert('xss')\">Click me</p>";
+            const result = renderMarkdown(xss);
+
+            expect(result).not.toContain("onclick");
+        });
+
+        it("should block iframe tags", () => {
+            const webChatProps = initWebChatComposer(mockProps, mockState, mockDispatch, mockFacadeChatSDK, mockEndChat);
+            const renderMarkdown = webChatProps.renderMarkdown;
+
+            const xss = "<iframe src=\"http://evil.com\"></iframe>";
+            const result = renderMarkdown(xss);
+
+            expect(result).not.toContain("<iframe");
         });
     });
 });

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -7,6 +7,7 @@ import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { Constants } from "../../../common/Constants";
 import { ConversationState } from "../../../contexts/common/ConversationState";
 import DOMPurify from "dompurify";
+import createDOMPurify from "dompurify";
 import { Dispatch } from "react";
 import { FacadeChatSDK } from "../../../common/facades/FacadeChatSDK";
 import HyperlinkTextOverrideRenderer from "../../webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer";
@@ -174,9 +175,11 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
 
         // MONITOR-ONLY: Test what the stricter allowlist would remove (Phase 1)
         // This does NOT modify the text, only logs telemetry
-        // Run asynchronously to avoid blocking message flow and adding latency
+        // Run during browser idle time to avoid blocking message flow and adding latency
         const textToMonitor = text; // Capture current text value
-        setTimeout(() => {
+
+        // Schedule monitoring to run during browser idle time
+        const scheduleMonitoring = () => {
             try {
                 monitorStrictSanitization(textToMonitor, state);
             } catch (error) {
@@ -185,7 +188,14 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
                     console.error("[Monitor] HTML sanitization monitoring failed:", error);
                 }
             }
-        }, 0);
+        };
+
+        // Use requestIdleCallback for truly idle execution, fallback to setTimeout for older browsers
+        if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+            window.requestIdleCallback(scheduleMonitoring);
+        } else {
+            setTimeout(scheduleMonitoring, 0);
+        }
 
         return text;
     };
@@ -198,6 +208,10 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
      * IMPORTANT: This function is wrapped in try-catch and runs asynchronously
      * to ensure failures don't block message flow or add latency.
      *
+     * ISOLATION: Uses a separate DOMPurify instance to completely isolate
+     * monitoring hooks from other sanitization paths (e.g., postDomPurifyActivities).
+     * The instance is garbage collected after use, no cleanup needed.
+     *
      * @param html - The HTML text that was already sanitized with existing config
      * @param state - Widget state containing orgId and chatId
      */
@@ -209,6 +223,10 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
         const startTime = performance.now();
 
         try {
+            // Create a separate DOMPurify instance for monitoring
+            // This completely isolates monitoring from other sanitization paths
+            const monitorDOMPurify = createDOMPurify(window);
+
             // Strict allowlist configuration (proposed new rules)
             const strictConfig = {
                 ALLOWED_TAGS: [
@@ -244,43 +262,33 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
             const removedTags: string[] = [];
             const removedAttributes: string[] = [];
 
-            try {
-                // Temporarily add hooks for tracking
-                DOMPurify.addHook("uponSanitizeElement", (node, data) => {
-                    try {
-                        const tagName = data.tagName.toLowerCase();
-                        // Filter out "body" tag which is DOMPurify's internal wrapper
-                        if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
-                            removedTags.push(tagName);
-                        }
-                    } catch (hookError) {
-                        // Silently ignore hook errors
-                    }
-                });
-
-                DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
-                    try {
-                        const attrName = data.attrName.toLowerCase();
-                        if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
-                            removedAttributes.push(attrName);
-                        }
-                    } catch (hookError) {
-                        // Silently ignore hook errors
-                    }
-                });
-
-                // Run sanitization to see what would be removed (we discard the result)
-                DOMPurify.sanitize(html, strictConfig);
-
-            } finally {
-                // Always clean up hooks, even if sanitization fails
+            // Add hooks to the isolated monitoring instance
+            monitorDOMPurify.addHook("uponSanitizeElement", (node, data) => {
                 try {
-                    DOMPurify.removeHook("uponSanitizeElement");
-                    DOMPurify.removeHook("uponSanitizeAttribute");
-                } catch (cleanupError) {
-                    // Silently ignore cleanup errors
+                    const tagName = data.tagName.toLowerCase();
+                    // Filter out "body" tag which is DOMPurify's internal wrapper
+                    if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                        removedTags.push(tagName);
+                    }
+                } catch (hookError) {
+                    // Silently ignore hook errors
                 }
-            }
+            });
+
+            monitorDOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
+                try {
+                    const attrName = data.attrName.toLowerCase();
+                    if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
+                        removedAttributes.push(attrName);
+                    }
+                } catch (hookError) {
+                    // Silently ignore hook errors
+                }
+            });
+
+            // Run sanitization on the isolated instance (we discard the result)
+            // No cleanup needed - the instance will be garbage collected with its hooks
+            monitorDOMPurify.sanitize(html, strictConfig);
 
             // Log telemetry if content would be affected by strict rules
             if (removedTags.length > 0 || removedAttributes.length > 0) {

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -251,7 +251,8 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
                     "div", "span"                               // Layout elements
                 ],
                 FORBID_ATTR: [
-                    "style"         // Inline CSS (event handlers blocked by default)
+                    "style",        // Inline CSS
+                    "action"        // Form action attribute (event handlers blocked by default)
                 ],
                 ALLOWED_URI_REGEXP: /^https?:/i,
                 ALLOW_DATA_ATTR: false,

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -191,7 +191,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
         };
 
         // Use requestIdleCallback for truly idle execution, fallback to setTimeout for older browsers
-        if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+        if (typeof window !== "undefined" && "requestIdleCallback" in window) {
             window.requestIdleCallback(scheduleMonitoring);
         } else {
             setTimeout(scheduleMonitoring, 0);
@@ -228,6 +228,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
             const monitorDOMPurify = createDOMPurify(window);
 
             // Strict allowlist configuration (proposed new rules)
+            // Note: DOMPurify blocks event handlers (onclick, onerror, etc.) by default
             const strictConfig = {
                 ALLOWED_TAGS: [
                     "b", "strong",      // Bold text
@@ -250,8 +251,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
                     "div", "span"                               // Layout elements
                 ],
                 FORBID_ATTR: [
-                    "style",        // Inline CSS
-                    /^on/i          // Event handlers (onclick, onerror, etc.)
+                    "style"         // Inline CSS (event handlers blocked by default)
                 ],
                 ALLOWED_URI_REGEXP: /^https?:/i,
                 ALLOW_DATA_ATTR: false,
@@ -307,12 +307,14 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
                     TelemetryHelper.logActionEvent(LogLevel.INFO, {
                         Event: TelemetryEvent.HTMLSanitized,
                         Description: "HTML content would be sanitized by stricter allowlist (monitor-only)",
-                        OrganizationId: orgId,
-                        ConversationId: conversationId,
-                        RemovedTags: uniqueTags.join(", "),
-                        RemovedAttributes: uniqueAttrs.join(", "),
-                        Phase: "Monitor",
-                        ExecutionTimeMs: executionTimeMs.toString()
+                        ElapsedTimeInMilliseconds: executionTimeMs,
+                        CustomProperties: {
+                            OrganizationId: orgId,
+                            ConversationId: conversationId,
+                            RemovedTags: uniqueTags.join(", "),
+                            RemovedAttributes: uniqueAttrs.join(", "),
+                            Phase: "Monitor"
+                        }
                     });
 
                     // Log to console in development for debugging

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -164,13 +164,173 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
             text = renderer.render(text);
         });
 
+        // EXISTING sanitization (continues to work as before)
         const config = {
             FORBID_TAGS: ["form", "button", "script", "div", "input"],
             FORBID_ATTR: ["action"],
             ADD_ATTR: ["target"]
         };
         text = DOMPurify.sanitize(text, config);
+
+        // MONITOR-ONLY: Test what the stricter allowlist would remove (Phase 1)
+        // This does NOT modify the text, only logs telemetry
+        // Run asynchronously to avoid blocking message flow and adding latency
+        const textToMonitor = text; // Capture current text value
+        setTimeout(() => {
+            try {
+                monitorStrictSanitization(textToMonitor, state);
+            } catch (error) {
+                // Silently catch errors to prevent blocking message flow
+                if (process.env.NODE_ENV === "development") {
+                    console.error("[Monitor] HTML sanitization monitoring failed:", error);
+                }
+            }
+        }, 0);
+
         return text;
+    };
+
+    /**
+     * Monitor-only sanitization (Phase 1: Gather telemetry)
+     * Tests what a stricter allowlist-based sanitization would remove
+     * WITHOUT actually removing it. Logs telemetry for analysis.
+     *
+     * IMPORTANT: This function is wrapped in try-catch and runs asynchronously
+     * to ensure failures don't block message flow or add latency.
+     *
+     * @param html - The HTML text that was already sanitized with existing config
+     * @param state - Widget state containing orgId and chatId
+     */
+    const monitorStrictSanitization = (html: string, state: ILiveChatWidgetContext): void => {
+        // Early exit for empty content
+        if (!html) return;
+
+        // Track execution time for performance monitoring
+        const startTime = performance.now();
+
+        try {
+            // Strict allowlist configuration (proposed new rules)
+            const strictConfig = {
+                ALLOWED_TAGS: [
+                    "b", "strong",      // Bold text
+                    "i", "em", "u",     // Italic, emphasis, underline
+                    "br", "p",          // Line breaks and paragraphs
+                    "ul", "ol", "li",   // Lists
+                    "a"                 // Links (with restricted attributes)
+                ],
+                ALLOWED_ATTR: [
+                    "href",    // For links (will be restricted to http/https)
+                    "target",  // For link behavior
+                    "rel"      // For security (noopener, noreferrer)
+                ],
+                FORBID_TAGS: [
+                    "img", "video", "audio",                    // Media (tracking beacons)
+                    "iframe", "object", "embed",                // Embedded content
+                    "script", "style",                          // Script and styling
+                    "form", "input", "textarea", "button",      // Form elements
+                    "link", "meta", "base",                     // Document metadata
+                    "div", "span"                               // Layout elements
+                ],
+                FORBID_ATTR: [
+                    "style",        // Inline CSS
+                    /^on/i          // Event handlers (onclick, onerror, etc.)
+                ],
+                ALLOWED_URI_REGEXP: /^https?:/i,
+                ALLOW_DATA_ATTR: false,
+                ALLOW_UNKNOWN_PROTOCOLS: false
+            };
+
+            // Track what would be removed
+            const removedTags: string[] = [];
+            const removedAttributes: string[] = [];
+
+            try {
+                // Temporarily add hooks for tracking
+                DOMPurify.addHook("uponSanitizeElement", (node, data) => {
+                    try {
+                        const tagName = data.tagName.toLowerCase();
+                        // Filter out "body" tag which is DOMPurify's internal wrapper
+                        if (node.nodeType === 1 && !strictConfig.ALLOWED_TAGS.includes(tagName) && tagName !== "body") {
+                            removedTags.push(tagName);
+                        }
+                    } catch (hookError) {
+                        // Silently ignore hook errors
+                    }
+                });
+
+                DOMPurify.addHook("uponSanitizeAttribute", (node, data) => {
+                    try {
+                        const attrName = data.attrName.toLowerCase();
+                        if (!strictConfig.ALLOWED_ATTR.includes(attrName) && attrName !== "class" && attrName !== "id") {
+                            removedAttributes.push(attrName);
+                        }
+                    } catch (hookError) {
+                        // Silently ignore hook errors
+                    }
+                });
+
+                // Run sanitization to see what would be removed (we discard the result)
+                DOMPurify.sanitize(html, strictConfig);
+
+            } finally {
+                // Always clean up hooks, even if sanitization fails
+                try {
+                    DOMPurify.removeHook("uponSanitizeElement");
+                    DOMPurify.removeHook("uponSanitizeAttribute");
+                } catch (cleanupError) {
+                    // Silently ignore cleanup errors
+                }
+            }
+
+            // Log telemetry if content would be affected by strict rules
+            if (removedTags.length > 0 || removedAttributes.length > 0) {
+                try {
+                    const uniqueTags = [...new Set(removedTags)];
+                    const uniqueAttrs = [...new Set(removedAttributes)];
+
+                    // Calculate execution time
+                    const endTime = performance.now();
+                    const executionTimeMs = Math.round((endTime - startTime) * 100) / 100; // Round to 2 decimal places
+
+                    // Get context for telemetry (with safe fallbacks)
+                    const orgId = state?.domainStates?.telemetryInternalData?.orgId || "unknown";
+                    const conversationId = state?.domainStates?.chatToken?.chatId || "unknown";
+
+                    TelemetryHelper.logActionEvent(LogLevel.INFO, {
+                        Event: TelemetryEvent.HTMLSanitized,
+                        Description: "HTML content would be sanitized by stricter allowlist (monitor-only)",
+                        OrganizationId: orgId,
+                        ConversationId: conversationId,
+                        RemovedTags: uniqueTags.join(", "),
+                        RemovedAttributes: uniqueAttrs.join(", "),
+                        Phase: "Monitor",
+                        ExecutionTimeMs: executionTimeMs.toString()
+                    });
+
+                    // Log to console in development for debugging
+                    if (process.env.NODE_ENV === "development") {
+                        console.warn("[Monitor] Stricter HTML sanitization would remove:", {
+                            orgId,
+                            conversationId,
+                            removedTags: uniqueTags,
+                            removedAttributes: uniqueAttrs,
+                            executionTimeMs
+                        });
+                    }
+                } catch (telemetryError) {
+                    // Silently ignore telemetry errors to prevent blocking
+                    if (process.env.NODE_ENV === "development") {
+                        console.error("[Monitor] Telemetry logging failed:", telemetryError);
+                    }
+                }
+            }
+        } catch (error) {
+            // Catch-all for any unexpected errors
+            // Silently fail to ensure monitoring never blocks message flow
+            if (process.env.NODE_ENV === "development") {
+                console.error("[Monitor] Monitoring failed:", error);
+            }
+        }
     };
 
     function postDomPurifyActivities() {

--- a/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
+++ b/chat-widget/src/components/livechatwidget/common/initWebChatComposer.ts
@@ -7,7 +7,6 @@ import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { Constants } from "../../../common/Constants";
 import { ConversationState } from "../../../contexts/common/ConversationState";
 import DOMPurify from "dompurify";
-import createDOMPurify from "dompurify";
 import { Dispatch } from "react";
 import { FacadeChatSDK } from "../../../common/facades/FacadeChatSDK";
 import HyperlinkTextOverrideRenderer from "../../webchatcontainerstateful/webchatcontroller/markdownrenderers/HyperlinkTextOverrideRenderer";
@@ -225,7 +224,7 @@ export const initWebChatComposer = (props: ILiveChatWidgetProps, state: ILiveCha
         try {
             // Create a separate DOMPurify instance for monitoring
             // This completely isolates monitoring from other sanitization paths
-            const monitorDOMPurify = createDOMPurify(window);
+            const monitorDOMPurify = DOMPurify(window);
 
             // Strict allowlist configuration (proposed new rules)
             // Note: DOMPurify blocks event handlers (onclick, onerror, etc.) by default

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/activityMiddleware.tsx
@@ -60,6 +60,8 @@ const handleSystemMessage = (next: any, args: any[], card: any, renderMarkdown: 
         originalSystemMessageTexts.set(activityKey, card.activity.text);
     }
     const sourceText = (activityKey && originalSystemMessageTexts.get(activityKey)) ?? card.activity.text;
+    // renderMarkdown sanitizes the HTML using DOMPurify with allowlist-based configuration
+    // See initWebChatComposer.ts for sanitization details
     const renderedHtml = renderMarkdown(sourceText);
     // eslint-disable-next-line react/display-name
     return () => (


### PR DESCRIPTION
Implements Phase 1 of HTML sanitization rollout strategy: monitor what stricter allowlist-based rules would remove WITHOUT actually blocking content.

Key Changes:
- Added monitorStrictSanitization() to track content that would be blocked
- Logs telemetry with OrganizationId, ConversationId, RemovedTags, ExecutionTimeMs
- Runs asynchronously (setTimeout) to avoid adding latency to message flow
- Comprehensive error handling to prevent monitoring from blocking messages
- Added 27 unit tests (all passing) for monitoring logic

Technical Details:
- Existing sanitization unchanged (FORBID_TAGS: form, button, script, div, input)
- New monitoring tests against strict allowlist (ALLOWED_TAGS: b, strong, i, em, u, br, p, ul, ol, li, a)
- Tracks img, video, iframe, style attributes, event handlers that would be removed
- No package.json changes (uses existing dompurify@3.2.4 from chat-widget)

Next Steps:
- Analyze telemetry to identify customers using unsafe HTML
- Phase 2: Customer notification and migration support
- Phase 3: Enforce strict allowlist after validation

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__