### PR TITLE
fix(a11y) LCWv2: email transcript SR prefix + focus reorder

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 - [A11y] Bot message avatar alt text now uses the full agent name instead of initials for screen readers
 - [A11y] Screen reader now announces "File sent successfully." when an attachment upload completes; uses append-and-remove assertive aria-live pattern for reliable announcement on Android TalkBack/WebView. Announcement text is customizable via `MIDDLEWARE_BANNER_FILE_SENT`.
 - [A11y] Adaptive card radio button groups now include aria-setsize and aria-posinset attributes for correct option count announcement
+- [A11y] Email transcript SR announcement prefixed with localized "Success." / "Error." via new `MIDDLEWARE_SR_PREFIX_SUCCESS` / `MIDDLEWARE_SR_PREFIX_ERROR` keys so screen readers announce the outcome immediately
+- [A11y] Email transcript focus on submit goes directly to the notification banner; skips the chat-widget shell detour
 
 ### Added
 - [A11y] E2E Playwright tests for 5 accessibility defects: focus trap, bot initials alt text, adaptive card radio count, attachment upload announcement, email notification aria-live regions

--- a/chat-widget/automation_tests/e2e/areas/accessibility/emailTranscriptAnnouncement.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/emailTranscriptAnnouncement.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * E2E accessibility regression test for the email transcript pane.
+ *
+ * Asserts the contracts that bug 4626904 / email a11y work depends on:
+ *   1. After submit success, an aria-live="assertive" region carries an
+ *      announcement starting with the localized "Success." prefix.
+ *   2. After submit failure, the same region carries the "Error." prefix.
+ *   3. After submit, focus does NOT land on the chat-widget shell — it lands
+ *      on the notification banner (close/expand button) directly.
+ *   4. After cancel, focus is restored to the element that opened the pane.
+ *
+ * Requires:
+ *   - chat-widget bundle built at chat-widget/dist/out.js (yarn build-sample)
+ *   - A test fixture that mounts the widget against a mock chat SDK so the
+ *     transcript submission resolves locally without a live agent. The
+ *     fixture pattern mirrors PR #907 (DesignerChatSDK + HTML fixture).
+ *
+ * If the prerequisites are not available the suite skips itself rather than
+ * failing CI. To exercise the assertions locally, set EMAIL_A11Y_E2E=1 and
+ * provide a fixture path via EMAIL_A11Y_FIXTURE.
+ */
+
+import { Browser, BrowserContext, Page } from "playwright";
+import * as playwright from "playwright";
+import * as fs from "fs";
+import * as path from "path";
+import { TestSettings } from "../../../configuration/test-settings";
+
+const fixturePath = process.env.EMAIL_A11Y_FIXTURE
+    ? path.resolve(process.cwd(), process.env.EMAIL_A11Y_FIXTURE)
+    : path.resolve(__dirname, "../../../customlivechatwidgets/EmailTranscriptFixture.html");
+
+const widgetBundle = path.resolve(__dirname, "../../../../dist/out.js");
+
+const prerequisitesPresent = (): boolean => {
+    if (process.env.EMAIL_A11Y_E2E !== "1") return false;
+    if (!fs.existsSync(widgetBundle)) return false;
+    if (!fs.existsSync(fixturePath)) return false;
+    return true;
+};
+
+const describeOrSkip = prerequisitesPresent() ? describe : describe.skip;
+
+describeOrSkip("Email transcript pane — accessibility", () => {
+    let browser: Browser;
+    let context: BrowserContext;
+    let page: Page;
+
+    beforeAll(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        browser = await playwright[TestSettings.Browsers as any].launch(TestSettings.LaunchBrowserSettings);
+        context = await browser.newContext({ viewport: TestSettings.Viewport });
+    });
+
+    afterAll(async () => {
+        await context?.close();
+        await browser?.close();
+    });
+
+    beforeEach(async () => {
+        page = await context.newPage();
+        await page.goto("file://" + fixturePath, { waitUntil: "domcontentloaded" });
+        await page.waitForSelector("#oc-lcw-chat-button-title", { timeout: 10000 });
+        await page.click("#oc-lcw-chat-button-title");
+        // Open the email transcript pane via the footer menu (selector pattern from existing widget)
+        await page.waitForSelector("[data-testid='oc-lcw-emailTranscript'], [aria-label*='email' i]", { timeout: 10000 });
+        await page.click("[data-testid='oc-lcw-emailTranscript'], [aria-label*='email' i]");
+        await page.waitForSelector("#oclcw-emailTranscriptDialogContainer", { timeout: 10000 });
+    });
+
+    afterEach(async () => {
+        await page?.close();
+    });
+
+    test("submit success announces 'Success. ' prefix via aria-live region", async () => {
+        await page.fill("#oclcw-emailTranscriptDialogContainer input[type='email']", "user@example.com");
+        await page.click("#oclcw-emailTranscriptDialogContainer button[type='submit'], [aria-label*='Send' i]");
+
+        // The doc.body announcement region created by announceMessageImmediately
+        const announcement = await page.waitForFunction(
+            () => {
+                const region = document.querySelector("[aria-live=\"assertive\"][role=\"alert\"]");
+                return region && region.textContent && region.textContent.includes("Success.")
+                    ? region.textContent
+                    : null;
+            },
+            { timeout: 5000 }
+        );
+        const text = await announcement.jsonValue();
+        expect(text).toMatch(/^Success\.\s/);
+    });
+
+    test("submit success lands focus on notification banner, not the chat-widget shell", async () => {
+        await page.fill("#oclcw-emailTranscriptDialogContainer input[type='email']", "user@example.com");
+        await page.click("#oclcw-emailTranscriptDialogContainer button[type='submit'], [aria-label*='Send' i]");
+
+        await page.waitForFunction(
+            () => {
+                const active = document.activeElement as HTMLElement | null;
+                if (!active) return false;
+                const cls = active.className || "";
+                return /webChatBanner(Expand|Close)Button/.test(cls);
+            },
+            { timeout: 5000 }
+        );
+
+        const focusedTagAndClass = await page.evaluate(() => {
+            const el = document.activeElement as HTMLElement;
+            return { tag: el?.tagName, cls: el?.className };
+        });
+        expect(focusedTagAndClass.tag).toBe("BUTTON");
+        expect(focusedTagAndClass.cls).toMatch(/webChatBanner/);
+    });
+
+    test("cancel restores focus to the element that opened the pane", async () => {
+        // The trigger element should be remembered as previousElementIdOnFocusBeforeModalOpen
+        const triggerHadId = await page.evaluate(() => {
+            const trigger = document.activeElement as HTMLElement;
+            return trigger ? trigger.id : null;
+        });
+
+        await page.click("#oclcw-emailTranscriptDialogContainer [aria-label*='Cancel' i]");
+
+        await page.waitForFunction(
+            (id) => document.activeElement && (id ? document.activeElement.id === id : true),
+            triggerHadId,
+            { timeout: 5000 }
+        );
+
+        const focusedId = await page.evaluate(() => document.activeElement && (document.activeElement as HTMLElement).id);
+        if (triggerHadId) {
+            expect(focusedId).toBe(triggerHadId);
+        } else {
+            // Fallback assertion: focus must be inside the chat widget, not on document.body
+            expect(focusedId).not.toBe("");
+        }
+    });
+
+    test("submit failure announces 'Error. ' prefix via aria-live region", async () => {
+        // Fixture toggles a flag that causes the mock SDK to reject emailLiveChatTranscript.
+        await page.evaluate(() => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (window as any).__forceEmailFailure = true;
+        });
+        await page.fill("#oclcw-emailTranscriptDialogContainer input[type='email']", "user@example.com");
+        await page.click("#oclcw-emailTranscriptDialogContainer button[type='submit'], [aria-label*='Send' i]");
+
+        const announcement = await page.waitForFunction(
+            () => {
+                const region = document.querySelector("[aria-live=\"assertive\"][role=\"alert\"]");
+                return region && region.textContent && region.textContent.includes("Error.")
+                    ? region.textContent
+                    : null;
+            },
+            { timeout: 5000 }
+        );
+        const text = await announcement.jsonValue();
+        expect(text).toMatch(/^Error\.\s/);
+    });
+});

--- a/chat-widget/src/common/utils.ts
+++ b/chat-widget/src/common/utils.ts
@@ -166,6 +166,43 @@ export const setFocusOnElement = (selector: string | HTMLElement) => {
     element?.focus();
 };
 
+const IMMEDIATE_ANNOUNCEMENT_REGION_ID = "oc-lcw-immediate-announcement";
+
+// Announces a message to screen readers via an aria-live="assertive" region
+// attached to document.body — outside the chat widget's DOM subtree — so the
+// screen reader does not have to traverse chat content to reach it.
+export const announceMessageImmediately = (message: string) => {
+    if (!message || typeof document === "undefined") {
+        return;
+    }
+
+    let region = document.getElementById(IMMEDIATE_ANNOUNCEMENT_REGION_ID);
+    if (!region) {
+        region = document.createElement("div");
+        region.id = IMMEDIATE_ANNOUNCEMENT_REGION_ID;
+        region.setAttribute("aria-live", "assertive");
+        region.setAttribute("role", "alert");
+        region.setAttribute("aria-atomic", "true");
+        region.style.position = "absolute";
+        region.style.width = "1px";
+        region.style.height = "1px";
+        region.style.overflow = "hidden";
+        region.style.clip = "rect(0 0 0 0)";
+        region.style.clipPath = "inset(50%)";
+        region.style.whiteSpace = "nowrap";
+        document.body.appendChild(region);
+    }
+
+    region.textContent = "";
+    // Re-set on the next tick so screen readers detect the change even when
+    // the same message is announced twice in a row.
+    setTimeout(() => {
+        if (region) {
+            region.textContent = message;
+        }
+    }, 50);
+};
+
 export const escapeHtml = (inputString: string) => {
     const entityMap: {
         [key: string]: string,

--- a/chat-widget/src/components/emailtranscriptpanestateful/EmailTranscriptPaneStateful.a11y.spec.tsx
+++ b/chat-widget/src/components/emailtranscriptpanestateful/EmailTranscriptPaneStateful.a11y.spec.tsx
@@ -1,0 +1,214 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "@testing-library/jest-dom";
+
+import * as utils from "../../common/utils";
+
+import { act, cleanup, render } from "@testing-library/react";
+
+import { EmailTranscriptPaneStateful } from "./EmailTranscriptPaneStateful";
+import { LiveChatWidgetActionType } from "../../contexts/common/LiveChatWidgetActionType";
+import { NotificationHandler } from "../webchatcontainerstateful/webchatcontroller/notification/NotificationHandler";
+import React from "react";
+
+// jest.mock factories may only reference identifiers prefixed with `mock`. Hold
+// the captured controlProps and shared state in mock-prefixed singletons.
+const mockCapturedControlProps: { current: any } = { current: undefined };
+const mockDispatch = jest.fn();
+const mockFacadeChatSDK = { emailLiveChatTranscript: jest.fn() };
+const mockState: { current: any } = { current: undefined };
+
+jest.mock("@microsoft/omnichannel-chat-components", () => ({
+    BroadcastService: {
+        postMessage: jest.fn(),
+        getMessageByEventName: jest.fn(() => ({
+            subscribe: () => ({ unsubscribe: jest.fn() })
+        }))
+    },
+    InputValidationPane: (props: any) => {
+        mockCapturedControlProps.current = props.controlProps;
+        return null;
+    }
+}));
+
+jest.mock("../../hooks/useChatContextStore", () => ({
+    __esModule: true,
+    default: () => [mockState.current, mockDispatch]
+}));
+
+jest.mock("../../hooks/useFacadeChatSDKStore", () => ({
+    __esModule: true,
+    default: () => [mockFacadeChatSDK]
+}));
+
+jest.mock("../webchatcontainerstateful/webchatcontroller/notification/NotificationHandler");
+
+const buildState = (overrides: Partial<any> = {}) => ({
+    appStates: {
+        previousElementIdOnFocusBeforeModalOpen: "previous-button",
+        preChatResponseEmail: ""
+    },
+    domainStates: {
+        liveChatContext: {},
+        globalDir: "ltr",
+        middlewareLocalizedTexts: {},
+        ...overrides
+    }
+});
+
+describe("EmailTranscriptPaneStateful — accessibility behavior", () => {
+    let announceSpy: jest.SpyInstance;
+    let setFocusOnElementSpy: jest.SpyInstance;
+    let setFocusOnSendBoxSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockCapturedControlProps.current = undefined;
+        mockState.current = buildState();
+
+        announceSpy = jest.spyOn(utils, "announceMessageImmediately").mockImplementation(() => undefined);
+        setFocusOnElementSpy = jest.spyOn(utils, "setFocusOnElement").mockImplementation(() => undefined);
+        setFocusOnSendBoxSpy = jest.spyOn(utils, "setFocusOnSendBox").mockImplementation(() => undefined);
+        jest.spyOn(utils, "preventFocusToMoveOutOfElement").mockImplementation(() => () => undefined);
+        // Return null so the component skips focus({}) on a non-existent element.
+        jest.spyOn(utils, "findAllFocusableElement").mockReturnValue(null as any);
+        jest.spyOn(utils, "findParentFocusableElementsWithoutChildContainer").mockReturnValue([] as any);
+        jest.spyOn(utils, "setTabIndices").mockImplementation(() => undefined);
+        jest.spyOn(utils, "createTimer").mockReturnValue({ milliSecondsElapsed: 0 } as any);
+    });
+
+    afterEach(() => {
+        cleanup();
+        jest.restoreAllMocks();
+    });
+
+    const renderPane = (props: any = {}) => {
+        render(<EmailTranscriptPaneStateful {...props} />);
+        return mockCapturedControlProps.current;
+    };
+
+    describe("onSend success path", () => {
+        it("announces with the default English 'Success. ' prefix when no localized override", async () => {
+            mockFacadeChatSDK.emailLiveChatTranscript.mockResolvedValueOnce(undefined);
+            const controlProps = renderPane();
+
+            await act(async () => {
+                await controlProps.onSend("user@example.com");
+            });
+
+            expect(announceSpy).toHaveBeenCalledTimes(1);
+            expect(announceSpy).toHaveBeenCalledWith("Success. Email will be sent after chat ends!");
+            expect(NotificationHandler.notifySuccess).toHaveBeenCalledTimes(1);
+        });
+
+        it("uses the localized SR success prefix when provided via middlewareLocalizedTexts", async () => {
+            mockState.current.domainStates.middlewareLocalizedTexts = {
+                MIDDLEWARE_SR_PREFIX_SUCCESS: "Succès. ",
+                MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS: "L'email sera envoyé."
+            };
+            mockFacadeChatSDK.emailLiveChatTranscript.mockResolvedValueOnce(undefined);
+            const controlProps = renderPane();
+
+            await act(async () => {
+                await controlProps.onSend("user@example.com");
+            });
+
+            expect(announceSpy).toHaveBeenCalledWith("Succès. L'email sera envoyé.");
+        });
+
+        it("skips focus restore on submit so the notification banner takes focus", async () => {
+            mockFacadeChatSDK.emailLiveChatTranscript.mockResolvedValueOnce(undefined);
+            const controlProps = renderPane();
+
+            await act(async () => {
+                await controlProps.onSend("user@example.com");
+            });
+
+            expect(setFocusOnElementSpy).not.toHaveBeenCalled();
+            expect(setFocusOnSendBoxSpy).not.toHaveBeenCalled();
+            expect(mockDispatch).toHaveBeenCalledWith(
+                expect.objectContaining({ type: LiveChatWidgetActionType.SET_SHOW_EMAIL_TRANSCRIPT_PANE, payload: false })
+            );
+        });
+    });
+
+    describe("onSend failure path", () => {
+        it("announces with the default English 'Error. ' prefix and notifies error", async () => {
+            mockFacadeChatSDK.emailLiveChatTranscript.mockRejectedValueOnce(new Error("boom"));
+            const controlProps = renderPane();
+
+            await act(async () => {
+                await controlProps.onSend("user@example.com");
+            });
+
+            expect(announceSpy).toHaveBeenCalledTimes(1);
+            expect(announceSpy).toHaveBeenCalledWith("Error. Email user@example.com could not be saved, try again later.");
+            expect(NotificationHandler.notifyError).toHaveBeenCalledTimes(1);
+        });
+
+        it("uses the localized SR error prefix when provided", async () => {
+            mockState.current.domainStates.middlewareLocalizedTexts = {
+                MIDDLEWARE_SR_PREFIX_ERROR: "Erreur. ",
+                MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR: "Email {0} non enregistré."
+            };
+            mockFacadeChatSDK.emailLiveChatTranscript.mockRejectedValueOnce(new Error("boom"));
+            const controlProps = renderPane();
+
+            await act(async () => {
+                await controlProps.onSend("user@example.com");
+            });
+
+            expect(announceSpy).toHaveBeenCalledWith("Erreur. Email user@example.com non enregistré.");
+        });
+
+        it("respects bannerMessageOnError prop when supplied", async () => {
+            mockFacadeChatSDK.emailLiveChatTranscript.mockRejectedValueOnce(new Error("boom"));
+            const controlProps = renderPane({ bannerMessageOnError: "Custom error copy." });
+
+            await act(async () => {
+                await controlProps.onSend("user@example.com");
+            });
+
+            expect(announceSpy).toHaveBeenCalledWith("Error. Custom error copy.");
+            expect(NotificationHandler.notifyError).toHaveBeenCalledWith(expect.anything(), "Custom error copy.");
+        });
+
+        it("skips focus restore on submit failure so the error banner takes focus", async () => {
+            mockFacadeChatSDK.emailLiveChatTranscript.mockRejectedValueOnce(new Error("boom"));
+            const controlProps = renderPane();
+
+            await act(async () => {
+                await controlProps.onSend("user@example.com");
+            });
+
+            expect(setFocusOnElementSpy).not.toHaveBeenCalled();
+            expect(setFocusOnSendBoxSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("onCancel path", () => {
+        it("restores focus to the previously focused element", () => {
+            const controlProps = renderPane();
+
+            act(() => {
+                controlProps.onCancel();
+            });
+
+            expect(setFocusOnElementSpy).toHaveBeenCalledWith("#previous-button");
+            expect(announceSpy).not.toHaveBeenCalled();
+            expect(NotificationHandler.notifySuccess).not.toHaveBeenCalled();
+            expect(NotificationHandler.notifyError).not.toHaveBeenCalled();
+        });
+
+        it("falls back to setFocusOnSendBox when no previous element id is stored", () => {
+            mockState.current.appStates.previousElementIdOnFocusBeforeModalOpen = null;
+            const controlProps = renderPane();
+
+            act(() => {
+                controlProps.onCancel();
+            });
+
+            expect(setFocusOnSendBoxSpy).toHaveBeenCalled();
+            expect(setFocusOnElementSpy).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/chat-widget/src/components/emailtranscriptpanestateful/EmailTranscriptPaneStateful.tsx
+++ b/chat-widget/src/components/emailtranscriptpanestateful/EmailTranscriptPaneStateful.tsx
@@ -1,6 +1,6 @@
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useCallback, useEffect, useState } from "react";
-import { createTimer, findAllFocusableElement, findParentFocusableElementsWithoutChildContainer, formatTemplateString, preventFocusToMoveOutOfElement, setFocusOnElement, setFocusOnSendBox, setTabIndices } from "../../common/utils";
+import { announceMessageImmediately, createTimer, findAllFocusableElement, findParentFocusableElementsWithoutChildContainer, formatTemplateString, preventFocusToMoveOutOfElement, setFocusOnElement, setFocusOnSendBox, setTabIndices } from "../../common/utils";
 
 import { DimLayer } from "../dimlayer/DimLayer";
 import { FacadeChatSDK } from "../../common/facades/FacadeChatSDK";
@@ -37,13 +37,19 @@ export const EmailTranscriptPaneStateful = (props: IEmailTranscriptPaneProps) =>
     
     const [facadeChatSDK]: [FacadeChatSDK | undefined, (facadeChatSDK: FacadeChatSDK) => void] = useFacadeSDKStore();
     const [initialEmail, setInitialEmail] = useState("");
-    const closeEmailTranscriptPane = () => {
+    // restoreFocus=false is used on the submit path: the notification banner
+    // (success or error) takes focus via NotificationHandler.setFocusOnNotificationCloseButton,
+    // so an intermediate restore to the chat-widget shell would otherwise cause SRs to
+    // announce "Enter <widget>" in between the dialog and the banner.
+    const closeEmailTranscriptPane = (restoreFocus = true) => {
         dispatch({ type: LiveChatWidgetActionType.SET_SHOW_EMAIL_TRANSCRIPT_PANE, payload: false });
-        const previousFocusedElementId = state.appStates.previousElementIdOnFocusBeforeModalOpen;
-        if (previousFocusedElementId) {
-            setFocusOnElement("#" + previousFocusedElementId);
-        } else {
-            setFocusOnSendBox();
+        if (restoreFocus) {
+            const previousFocusedElementId = state.appStates.previousElementIdOnFocusBeforeModalOpen;
+            if (previousFocusedElementId) {
+                setFocusOnElement("#" + previousFocusedElementId);
+            } else {
+                setFocusOnSendBox();
+            }
         }
         dispatch({ type: LiveChatWidgetActionType.SET_PREVIOUS_FOCUSED_ELEMENT_ID, payload: null });
         setTabIndices(elements, initialTabIndexMap, true);
@@ -51,14 +57,22 @@ export const EmailTranscriptPaneStateful = (props: IEmailTranscriptPaneProps) =>
 
     const onSend = useCallback(async (email: string) => {
         const liveChatContext = state?.domainStates?.liveChatContext;
-        closeEmailTranscriptPane();
+        closeEmailTranscriptPane(false);
         const chatTranscriptBody: IChatTranscriptBody = {
             emailAddress: email,
             attachmentMessage: props?.attachmentMessage ?? "The following attachment was uploaded during the conversation:"
         };
         try {
             await facadeChatSDK?.emailLiveChatTranscript(chatTranscriptBody, {liveChatContext});
-            NotificationHandler.notifySuccess(NotificationScenarios.EmailAddressSaved, state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS ?? defaultMiddlewareLocalizedTexts?.MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS as string);
+            const successMessage = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS ?? defaultMiddlewareLocalizedTexts?.MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS as string;
+            // Announce from a live region at document.body level so the
+            // screen reader speaks the confirmation immediately, without
+            // traversing the chat transcript on the way to the banner.
+            // Prefix with the explicit state word so SR users hear the outcome
+            // (visual users already see a success icon on the banner).
+            const successSrPrefix = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_SR_PREFIX_SUCCESS ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_SR_PREFIX_SUCCESS as string;
+            announceMessageImmediately(`${successSrPrefix}${successMessage}`);
+            NotificationHandler.notifySuccess(NotificationScenarios.EmailAddressSaved, successMessage);
             TelemetryHelper.logActionEventToAllTelemetry(LogLevel.INFO, {
                 Event: TelemetryEvent.EmailTranscriptSent,
                 Description: "Transcript sent to email successfully."
@@ -72,9 +86,12 @@ export const EmailTranscriptPaneStateful = (props: IEmailTranscriptPaneProps) =>
                 }
             });
             const message = formatTemplateString(state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR as string, [email]);
+            const bannerMessage = props?.bannerMessageOnError ?? message;
+            const errorSrPrefix = state?.domainStates?.middlewareLocalizedTexts?.MIDDLEWARE_SR_PREFIX_ERROR ?? defaultMiddlewareLocalizedTexts.MIDDLEWARE_SR_PREFIX_ERROR as string;
+            announceMessageImmediately(`${errorSrPrefix}${bannerMessage}`);
             NotificationHandler.notifyError(
                 NotificationScenarios.EmailTranscriptError,
-                props?.bannerMessageOnError ?? message);
+                bannerMessage);
         }
     }, [props.attachmentMessage, props.bannerMessageOnError, facadeChatSDK, state.domainStates.liveChatContext]);
 

--- a/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/defaultProps/defaultMiddlewareLocalizedTexts.ts
@@ -32,6 +32,8 @@ export const defaultMiddlewareLocalizedTexts: ILiveChatWidgetLocalizedTexts = {
     MIDDLEWARE_BANNER_FILE_SENT: "File sent successfully.",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_SUCCESS: "Email will be sent after chat ends!",
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR: "Email {0} could not be saved, try again later.",
+    MIDDLEWARE_SR_PREFIX_SUCCESS: "Success. ",
+    MIDDLEWARE_SR_PREFIX_ERROR: "Error. ",
     PREVIOUS_MESSAGES_LOADING: "Loading previous messages...",
     CONVERSATION_DIVIDER_ARIA_LABEL: "Conversation history divider"
 };

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/notification/NotificationHandler.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/notification/NotificationHandler.ts
@@ -7,7 +7,11 @@ import { setFocusOnSendBox } from "../../../../common/utils";
 import { BroadcastService } from "@microsoft/omnichannel-chat-components";
 import { BroadcastEvent } from "../../../../common/telemetry/TelemetryConstants";
 
+const LIVE_REGION_ID = "oc-lcw-notification-live-region";
+const LIVE_REGION_CLEAR_DELAY_MS = 1000;
+
 export class NotificationHandler {
+    private static clearTimeoutId: ReturnType<typeof setTimeout> | undefined;
     private static notify(id: string, level: NotificationLevel, message: string) {
         if (WebChatStoreLoader.store) {
             WebChatStoreLoader.store.dispatch({
@@ -18,8 +22,57 @@ export class NotificationHandler {
                     message
                 }
             });
+            NotificationHandler.announceToScreenReader(message);
             NotificationHandler.setFocusOnNotificationCloseButton();
         }
+    }
+
+    /**
+     * Announces a message immediately to screen readers via an aria-live="assertive" region.
+     * This ensures notifications interrupt the current screen reader output
+     * instead of waiting for it to finish reading other content.
+     */
+    private static announceToScreenReader(message: string) {
+        let liveRegion = document.getElementById(LIVE_REGION_ID);
+        if (!liveRegion) {
+            liveRegion = document.createElement("div");
+            liveRegion.id = LIVE_REGION_ID;
+            liveRegion.setAttribute("aria-live", "assertive");
+            liveRegion.setAttribute("role", "alert");
+            liveRegion.setAttribute("aria-atomic", "true");
+            // Visually hidden but accessible to screen readers
+            liveRegion.style.position = "absolute";
+            liveRegion.style.width = "1px";
+            liveRegion.style.height = "1px";
+            liveRegion.style.overflow = "hidden";
+            liveRegion.style.clip = "rect(0 0 0 0)";
+            liveRegion.style.clipPath = "inset(50%)";
+            liveRegion.style.whiteSpace = "nowrap";
+
+            const widgetContainer = document.getElementById(HtmlIdNames.MSLiveChatWidget);
+            (widgetContainer || document.body).appendChild(liveRegion);
+        }
+
+        // Clear first, then set after a microtask so the browser detects the change
+        // even when the same message is announced consecutively.
+        liveRegion.textContent = "";
+        requestAnimationFrame(() => {
+            if (liveRegion) {
+                liveRegion.textContent = message;
+            }
+        });
+
+        // Cancel any previous clear timer to avoid prematurely clearing a newer message
+        if (NotificationHandler.clearTimeoutId) {
+            clearTimeout(NotificationHandler.clearTimeoutId);
+        }
+
+        // Clear the live region after a delay so repeated identical messages still trigger
+        NotificationHandler.clearTimeoutId = setTimeout(() => {
+            if (liveRegion) {
+                liveRegion.textContent = "";
+            }
+        }, LIVE_REGION_CLEAR_DELAY_MS);
     }
 
     public static dismissNotification(id: string) {

--- a/chat-widget/src/contexts/common/ILiveChatWidgetLocalizedTexts.ts
+++ b/chat-widget/src/contexts/common/ILiveChatWidgetLocalizedTexts.ts
@@ -178,4 +178,18 @@ export interface ILiveChatWidgetLocalizedTexts {
      * {0} - e-mail address introduced
      */
     MIDDLEWARE_BANNER_FILE_EMAIL_ADDRESS_RECORDED_ERROR?: string;
+
+    /**
+     * Screen-reader prefix spoken before a success banner message, so SR users hear
+     * the explicit state word (e.g. "Success. Email will be sent after chat ends!").
+     * Include trailing spacing/punctuation as needed for the target locale.
+     */
+    MIDDLEWARE_SR_PREFIX_SUCCESS?: string;
+
+    /**
+     * Screen-reader prefix spoken before an error banner message, so SR users hear
+     * the explicit state word (e.g. "Error. Email foo@bar.com could not be saved...").
+     * Include trailing spacing/punctuation as needed for the target locale.
+     */
+    MIDDLEWARE_SR_PREFIX_ERROR?: string;
 }


### PR DESCRIPTION
[5983596](https://dynamicscrm.visualstudio.com/OneCRM/_workitems/edit/5983596/)

## Summary

- Email transcript notifications now announce a localized state-word prefix (`Success.` / `Error.`) via aria-live so screen readers hear the outcome immediately, without navigating to the banner.
- Submit focus goes directly from the dialog to the notification banner; skips the chat-widget shell detour that made NVDA/Narrator/VoiceOver announce "Enter Live Chat Widget" between the dialog and the banner.
- Adds two optional localized keys `MIDDLEWARE_SR_PREFIX_SUCCESS` / `MIDDLEWARE_SR_PREFIX_ERROR` (English defaults `"Success. "` / `"Error. "`) so the prefix can be translated per-locale via `middlewareLocalizedTexts`.

## What changed

| File | Change |
|---|---|
| `EmailTranscriptPaneStateful.tsx` | Prefix + `closeEmailTranscriptPane(false)` on submit |
| `defaultMiddlewareLocalizedTexts.ts` | English defaults for new keys |
| `ILiveChatWidgetLocalizedTexts.ts` | Two new optional fields (additive — non-breaking) |
| `utils.ts` | `announceMessageImmediately()` doc.body live-region helper |
| `NotificationHandler.ts` | `announceToScreenReader()` path on `notify()` |
| `EmailTranscriptPaneStateful.a11y.spec.tsx` | 9 unit tests covering success/error/cancel paths and localized prefix override |
| `automation_tests/e2e/areas/accessibility/emailTranscriptAnnouncement.spec.ts` | 4 E2E tests (auto-skip without `EMAIL_A11Y_E2E=1` + fixture) |

## Test plan

- [x] `yarn lint` clean
- [x] `yarn tsc --noEmit` clean
- [x] Unit tests: 9/9 new email pane tests pass; `localizedStringsBotInitialsMiddleware` 10/10 still pass
- [ ] Manual NVDA pass: submit success announces `"Success. Email will be sent..."`; focus lands on banner close button
- [ ] Manual NVDA pass: submit failure announces `"Error. Email <addr> could not be saved..."`
- [ ] Manual VoiceOver pass on macOS Safari
- [ ] Localized customer pass once `MIDDLEWARE_SR_PREFIX_*` translations land

## Non-breaking

All public-API additions are optional. No existing string defaults changed. Customers overriding `middlewareLocalizedTexts` continue to work; new keys fall back to English when omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)