### PR TITLE
chore(ci): add explicit least-privilege permissions to remaining workflows

### DIFF
--- a/.github/workflows/chat-components-pr.yml
+++ b/.github/workflows/chat-components-pr.yml
@@ -8,8 +8,12 @@ on:
     paths:
       - 'chat-components/**'
       - '.github/workflows/**'
-      
-jobs: 
+
+permissions:
+  contents: read       # For checkout
+  actions: write       # For downloading and uploading artifacts
+
+jobs:
   build:
     runs-on: windows-2022
     steps:

--- a/.github/workflows/chat-components-release-manual.yml
+++ b/.github/workflows/chat-components-release-manual.yml
@@ -3,7 +3,11 @@ name: chat-components-release-manual
 on:
   workflow_dispatch:
 
-jobs: 
+permissions:
+  contents: read       # For checkout
+  actions: write       # For downloading and uploading artifacts
+
+jobs:
   build:
     runs-on: windows-2022
     steps:

--- a/.github/workflows/chat-components-release.yml
+++ b/.github/workflows/chat-components-release.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'chat-components/**'
 
+permissions:
+  contents: read       # For checkout
+  actions: write       # For downloading and uploading artifacts
+
 jobs:
   build:
     if: github.repository == 'microsoft/omnichannel-chat-widget'

--- a/.github/workflows/chat-widget-release-manual.yml
+++ b/.github/workflows/chat-widget-release-manual.yml
@@ -3,7 +3,11 @@ name: chat-widget-release-manual
 on:
   workflow_dispatch:
 
-jobs: 
+permissions:
+  contents: read       # For checkout
+  actions: write       # For downloading and uploading artifacts
+
+jobs:
   build:
     runs-on: windows-2022
     steps:

--- a/.github/workflows/sync-issue-to-ado-work-item.yml
+++ b/.github/workflows/sync-issue-to-ado-work-item.yml
@@ -7,6 +7,9 @@ on:
   issue_comment:
     types: [created, edited, deleted]
 
+permissions:
+  contents: read       # workflow uses GH_PERSONAL_ACCESS_TOKEN secret, not GITHUB_TOKEN, for the ADO sync
+
 jobs:
   alert:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds explicit workflow-level `permissions:` blocks to five workflows that currently declare none:

| Workflow | Scope | Why |
|---|---|---|
| `chat-components-pr.yml` | `contents: read`, `actions: write` | PR validation; uses `actions/upload-artifact` for VRT failures |
| `chat-components-release-manual.yml` | `contents: read`, `actions: write` | Manual release; artifact upload, `npm publish` via NPM token (no GITHUB_TOKEN write) |
| `chat-components-release.yml` | `contents: read`, `actions: write` | Tag-triggered release; artifact upload |
| `chat-widget-release-manual.yml` | `contents: read`, `actions: write` | Manual release; artifact upload, `npm publish` via NPM token |
| `sync-issue-to-ado-work-item.yml` | `contents: read` | ADO sync uses `GH_PERSONAL_ACCESS_TOKEN` (external PAT), not `GITHUB_TOKEN` |

## Why

The repo already declares per-workflow `permissions:` in `chat-widget-pr.yml`, `chat-widget-release.yml`, `accessibility-scan.yml`, `accessibility-sr.yml`, `chat-component-release-npm-manual.yml`, `chat-widget-release-npm-manual.yml`, `npm-release.yml`, and `storybook-release.yml` — each using the `contents: read` + `actions: write` pattern with the inline comment `# For downloading and uploading artifacts`. This PR brings the remaining five workflows in line with that pattern.

For `sync-issue-to-ado-work-item.yml`, the workflow does not need any GITHUB_TOKEN write scope because the ADO sync action authenticates with `GH_PERSONAL_ACCESS_TOKEN` and `ADO_PERSONAL_ACCESS_TOKEN` secrets, not the default GITHUB_TOKEN.

## Verification

- YAML validity: `python3 -c "import yaml; yaml.safe_load(open(...))"` passes on each of the five files.
- No change to jobs, steps, or matrix. Only `permissions:` blocks added.

## Reference

- [GitHub docs — Modifying the permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)