### PR TITLE
[Draft]feat(sendbox): add enterToNewLine prop to invert Enter/Shift+Enter behavior

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Added `enterToNewLine` prop to `sendBoxTextBox` in `webChatContainerProps`. When `true`, pressing **Enter** inserts a new line and **Shift+Enter** sends the message (inverts the default WebChat behavior). Requires `sendBoxTextWrap: true` in `webChatStyles`. Opt-in; default behavior unchanged.
+
 ### Fixed
 - [A11y] Fixed focus trap for single-focusable-element case — Tab/Shift+Tab no longer escapes the widget when only the chat button is present
 - [A11y] Bot message avatar alt text now uses the full agent name instead of initials for screen readers

--- a/chat-widget/src/components/livechatwidget/interfaces/ISendBox.ts
+++ b/chat-widget/src/components/livechatwidget/interfaces/ISendBox.ts
@@ -8,5 +8,11 @@ export interface ISendBox {
          * Hebrew, etc) will show a scrollbar in the textarea element when placeholder is visible
          */
         minHeight?: string;
-    }
+    };
+    /**
+     * When true, pressing Enter inserts a new line and Shift+Enter sends the message.
+     * Default WebChat behavior is Enter to send and Shift+Enter to insert a new line.
+     * Only effective when sendBoxTextWrap is true in webChatStyles.
+     */
+    enterToNewLine?: boolean;
 }

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -31,6 +31,7 @@ import { defaultWebChatContainerStatefulProps } from "./common/defaultProps/defa
 import { shouldLoadPersistentChatHistory } from "../livechatwidget/common/liveChatConfigUtils";
 import { useChatContextStore } from "../..";
 import useFacadeSDKStore from "../../hooks/useFacadeChatSDKStore";
+import useEnterToNewLine from "./hooks/useEnterToNewLine";
 import usePersistentChatHistory from "./hooks/usePersistentChatHistory";
 
 let uiTimer: ITimer;
@@ -266,6 +267,8 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
             ElapsedTimeInMilliseconds: uiTimer.milliSecondsElapsed
         });
     }, []);
+
+    useEnterToNewLine(props.webChatContainerProps?.sendBoxTextBox?.enterToNewLine);
 
     // Set focus to the sendbox
     useEffect(() => {

--- a/chat-widget/src/components/webchatcontainerstateful/hooks/useEnterToNewLine.test.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/hooks/useEnterToNewLine.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from "@testing-library/react";
+import useEnterToNewLine from "./useEnterToNewLine";
+
+const makeSendBoxInput = (): HTMLTextAreaElement => {
+    const input = document.createElement("textarea");
+    input.setAttribute("data-id", "webchat-sendbox-input");
+    document.body.appendChild(input);
+    return input;
+};
+
+describe("useEnterToNewLine", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("does not stop Enter propagation when disabled", () => {
+        renderHook(() => useEnterToNewLine(false));
+        const input = makeSendBoxInput();
+
+        const event = new KeyboardEvent("keypress", { key: "Enter", bubbles: true, cancelable: true });
+        const stopSpy = jest.spyOn(event, "stopPropagation");
+        input.dispatchEvent(event);
+
+        expect(stopSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not stop Enter propagation when undefined", () => {
+        renderHook(() => useEnterToNewLine(undefined));
+        const input = makeSendBoxInput();
+
+        const event = new KeyboardEvent("keypress", { key: "Enter", bubbles: true, cancelable: true });
+        const stopSpy = jest.spyOn(event, "stopPropagation");
+        input.dispatchEvent(event);
+
+        expect(stopSpy).not.toHaveBeenCalled();
+    });
+
+    it("stops Enter propagation to prevent submit when enabled", () => {
+        renderHook(() => useEnterToNewLine(true));
+        const input = makeSendBoxInput();
+
+        const event = new KeyboardEvent("keypress", { key: "Enter", bubbles: true, cancelable: true });
+        const stopSpy = jest.spyOn(event, "stopPropagation");
+        input.dispatchEvent(event);
+
+        expect(stopSpy).toHaveBeenCalled();
+    });
+
+    it("prevents default on Shift+Enter and dispatches form submit when enabled", () => {
+        renderHook(() => useEnterToNewLine(true));
+
+        const form = document.createElement("form");
+        const input = document.createElement("textarea");
+        input.setAttribute("data-id", "webchat-sendbox-input");
+        form.appendChild(input);
+        document.body.appendChild(form);
+
+        const submitHandler = jest.fn();
+        form.addEventListener("submit", submitHandler);
+
+        const event = new KeyboardEvent("keypress", {
+            key: "Enter",
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true
+        });
+        const preventSpy = jest.spyOn(event, "preventDefault");
+        input.dispatchEvent(event);
+
+        expect(preventSpy).toHaveBeenCalled();
+        expect(submitHandler).toHaveBeenCalled();
+    });
+
+    it("ignores non-Enter keys", () => {
+        renderHook(() => useEnterToNewLine(true));
+        const input = makeSendBoxInput();
+
+        const event = new KeyboardEvent("keypress", { key: "a", bubbles: true, cancelable: true });
+        const stopSpy = jest.spyOn(event, "stopPropagation");
+        const preventSpy = jest.spyOn(event, "preventDefault");
+        input.dispatchEvent(event);
+
+        expect(stopSpy).not.toHaveBeenCalled();
+        expect(preventSpy).not.toHaveBeenCalled();
+    });
+
+    it("ignores keypress events outside the send box", () => {
+        renderHook(() => useEnterToNewLine(true));
+
+        const other = document.createElement("input");
+        document.body.appendChild(other);
+
+        const event = new KeyboardEvent("keypress", { key: "Enter", bubbles: true, cancelable: true });
+        const stopSpy = jest.spyOn(event, "stopPropagation");
+        other.dispatchEvent(event);
+
+        expect(stopSpy).not.toHaveBeenCalled();
+    });
+
+    it("removes listener on unmount", () => {
+        const { unmount } = renderHook(() => useEnterToNewLine(true));
+        const input = makeSendBoxInput();
+        unmount();
+
+        const event = new KeyboardEvent("keypress", { key: "Enter", bubbles: true, cancelable: true });
+        const stopSpy = jest.spyOn(event, "stopPropagation");
+        input.dispatchEvent(event);
+
+        expect(stopSpy).not.toHaveBeenCalled();
+    });
+});

--- a/chat-widget/src/components/webchatcontainerstateful/hooks/useEnterToNewLine.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/hooks/useEnterToNewLine.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+
+const useEnterToNewLine = (enabled: boolean | undefined) => {
+    useEffect(() => {
+        if (!enabled) return;
+
+        const handleKeyPress = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement;
+            if (!target.closest("[data-id=\"webchat-sendbox-input\"]")) return;
+            if (event.key !== "Enter") return;
+
+            if (!event.shiftKey) {
+                event.stopPropagation();
+            } else {
+                event.preventDefault();
+                const form = target.closest("form");
+                form?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+            }
+        };
+
+        document.addEventListener("keypress", handleKeyPress, true);
+        return () => document.removeEventListener("keypress", handleKeyPress, true);
+    }, [enabled]);
+};
+
+export default useEnterToNewLine;


### PR DESCRIPTION


When sendBoxTextBox.enterToNewLine is true, pressing Enter inserts a new line and Shift+Enter sends the message — the inverse of the default WebChat behavior. Implemented via a capture-phase keypress listener that intercepts events before botframework-webchat's submit handler fires.

Requires webChatStyles.sendBoxTextWrap: true to render the send box as a multi-line textarea. Opt-in only — default behavior unchanged.

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
<img width="1342" height="715" alt="Screenshot 2026-04-20 at 10 27 21 PM" src="https://github.com/user-attachments/assets/458b64ad-60d7-420a-915a-dfce26b05eec" />
<img width="1232" height="728" alt="Screenshot 2026-04-20 at 10 40 00 PM" src="https://github.com/user-attachments/assets/1a11dc40-bb83-4082-be8a-61947a4cfd5b" />

_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__