### PR TITLE
fix(a11y): announce file sent via screen reader on Android TalkBack

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - [A11y] Fixed focus trap for single-focusable-element case — Tab/Shift+Tab no longer escapes the widget when only the chat button is present
 - [A11y] Bot message avatar alt text now uses the full agent name instead of initials for screen readers
-- [A11y] Screen reader now announces "File sent" when an attachment upload completes via an aria-live region
+- [A11y] Screen reader now announces "File sent successfully." when an attachment upload completes; uses append-and-remove assertive aria-live pattern for reliable announcement on Android TalkBack/WebView. Announcement text is customizable via `MIDDLEWARE_BANNER_FILE_SENT`.
 - [A11y] Adaptive card radio button groups now include aria-setsize and aria-posinset attributes for correct option count announcement
 
 ### Added

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -180,6 +180,7 @@ export const Regex = class {
 
 export class HtmlIdNames {
     public static readonly MSLiveChatWidget = "MSLiveChatWidget";
+    public static readonly fileSentAnnouncementRegionId = "ms_lcw_file_sent_announcement";
 }
 
 export class HtmlClassNames {

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -1,4 +1,4 @@
-import { Constants, HtmlAttributeNames, HtmlClassNames } from "../../common/Constants";
+import { Constants, HtmlAttributeNames, HtmlClassNames, HtmlIdNames } from "../../common/Constants";
 import { IRawStyle, IStackStyles, Stack } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect, useRef, useState } from "react";
@@ -449,6 +449,26 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
                     <BasicWebChat></BasicWebChat>
                 </div>
             </Stack>
+            {/* Visually hidden alert region for screen reader announcements (e.g. file sent).
+                role="alert" + aria-live="assertive" guarantees TalkBack announces even when
+                focus shifts to the send box immediately after the file is sent. */}
+            <div
+                id={HtmlIdNames.fileSentAnnouncementRegionId}
+                role="alert"
+                aria-live="assertive"
+                aria-atomic="true"
+                style={{
+                    position: "absolute",
+                    width: "1px",
+                    height: "1px",
+                    padding: "0",
+                    margin: "-1px",
+                    overflow: "hidden",
+                    clip: "rect(0, 0, 0, 0)",
+                    whiteSpace: "nowrap",
+                    border: "0"
+                }}
+            />
             {citationPaneOpen && (
                 <CitationPaneStateful
                     id={props.citationPaneProps?.id || HtmlAttributeNames.ocwCitationPaneClassName}

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
@@ -29,6 +29,7 @@ export const defaultMiddlewareLocalizedTexts: ILiveChatWidgetLocalizedTexts = {
     MIDDLEWARE_BANNER_CHAT_DISCONNECT: "Your conversation has been disconnected. For additional assistance, please start a new chat.",
     THIRD_PARTY_COOKIES_BLOCKED_ALERT_MESSAGE: "Allow sites to save/read cookies in browser settings. Reloading page starts a new chat.",
     MIDDLEWARE_BANNER_FILE_IS_MALICIOUS: "{0} has been blocked because the file may contain a malware.",
+    MIDDLEWARE_BANNER_FILE_SENT: "File sent successfully.",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS: "Email will be sent after chat ends!",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR: "Email {0} could not be saved, try again later.",
     PREVIOUS_MESSAGES_LOADING: "Loading previous messages...",

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/storemiddlewares/attachmentUploadValidatorMiddleware.ts
@@ -6,7 +6,7 @@
 
 import { LogLevel, TelemetryEvent } from "../../../../../common/telemetry/TelemetryConstants";
 
-import { AMSConstants } from "../../../../../common/Constants";
+import { AMSConstants, HtmlIdNames } from "../../../../../common/Constants";
 import { ILiveChatWidgetLocalizedTexts } from "../../../../../contexts/common/ILiveChatWidgetLocalizedTexts";
 import { IWebChatAction } from "../../../interfaces/IWebChatAction";
 import { NotificationHandler } from "../../notification/NotificationHandler";
@@ -15,6 +15,32 @@ import { TelemetryHelper } from "../../../../../common/telemetry/TelemetryHelper
 import { WebChatActionType } from "../../enums/WebChatActionType";
 
 const MBtoBRatio = 1000000;
+
+const announceFileSent = (message: string) => {
+    // TalkBack on Android WebView reliably announces newly *appended* role="alert"
+    // nodes but often misses text-content updates on existing nodes.
+    // Strategy: clear the static region, wait 500ms for the send-box focus shift
+    // to settle, then inject a fresh alert element and remove it after 3s.
+    const region = document.getElementById(HtmlIdNames.fileSentAnnouncementRegionId);
+    if (region) {
+        region.textContent = "";
+    }
+    setTimeout(() => {
+        const el = document.createElement("div");
+        el.setAttribute("role", "alert");
+        el.setAttribute("aria-live", "assertive");
+        el.setAttribute("aria-atomic", "true");
+        el.style.cssText = "position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;";
+        el.textContent = message;
+        document.body.appendChild(el);
+        // Remove after TalkBack has had time to read it
+        setTimeout(() => {
+            if (el.parentNode) {
+                el.parentNode.removeChild(el);
+            }
+        }, 3000);
+    }, 500);
+};
 
 /*
 * If an attachment is invalid, delete this attachment from the attachments list
@@ -192,7 +218,14 @@ const createAttachmentUploadValidatorMiddleware = (allowedFileExtensions: string
 
         if (payload?.activity.attachments && payload.activity.attachments.length > 0 &&
             payload?.activity?.attachments?.length === payload?.activity?.channelData?.attachmentSizes?.length) {
-            return next(validateAttachment(action, allowedFileExtensions, maxFileSizeSupportedByDynamics, localizedTexts));
+            const validatedAction = validateAttachment(action, allowedFileExtensions, maxFileSizeSupportedByDynamics, localizedTexts);
+
+            // Announce to screen readers that the file was sent when validation passes
+            if (validatedAction.payload?.activity?.attachments?.length > 0) {
+                announceFileSent(localizedTexts.MIDDLEWARE_BANNER_FILE_SENT ?? "File sent successfully.");
+            }
+
+            return next(validatedAction);
         }
     }
     return next(action);

--- a/chat-widget/src/contexts/common/ILiveChatWidgetLocalizedTexts.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetLocalizedTexts.ts
@@ -163,6 +163,12 @@ export interface ILiveChatWidgetLocalizedTexts {
     MIDDLEWARE_BANNER_FILE_IS_MALICIOUS?: string;
 
     /**
+     * Success message announced by screen readers when a file is successfully sent.
+     * e.g. "File sent successfully."
+     */
+    MIDDLEWARE_BANNER_FILE_SENT?: string;
+
+    /**
      * Success message, indicating the email address introduced has been registered to receive the transcript.
      */
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS?: string;


### PR DESCRIPTION
TalkBack on Android WebView silently drops text-content updates to existing aria-live regions during focus transitions. Fix uses an append-and-remove assertive aria-live pattern so TalkBack reliably announces newly appended alert nodes. Announcement text is customizable via MIDDLEWARE_BANNER_FILE_SENT localized text prop.

## **Thank you for your contribution. Before submitting this PR, please include:**

### Id of the task, bug, story or other reference.

### Description
_Include a description of the problem to be solved_

## Solution Proposed
_Detail what is the solution proposed, include links to design document if required or any other document required to support the solution_

### Acceptance criteria
_Define what are the conditions to consider the PR has achieved the intended goal_

## Test cases and evidence
_Include what tests cases were considered, any evidence of testing for future references, to identify any corner cases, etc_

### Sanity Tests
-   [ ] You have tested all changes in Popout mode
-   [ ] You have tested all changes in cross browsers i.e Edge, Chrome, Firefox, Safari and mobile devices(iOS and Android)
-   [ ] Your changes are included in the [CHANGELOG](../CHANGE_LOG.md)


## A11y
- [ ] You have run the [Automated Accessibility Check](https://accessibilityinsights.io/docs/en/windows/getstarted/automatedchecks) and have no reported issues

__*Please provide justification if any of the validations has been skipped.*__