### PR TITLE
chore: uptake chat-components 1.1.17-main.f21df63 to deliver iOS prechat dropdown fix

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 - [Mid-Auth] Added `isMidAuthEnabled` option passthrough to `getAuthToken` for Power Pages support
 
 ### Changed
+- Uptake `@microsoft/omnichannel-chat-components@1.1.17-main.f21df63` so consumers receive the iOS Safari prechat dropdown blank-option fix from #899
 - Updated outdated npm dependencies across packages.
 - Updated OC SDK package that has new ACS adapter for beta.6 w/ botframework
 - Update GitHub Actions (checkout, setup-node) from v2/v3 to v4 and Node.js from 20.x to 22.x across chat-widget workflows to address Node.js 20 deprecation in GitHub Actions

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
-    "@microsoft/omnichannel-chat-components": "1.1.17-main.d4c4cb2",
+    "@microsoft/omnichannel-chat-components": "1.1.17-main.f21df63",
     "@microsoft/omnichannel-chat-sdk": "1.11.9-main.da8219b",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -3643,10 +3643,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.1.14-main.9951e38.tgz#199903715de20373dbddbbf18b5d4ee9fc1b5a08"
   integrity sha512-bbgMmYmCKBzOrs/VGd/yPCn7bOoU0f2kTwAlX8Fl3MdfMgXL2DVGBJo5EsF4M3bFQDJITavTAbyii07aro4Mtw==
 
-"@microsoft/omnichannel-chat-components@1.1.17-main.d4c4cb2":
-  version "1.1.17-main.d4c4cb2"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-1.1.17-main.d4c4cb2.tgz#fe371e54bc1a502a05d6a92f5bd70c41472c1036"
-  integrity sha512-J3CJh3ER7aAHymxSGOxtGyJHTaTRf8qOj+3asN9BQuZgUMOikgtar8CSvV4nelTK49gNcx5B0F4cgQcuiIc/SQ==
+"@microsoft/omnichannel-chat-components@1.1.17-main.f21df63":
+  version "1.1.17-main.f21df63"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-1.1.17-main.f21df63.tgz#f8d448c29f6ad76be8ac7d08c3e4b90403bce099"
+  integrity sha512-C4RnOmqscII+cQAJIVHg6ezh+THPI2ZFO7ILPDYA2XSzmNmKk469HmROhIPCfCthX8uY/BArBsrblldiMahLXg==
   dependencies:
     "@fluentui/react" "^8.46.0"
     adaptivecards "^2.10.0"


### PR DESCRIPTION
## Why

PR #899 (commit `370ce43f`) fixed the **"additional blank option in the prechat survey dropdown on iOS Safari"** bug (ICM 51000000905069). The actual fix lives in `chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx`.

However, `chat-widget/package.json` is still pinning:
```
"@microsoft/omnichannel-chat-components": "1.1.17-main.d4c4cb2"
```
That version was published on **2026-03-30**, four days **before** PR #899 merged (2026-04-03), so every `@microsoft/omnichannel-chat-widget@1.8.4-main.*` prerelease — including `1.8.4-main.9284e84` currently shipping on the **public prod CDN** (`oc-cdn-public.azureedge.net/livechatwidget/v2scripts/`) — does **not** carry the fix at runtime. Verified by grepping the bundled `ocw.js` for the fix markers (`Fix iOS Safari blank space`, `Remove hidden placeholder option`) → 0 hits.

## What changes

| File | Change |
|---|---|
| `chat-widget/package.json` | Bump `@microsoft/omnichannel-chat-components` from `1.1.17-main.d4c4cb2` → `1.1.17-main.f21df63` (first chat-components prerelease published after #899; verified to contain the fix in `PreChatSurveyPane.js`) |
| `chat-widget/yarn.lock` | Refreshed entry with new tarball / integrity for `1.1.17-main.f21df63` |
| `CHANGE_LOG.md` | Added `[Unreleased] → Changed` entry describing the uptake |

## Verification

- Unpacked `@microsoft/omnichannel-chat-components@1.1.17-main.f21df63` and confirmed `lib/esm/components/prechatsurveypane/PreChatSurveyPane.js` contains the `// Fix iOS Safari blank space in <select> dropdowns` block.
- Locally built CRM.OmniChannel.LiveChatWidget with this chat-components version forced via `resolutions`; the "Yes/No" prechat dropdown on iOS Safari no longer renders the blank first row.

## Follow-up

After this PR merges and a new `1.8.4-main.<sha>` prerelease of `@microsoft/omnichannel-chat-widget` is published, LCW (`CRM.OmniChannel.LiveChatWidget/src/package.json`) needs a companion bump from `1.8.4-main.9284e84` to the new prerelease so the fix reaches prod CDN.

Related: ICM 51000000905069, PR #899