### PR TITLE
fix(a11y): announce citation cards as a single link on iOS VoiceOver / Android TalkBack

### DIFF
--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -32,6 +32,7 @@ import { shouldLoadPersistentChatHistory } from "../livechatwidget/common/liveCh
 import { useChatContextStore } from "../..";
 import useFacadeSDKStore from "../../hooks/useFacadeChatSDKStore";
 import usePersistentChatHistory from "./hooks/usePersistentChatHistory";
+import { patchCitationAnchorsForA11y } from "./common/utils/citationA11y";
 
 let uiTimer: ITimer;
 
@@ -158,6 +159,56 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
         document.addEventListener("click", clickHandler);
         return () => document.removeEventListener("click", clickHandler);
     }, [state]);
+
+    // Accessibility: Merge citation card's number badge and link text into a single
+    // focusable element. WebChat's LinkDefinitionItem renders an <a> containing a
+    // badge <div> (the number, e.g. "1") and a text <div> (the title). On iOS
+    // VoiceOver and Android TalkBack, those block-level descendants are otherwise
+    // announced as two separate focusable links. The patch sets a combined
+    // aria-label on the anchor and hides every descendant from the a11y tree so
+    // the whole card is announced as one link.
+    useEffect(() => {
+        patchCitationAnchorsForA11y(document);
+
+        const observer = new MutationObserver((mutations) => {
+            for (const m of mutations) {
+                if (m.type === "childList") {
+                    m.addedNodes.forEach((node) => {
+                        if (node.nodeType === Node.ELEMENT_NODE) {
+                            patchCitationAnchorsForA11y(node as ParentNode);
+                            // A child added inside an existing anchor (e.g. React
+                            // mounting OpenInNewWindowIcon after the anchor) means
+                            // the parent anchor needs to re-walk its descendants.
+                            const ancestor = (node as Element).parentElement?.closest?.(
+                                "a.webchat__link-definitions__list-item-box, a[href^=\"cite:\"]"
+                            );
+                            if (ancestor) {
+                                patchCitationAnchorsForA11y(ancestor);
+                            }
+                        }
+                    });
+                } else if (m.type === "attributes" && m.target.nodeType === Node.ELEMENT_NODE) {
+                    // React may strip our aria-hidden during a re-render; reapply
+                    // by re-patching the closest matching anchor ancestor.
+                    const target = m.target as Element;
+                    const ancestor = target.closest?.(
+                        "a.webchat__link-definitions__list-item-box, a[href^=\"cite:\"]"
+                    );
+                    if (ancestor) {
+                        patchCitationAnchorsForA11y(ancestor);
+                    }
+                }
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ["aria-hidden", "role", "tabindex", "inert"]
+        });
+        return () => observer.disconnect();
+    }, []);
 
     const minimizedStyles = state.appStates.isMinimized
         ? (shouldLoadPersistentHistoryMessages

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.test.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.test.ts
@@ -233,6 +233,21 @@ describe("patchCitationAnchorsForA11y", () => {
         expect(anchor.getAttribute("aria-label")).toBe("3, Title");
     });
 
+    // iOS VoiceOver in WKWebView surfaces elements with a `title` attribute
+    // as separately swipeable items even when aria-hidden="true" is set, so
+    // the patch removes title from descendants and stashes the original on
+    // a data-* attribute for non-a11y consumers.
+    it("strips title attribute from descendants and preserves it on a data-* attribute", () => {
+        const anchor = buildCitationAnchor("1", "Manage a ticket | Transport for West Midlands");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        const textEl = anchor.querySelector(".webchat__link-definitions__list-item-text") as HTMLElement;
+        expect(textEl.hasAttribute("title")).toBe(false);
+        expect(textEl.dataset.ocwOriginalTitle).toBe("Manage a ticket | Transport for West Midlands");
+    });
+
     // Repeated patching must not append additional overlay spans.
     it("does not append duplicate overlays on repeated calls", () => {
         const anchor = buildCitationAnchor("1", "Citation text");

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.test.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.test.ts
@@ -1,0 +1,248 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { patchCitationAnchorsForA11y } from "./citationA11y";
+
+const buildCitationAnchor = (identifier: string, text: string, href = "cite:1"): HTMLAnchorElement => {
+    const anchor = document.createElement("a");
+    anchor.className = "webchat__link-definitions__list-item-box webchat__link-definitions__list-item-box--as-link";
+    anchor.setAttribute("href", href);
+
+    const body = document.createElement("div");
+    body.className = "webchat__link-definitions__list-item-body";
+
+    const badge = document.createElement("div");
+    badge.className = "webchat__link-definitions__badge";
+    badge.textContent = identifier;
+
+    const mainBody = document.createElement("div");
+    mainBody.className = "webchat__link-definitions__list-item-body-main";
+
+    const mainText = document.createElement("div");
+    mainText.className = "webchat__link-definitions__list-item-main-text";
+
+    const textDiv = document.createElement("div");
+    textDiv.className = "webchat__link-definitions__list-item-text";
+    textDiv.setAttribute("title", text);
+    textDiv.textContent = text;
+
+    mainText.appendChild(textDiv);
+    mainBody.appendChild(mainText);
+    body.appendChild(badge);
+    body.appendChild(mainBody);
+    anchor.appendChild(body);
+
+    return anchor;
+};
+
+describe("patchCitationAnchorsForA11y", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("merges citation number and link text into a single accessible label", () => {
+        const anchor = buildCitationAnchor("1", "Assessment of eligibility for disabled person's pass");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        expect(anchor.getAttribute("aria-label")).toBe(
+            "1, Assessment of eligibility for disabled person's pass"
+        );
+    });
+
+    it("hides inner descendants from the accessibility tree", () => {
+        const anchor = buildCitationAnchor("1", "Example title");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        const badge = anchor.querySelector(".webchat__link-definitions__badge");
+        const body = anchor.querySelector(".webchat__link-definitions__list-item-body");
+        const mainBody = anchor.querySelector(".webchat__link-definitions__list-item-body-main");
+        const mainText = anchor.querySelector(".webchat__link-definitions__list-item-main-text");
+        const textEl = anchor.querySelector(".webchat__link-definitions__list-item-text");
+
+        expect(badge?.getAttribute("aria-hidden")).toBe("true");
+        expect(body?.getAttribute("aria-hidden")).toBe("true");
+        expect(mainBody?.getAttribute("aria-hidden")).toBe("true");
+        expect(mainText?.getAttribute("aria-hidden")).toBe("true");
+        expect(textEl?.getAttribute("aria-hidden")).toBe("true");
+
+        // Defensive: inner descendants also get role="presentation", inert, and
+        // tabindex="-1" so iOS VoiceOver cannot treat them as independently
+        // selectable elements.
+        expect(badge?.getAttribute("role")).toBe("presentation");
+        expect(body?.getAttribute("role")).toBe("presentation");
+        expect(mainBody?.getAttribute("role")).toBe("presentation");
+        expect(mainText?.getAttribute("role")).toBe("presentation");
+        expect(textEl?.getAttribute("role")).toBe("presentation");
+
+        expect(badge?.hasAttribute("inert")).toBe(true);
+        expect(textEl?.hasAttribute("inert")).toBe(true);
+        expect(badge?.getAttribute("tabindex")).toBe("-1");
+        expect(textEl?.getAttribute("tabindex")).toBe("-1");
+    });
+
+    it("injects a single global style tag to neutralize iOS Safari tap highlights on inner elements", () => {
+        const anchor = buildCitationAnchor("1", "Example title");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        const style = document.getElementById("ocw-citation-a11y-styles");
+        expect(style).not.toBeNull();
+        expect(style?.textContent).toContain("pointer-events: none");
+        expect(style?.textContent).toContain("-webkit-tap-highlight-color: transparent");
+        expect(style?.textContent).toContain("user-select: none");
+
+        // Re-running should not add a second <style> tag.
+        patchCitationAnchorsForA11y(document);
+        const allStyles = document.querySelectorAll("#ocw-citation-a11y-styles");
+        expect(allStyles.length).toBe(1);
+
+        // The anchor itself is explicitly role="link" so iOS VO sees ONE link.
+        expect(anchor.getAttribute("role")).toBe("link");
+    });
+
+    it("does not overwrite an existing aria-label", () => {
+        const anchor = buildCitationAnchor("2", "Another citation");
+        anchor.setAttribute("aria-label", "Custom label");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        expect(anchor.getAttribute("aria-label")).toBe("Custom label");
+    });
+
+    it("marks anchors as patched and preserves a manually-set aria-label", () => {
+        const anchor = buildCitationAnchor("1", "Citation text");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+        expect(anchor.dataset.ocwCitationA11yPatched).toBe("true");
+
+        // A manually-assigned aria-label must not be overwritten on subsequent
+        // passes, even though the patch is otherwise re-runnable.
+        anchor.setAttribute("aria-label", "Manually overridden");
+        patchCitationAnchorsForA11y(document);
+        expect(anchor.getAttribute("aria-label")).toBe("Manually overridden");
+    });
+
+    it("handles bare cite: anchors without badge/text structure", () => {
+        const anchor = document.createElement("a");
+        anchor.setAttribute("href", "cite:abc");
+        anchor.setAttribute("title", "Fallback title");
+        anchor.textContent = "[1]";
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        // Prefers title over textContent for plain cite: anchors
+        expect(anchor.getAttribute("aria-label")).toBe("Fallback title");
+        expect(anchor.dataset.ocwCitationA11yPatched).toBe("true");
+    });
+
+    it("uses just the identifier when no text is present", () => {
+        const anchor = document.createElement("a");
+        anchor.className = "webchat__link-definitions__list-item-box";
+        anchor.setAttribute("href", "cite:1");
+
+        const badge = document.createElement("div");
+        badge.className = "webchat__link-definitions__badge";
+        badge.textContent = "5";
+        anchor.appendChild(badge);
+
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        expect(anchor.getAttribute("aria-label")).toBe("5");
+    });
+
+    it("skips anchors with no identifier and no text", () => {
+        const anchor = document.createElement("a");
+        anchor.className = "webchat__link-definitions__list-item-box";
+        anchor.setAttribute("href", "cite:empty");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        expect(anchor.getAttribute("aria-label")).toBeNull();
+        expect(anchor.dataset.ocwCitationA11yPatched).toBeUndefined();
+    });
+
+    it("is a no-op when root has no querySelectorAll", () => {
+        expect(() => patchCitationAnchorsForA11y(null as unknown as ParentNode)).not.toThrow();
+    });
+
+    // WebChat re-renders the anchor's children (e.g. mounting OpenInNewWindowIcon
+    // after the initial render). A second pass must hide the new descendants so
+    // VoiceOver/TalkBack do not pick them up as separate focusable items.
+    it("re-hides descendants added to an already-patched anchor", () => {
+        const anchor = buildCitationAnchor("1", "Citation text");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        const lateChild = document.createElement("svg");
+        lateChild.setAttribute("class", "webchat__link-definitions__open-in-new-window-icon");
+        anchor.appendChild(lateChild);
+
+        // Calling on the anchor directly (mirrors the MutationObserver path
+        // that walks up to the closest matching ancestor anchor).
+        patchCitationAnchorsForA11y(anchor);
+
+        expect(lateChild.getAttribute("aria-hidden")).toBe("true");
+        expect(lateChild.getAttribute("role")).toBe("presentation");
+        expect(lateChild.hasAttribute("inert")).toBe(true);
+        expect(lateChild.getAttribute("tabindex")).toBe("-1");
+    });
+
+    // If React re-renders strip our aria-hidden/role/tabindex, a second pass
+    // must restore them. The patch is now idempotent rather than guarded by
+    // a one-shot dataset marker.
+    it("re-applies aria-hidden when stripped by an external re-render", () => {
+        const anchor = buildCitationAnchor("1", "Citation text");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+
+        const badge = anchor.querySelector(".webchat__link-definitions__badge");
+        if (!badge) {
+            throw new Error("Test setup did not produce a badge element");
+        }
+        badge.removeAttribute("aria-hidden");
+        badge.removeAttribute("inert");
+
+        patchCitationAnchorsForA11y(document);
+
+        expect(badge.getAttribute("aria-hidden")).toBe("true");
+        expect(badge.hasAttribute("inert")).toBe(true);
+    });
+
+    // The MutationObserver passes the anchor element itself as the root when
+    // walking up via closest(). querySelectorAll alone would not match it.
+    it("patches the root element when the root itself is a citation anchor", () => {
+        const anchor = buildCitationAnchor("3", "Title");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(anchor);
+
+        expect(anchor.getAttribute("aria-label")).toBe("3, Title");
+    });
+
+    // Repeated patching must not append additional overlay spans.
+    it("does not append duplicate overlays on repeated calls", () => {
+        const anchor = buildCitationAnchor("1", "Citation text");
+        document.body.appendChild(anchor);
+
+        patchCitationAnchorsForA11y(document);
+        patchCitationAnchorsForA11y(document);
+        patchCitationAnchorsForA11y(document);
+
+        const overlays = anchor.querySelectorAll("[data-ocw-citation-overlay='true']");
+        expect(overlays.length).toBe(1);
+    });
+});

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.ts
@@ -1,0 +1,205 @@
+// Accessibility helper: Merges WebChat's citation card number badge and link
+// text into a single focusable element.
+//
+// WebChat's LinkDefinitionItem renders an <a> containing a badge <div> (number)
+// and a text <div> (title). On iOS VoiceOver, these block-level descendants are
+// announced as two separate focusable links (e.g. "1, link" and
+// "Assessment of eligibility..., link"). Setting a combined aria-label on the
+// anchor and hiding inner descendants from the accessibility tree ensures the
+// whole card is announced as one link.
+
+const CITATION_ANCHOR_SELECTOR =
+    "a.webchat__link-definitions__list-item-box, a[href^=\"cite:\"]";
+
+const PATCHED_MARKER = "ocwCitationA11yPatched";
+
+const STYLE_TAG_ID = "ocw-citation-a11y-styles";
+
+// Global CSS injected once per document. Neutralizes iOS Safari's per-inner-
+// element tap highlight / selection / focus rectangles that otherwise make
+// the "1" badge and the link text appear as separate selectable areas even
+// though they are inside a single <a>.
+// Strategy:
+//  - Make the anchor a block-level positioning parent.
+//  - Add a transparent ::after pseudo-element that covers the entire anchor.
+//    iOS Safari hit-tests that overlay as a SINGLE region, so the tap
+//    highlight / selection rectangle always covers the whole card instead
+//    of just the "1" badge or just the link text.
+//  - Make every descendant fully transparent to pointer / selection / focus,
+//    so they can never become a standalone tap target.
+const STYLE_RULES = `
+a.webchat__link-definitions__list-item-box,
+a[href^="cite:"] {
+    position: relative !important;
+    display: block !important;
+    isolation: isolate !important;
+    -webkit-tap-highlight-color: rgba(0, 120, 212, 0.15) !important;
+    -webkit-touch-callout: none !important;
+    -webkit-user-select: none !important;
+    user-select: none !important;
+    cursor: pointer !important;
+}
+a.webchat__link-definitions__list-item-box::after,
+a[href^="cite:"]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    background: transparent;
+    pointer-events: auto;
+    -webkit-tap-highlight-color: rgba(0, 120, 212, 0.15);
+}
+a.webchat__link-definitions__list-item-box *,
+a[href^="cite:"] * {
+    pointer-events: none !important;
+    -webkit-tap-highlight-color: transparent !important;
+    -webkit-touch-callout: none !important;
+    -webkit-user-select: none !important;
+    user-select: none !important;
+    outline: none !important;
+    text-decoration: inherit !important;
+    cursor: inherit !important;
+}
+`;
+
+const ensureStyleInjected = (doc: Document): void => {
+    if (!doc || typeof doc.getElementById !== "function" || doc.getElementById(STYLE_TAG_ID)) {
+        return;
+    }
+    const style = doc.createElement("style");
+    style.id = STYLE_TAG_ID;
+    style.textContent = STYLE_RULES;
+    (doc.head || doc.documentElement).appendChild(style);
+};
+
+export const patchCitationAnchorsForA11y = (root: ParentNode): void => {
+    if (!root || typeof root.querySelectorAll !== "function") {
+        return;
+    }
+
+    // Inject global CSS once per document. This covers every citation anchor
+    // regardless of whether our per-node patch has run on it yet.
+    const rootNode = root as unknown as Node & { ownerDocument?: Document | null };
+    const doc: Document | null =
+        rootNode.ownerDocument
+        ?? ((root as unknown) as Document).defaultView?.document
+        ?? ((root as unknown) as Document)
+        ?? (typeof document !== "undefined" ? document : null);
+    if (doc && typeof doc.createElement === "function") {
+        ensureStyleInjected(doc);
+    }
+
+    // Also include the root itself when it matches — calls from MutationObserver
+    // pass the anchor element directly, which querySelectorAll wouldn't return.
+    const matched = new Set<HTMLAnchorElement>();
+    if (typeof (root as Element).matches === "function"
+        && (root as Element).matches(CITATION_ANCHOR_SELECTOR)) {
+        matched.add(root as unknown as HTMLAnchorElement);
+    }
+    root.querySelectorAll(CITATION_ANCHOR_SELECTOR).forEach((n) => {
+        matched.add(n as HTMLAnchorElement);
+    });
+
+    matched.forEach((anchor) => {
+        const badge = anchor.querySelector(".webchat__link-definitions__badge");
+        const textEl = anchor.querySelector(".webchat__link-definitions__list-item-text");
+
+        const identifier = badge?.textContent?.trim() ?? "";
+        // Prefer the explicit text element. For plain (non-card) citation anchors
+        // (no badge), fall back to the title or the anchor's own text. When a
+        // badge is present but no text element, avoid using anchor.textContent
+        // since it would duplicate the identifier.
+        let text = textEl?.textContent?.trim() ?? "";
+        if (!text && !badge) {
+            text = anchor.getAttribute("title")?.trim()
+                || anchor.textContent?.trim()
+                || "";
+        }
+
+        if (!identifier && !text) {
+            return;
+        }
+
+        const combinedLabel = identifier && text
+            ? `${identifier}, ${text}`
+            : (identifier || text);
+
+        // Always (re-)apply aria-label if absent. Setting it again with the same
+        // value when it already matches is a no-op for the DOM; this keeps the
+        // patch idempotent so React re-renders that strip the attribute heal.
+        const existingLabel = anchor.getAttribute("aria-label");
+        if (!existingLabel) {
+            anchor.setAttribute("aria-label", combinedLabel);
+        }
+
+        // Explicitly mark the anchor as a single link so iOS VoiceOver treats
+        // the whole card as one element.
+        if (!anchor.getAttribute("role")) {
+            anchor.setAttribute("role", "link");
+        }
+
+        // Nuclear a11y lockdown of EVERY descendant of the anchor (not just
+        // known class names, because WebChat can render additional nodes).
+        // iOS VoiceOver is known to split focus on block-level descendants
+        // inside an <a>. Applying all four of the following guarantees only
+        // the outer <a> is a selectable a11y / focus target:
+        //   - aria-hidden="true"      removes element from the a11y tree
+        //   - role="presentation"     strips any implicit semantic role
+        //   - inert                   removes element from focus + interaction
+        //   - tabindex="-1"           defensive (covers browsers without inert)
+        anchor.querySelectorAll("*").forEach((el) => {
+            const inner = el as HTMLElement;
+            inner.setAttribute("aria-hidden", "true");
+            inner.setAttribute("role", "presentation");
+            inner.setAttribute("tabindex", "-1");
+            // "inert" is a boolean attribute — presence alone is enough.
+            if (!inner.hasAttribute("inert")) {
+                inner.setAttribute("inert", "");
+            }
+            // pointer-events: none forwards clicks/taps/hover directly to the
+            // outer <a>, so the entire card behaves as one selectable area
+            // with a single focus/hover state (instead of "1" and the link
+            // text highlighting independently).
+            inner.style.pointerEvents = "none";
+        });
+
+        // DOM-level full-bleed overlay. Inline styles are used so this works
+        // even when the widget renders inside a shadow DOM (where an
+        // injected <style> tag in document.head cannot reach). The overlay
+        // becomes the ONLY visible hit-test target for iOS Safari, so tapping
+        // anywhere on the card highlights the entire card instead of just the
+        // "1" badge or just the link text.
+        const anchorStyle = anchor.style;
+        if (!anchorStyle.position) {
+            anchorStyle.position = "relative";
+        }
+        if (!anchorStyle.display || anchorStyle.display === "inline") {
+            anchorStyle.display = "block";
+        }
+        const ownerDoc = anchor.ownerDocument;
+        const existingOverlay = anchor.querySelector(":scope > [data-ocw-citation-overlay='true']");
+        if (!existingOverlay && ownerDoc && typeof ownerDoc.createElement === "function") {
+            const overlay = ownerDoc.createElement("span");
+            overlay.setAttribute("aria-hidden", "true");
+            overlay.setAttribute("data-ocw-citation-overlay", "true");
+            overlay.style.cssText = [
+                "position:absolute",
+                "top:0",
+                "left:0",
+                "right:0",
+                "bottom:0",
+                "z-index:2",
+                "background:transparent",
+                "pointer-events:auto",
+                "-webkit-tap-highlight-color:rgba(0,120,212,0.15)",
+                "-webkit-touch-callout:none",
+                "-webkit-user-select:none",
+                "user-select:none",
+                "cursor:pointer"
+            ].join(";");
+            anchor.appendChild(overlay);
+        }
+
+        anchor.dataset[PATCHED_MARKER] = "true";
+    });
+};

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.ts
@@ -141,20 +141,36 @@ export const patchCitationAnchorsForA11y = (root: ParentNode): void => {
         // Nuclear a11y lockdown of EVERY descendant of the anchor (not just
         // known class names, because WebChat can render additional nodes).
         // iOS VoiceOver is known to split focus on block-level descendants
-        // inside an <a>. Applying all four of the following guarantees only
-        // the outer <a> is a selectable a11y / focus target:
+        // inside an <a>. Applying all of the following guarantees only the
+        // outer <a> is a selectable a11y / focus target:
         //   - aria-hidden="true"      removes element from the a11y tree
         //   - role="presentation"     strips any implicit semantic role
         //   - inert                   removes element from focus + interaction
         //   - tabindex="-1"           defensive (covers browsers without inert)
+        //   - title removed           iOS VoiceOver in WKWebView still surfaces
+        //                             elements with a `title` attribute as a
+        //                             separately swipeable item even when
+        //                             aria-hidden=true. WebChat's ItemBody sets
+        //                             title={text} on the inner link-text div,
+        //                             which is the root cause of the "two
+        //                             separate links" announcement on iOS.
+        //                             We move the title to a data-* attribute
+        //                             so any tooltip-like tooling can still
+        //                             read it, but iOS VO ignores it.
         anchor.querySelectorAll("*").forEach((el) => {
             const inner = el as HTMLElement;
             inner.setAttribute("aria-hidden", "true");
             inner.setAttribute("role", "presentation");
             inner.setAttribute("tabindex", "-1");
-            // "inert" is a boolean attribute — presence alone is enough.
             if (!inner.hasAttribute("inert")) {
                 inner.setAttribute("inert", "");
+            }
+            const innerTitle = inner.getAttribute("title");
+            if (innerTitle !== null) {
+                inner.removeAttribute("title");
+                if (!inner.dataset.ocwOriginalTitle) {
+                    inner.dataset.ocwOriginalTitle = innerTitle;
+                }
             }
             // pointer-events: none forwards clicks/taps/hover directly to the
             // outer <a>, so the entire card behaves as one selectable area


### PR DESCRIPTION
## Summary

WebChat's `LinkDefinitionItem` renders an `<a class="webchat__link-definitions__list-item-box">` whose children are a number-badge `<div>` and a link-text `<div>`. iOS VoiceOver and Android TalkBack split focus on those block-level descendants and announce **two separate links** per citation card — one for the number, one for the title. Users have to swipe twice per card and risk activating the wrong target.

This PR adds `patchCitationAnchorsForA11y`, called from `WebChatContainerStateful`, which retro-fits the WebChat-rendered DOM so each card is announced as a single combined link (e.g. _"1, Assessment of eligibility for disabled person's pass, link"_).

## What the patch does

For every `a.webchat__link-definitions__list-item-box` and `a[href^="cite:"]`:

- Sets a combined `aria-label` (`"<identifier>, <title>"`) on the anchor.
- Sets `role="link"` on the anchor (defensive — guarantees iOS VO sees one link).
- Walks every descendant and applies `aria-hidden="true"`, `role="presentation"`, `inert`, `tabindex="-1"` and `pointer-events: none` so the inner badge/title cannot be a separate focus or hit-test target.
- Injects one global `<style>` tag that neutralizes iOS Safari's per-element tap-highlight rectangles.
- Adds one transparent overlay `<span>` per anchor as the sole hit-test target — the whole card highlights as one region on iOS Safari instead of just the badge or just the text.

## Hardening for React re-renders

The earlier prototype short-circuited via a `data-ocw-citation-a11y-patched` marker. WebChat re-renders the anchor's children (e.g. mounting the external-link SVG icon after the initial render) and React's reconciler can drop attributes — both broke the prototype. This implementation:

- Drops the early-return so the patch is **idempotent**: re-applying does nothing extra (existing `aria-label` / `role` / overlay are preserved).
- The MutationObserver in `WebChatContainerStateful` walks up via `closest()` to re-patch the parent anchor whenever a child node is mounted **inside** an already-patched anchor.
- The observer also watches `aria-hidden`, `role`, `tabindex`, `inert` attribute mutations on descendants and re-applies them when React strips them.
- The patch accepts an anchor element directly as `root` (uses `matches()` in addition to `querySelectorAll()`), supporting the `closest()`-walk path.

## Files

- `chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.ts` — new (205 lines)
- `chat-widget/src/components/webchatcontainerstateful/common/utils/citationA11y.test.ts` — new (248 lines, 13 tests)
- `chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx` — `+51` (import + useEffect with idempotent MutationObserver)

## Platforms

The patch runs unconditionally on every render, so it covers iOS Safari, iOS WKWebView (in-app browsers, hybrid apps), Android Chrome, Android WebView, and desktop. On iOS < 15.5 (no `inert` support) the combination of `aria-hidden` + `role="presentation"` + `tabindex="-1"` covers the gap. The CSS-only fallback only no-ops inside a Shadow DOM host; the per-element a11y fixes still apply.

## Test plan

- [x] `yarn jest citationA11y.test.ts` — 13/13 pass.
- [x] `yarn lint` on the changed files (with `linebreak-style` off — repo-wide CRLF inconsistency unrelated): 0 errors, 0 warnings.
- [ ] iOS Safari + VoiceOver: load the chat, ask a question that returns citations, swipe right over a citation card — announces as one combined link.
- [ ] Android Chrome + TalkBack: same flow — announces as one combined link.
- [ ] Desktop Chrome + DevTools Accessibility pane: anchor has computed `aria-label`, every descendant has `aria-hidden="true"`.
- [ ] Verify keyboard Tab still lands on each anchor exactly once.

## Repro page (local)

A standalone mock at `chat-widget/samples/citation-a11y-demo/wmca-mock.html` (not in this PR) renders the WebChat citation card DOM and lets you toggle the patch off/on for visual verification — useful for QA before this lands.