### PR TITLE
test(a11y): deterministic repro catchers for 5 remaining LCW a11y bugs

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Tests
-- [A11y] Added deterministic repro catchers (skipped by default; un-skip to validate fixes) for AB#5929337 (AdaptiveCard TalkBack non-radio duplicate labels), AB#3412046 (ChatButton browse-mode duplicate stops), AB#3012996 (agent profile name not announced), AB#6003259 (blank announcement live regions), AB#6093367 (focus trap leak across page reload), plus a passing regression guard for ConfirmationPane focus-trap install/cleanup symmetry
+- [A11y] Added deterministic repro catchers (skipped by default; un-skip to validate fixes) for internal tracking (AdaptiveCard TalkBack non-radio duplicate labels), internal tracking (ChatButton browse-mode duplicate stops), internal tracking (agent profile name not announced), internal tracking (blank announcement live regions), internal tracking (focus trap leak across page reload), plus a passing regression guard for ConfirmationPane focus-trap install/cleanup symmetry
 
 ### Fixed
 - [VRT] Stabilized post-chat survey pane snapshots by intercepting external survey iframe requests with a deterministic fixture
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file.
 - [A11y] Phase 2 utilities (`chat-widget/automation_tests/e2e/utility/`): `liveRegionObserver` (aria-live mutation observer), `keyboardLoop` (Tab/Shift+Tab traversal helpers), `a11yTree` (accessibility-tree shape assertions), `axeOnPage` (live-page axe runs)
 - [A11y] Phase 2 specs (`chat-widget/automation_tests/e2e/areas/accessibility/`): `citationCard` (link `title` attribute + single-link guarantee), `markdownAnchorMerge` (adjacent same-href anchors collapse to one tab stop), `mobileFocusTrap` (Pixel 5 emulation of the focus-trap regression class)
 - [A11y] Phase 3 utilities + scaffolding for screen-reader and keyboard layers: `expectTabOrder` (named tab-order assertion), `srAssert` (Guidepup-backed NVDA assertion + `phraseFor` lookup), `tools/accessibility/nvda-phrases.json` (event→phrase catalog with NVDA version pin), `tools/accessibility/setupNvda.ps1` (silent NVDA install for Windows runners), `focus-ring` and `focus-ring-forced-colors` Storybook screenshot profiles, `.github/workflows/accessibility-sr.yml` (soak-only, concurrency-limited NVDA spec workflow)
-- [A11y] Phase 3 specs: `keyboard/keyboardFlows.spec.ts` (6 critical-flow keyboard tests: open chat, send, attachment cycle, header reachability, Esc/close, re-open), `keyboard/skipLink.spec.ts` (`test.todo` placeholders documenting the skip-link / landmark gap), `sr-nvda/nvdaCriticalFlows.spec.ts` (10 NVDA spec sweep — auto-skips off-Windows / no-NVDA / no-`@guidepup/guidepup`), and `NotDeliveredTimestamp.a11y.test.tsx` RTL unit test asserting the retry control is a native `<button>` (regression catcher for AB#5376198)
+- [A11y] Phase 3 specs: `keyboard/keyboardFlows.spec.ts` (6 critical-flow keyboard tests: open chat, send, attachment cycle, header reachability, Esc/close, re-open), `keyboard/skipLink.spec.ts` (`test.todo` placeholders documenting the skip-link / landmark gap), `sr-nvda/nvdaCriticalFlows.spec.ts` (10 NVDA spec sweep — auto-skips off-Windows / no-NVDA / no-`@guidepup/guidepup`), and `NotDeliveredTimestamp.a11y.test.tsx` RTL unit test asserting the retry control is a native `<button>` (regression catcher for internal tracking)
 - [A11y] Per-package axe rule disable list (`accessibility-disable-rules.json`) covering 7 story-isolation rules (`landmark-one-main`, `page-has-heading-one`, `region`, `html-has-lang`, `html-lang-valid`, `document-title`, `bypass`) so axe results highlight real component issues instead of canvas artifacts. Drives chat-widget Storybook violations from 19 → 1 (the lone real `aria-command-name` finding remains as a tracked work item).
 - [A11y] `axeScan.cjs` extended with `--disable-rules`, `--gate-rules`, and `A11Y_SCAN_DISABLE_RULES` env support; new `yarn scan:a11y:axe:gated` script gates `image-alt` and `button-name` (currently 0 violations across both packages).
 - [Security] Added monitor-only HTML sanitization to gather telemetry before enforcing stricter allowlist rules (Phase 1). Tracks OrganizationId, ConversationId, RemovedTags, RemovedAttributes, and ExecutionTimeMs when content would be blocked by strict allowlist. Runs asynchronously to avoid message latency. Includes 27 unit tests.
@@ -69,7 +69,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed email transcript dialog persisting across conversations by resetting `showEmailTranscriptPane` state during chat close cleanup
-- [A11Y] Replace `<span role="button">` with native `<button>` for Retry element in failed message timestamp so screen readers announce "Retry, button" (AB#5376198)
+- [A11Y] Replace `<span role="button">` with native `<button>` for Retry element in failed message timestamp so screen readers announce "Retry, button" (internal tracking)
 - Fix iOS Safari auto-zoom on prechat survey input fields by setting default font-size to 16px for text input, multiline text input, and multichoice input elements
 - Fix iOS Safari blank space in prechat survey dropdown caused by hidden placeholder `<option>` in adaptive card `<select>` elements
 - Resolved underscores in a system message renders the text weirdly in iOS

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Tests
+- [A11y] Added deterministic repro catchers (skipped by default; un-skip to validate fixes) for AB#5929337 (AdaptiveCard TalkBack non-radio duplicate labels), AB#3412046 (ChatButton browse-mode duplicate stops), AB#3012996 (agent profile name not announced), AB#6003259 (blank announcement live regions), AB#6093367 (focus trap leak across page reload), plus a passing regression guard for ConfirmationPane focus-trap install/cleanup symmetry
+
 ### Fixed
 - [VRT] Stabilized post-chat survey pane snapshots by intercepting external survey iframe requests with a deterministic fixture
 - [A11y] Transfer system messages now reset cached agent names so later bot messages do not announce stale agents

--- a/chat-components/src/components/chatbutton/ChatButton.blankAnnouncements.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.blankAnnouncements.a11y.spec.tsx
@@ -12,7 +12,7 @@ import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonP
 import { defaultLoadingPaneProps } from "../loadingpane/common/defaultProps/defaultLoadingPaneProps";
 
 /**
- * Repro / catcher for AB#6003259 — screen reader announces hidden / irrelevant
+ * Repro / catcher for internal tracking — screen reader announces hidden / irrelevant
  * text such as "blank" while navigating the chat surface. NVDA / JAWS announce
  * "blank" when they encounter:
  *   - an element with an announceable role (button, link, textbox, listitem,
@@ -155,7 +155,7 @@ const summarize = (offenders: Element[]) =>
         classes: el.className
     }));
 
-describe("ChatButton — 'blank' / empty-name announcements (AB#6003259 regression guard)", () => {
+describe("ChatButton — 'blank' / empty-name announcements (internal tracking regression guard)", () => {
     it("no announceable role/tag in the chat-button subtree may have an empty accessible name", () => {
         const { container } = render(<ChatButton {...defaultChatButtonProps} />);
         const button = container.firstElementChild as HTMLElement;
@@ -179,7 +179,7 @@ describe("ChatButton — 'blank' / empty-name announcements (AB#6003259 regressi
     });
 });
 
-describe("LoadingPane — 'blank' / empty-name announcements (AB#6003259 regression guard)", () => {
+describe("LoadingPane — 'blank' / empty-name announcements (internal tracking regression guard)", () => {
     it("no announceable role/tag in the loading-pane subtree may have an empty accessible name", () => {
         const { container } = render(<LoadingPane {...defaultLoadingPaneProps} />);
         const pane = container.firstElementChild as HTMLElement;

--- a/chat-components/src/components/chatbutton/ChatButton.blankAnnouncements.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.blankAnnouncements.a11y.spec.tsx
@@ -1,0 +1,197 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "@testing-library/jest-dom/extend-expect";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { BroadcastServiceInitialize } from "../../services/BroadcastService";
+import ChatButton from "./ChatButton";
+import { IChatButtonProps } from "./interfaces/IChatButtonProps";
+import LoadingPane from "../loadingpane/LoadingPane";
+import React from "react";
+import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonProps";
+import { defaultLoadingPaneProps } from "../loadingpane/common/defaultProps/defaultLoadingPaneProps";
+
+/**
+ * Repro / catcher for AB#6003259 — screen reader announces hidden / irrelevant
+ * text such as "blank" while navigating the chat surface. NVDA / JAWS announce
+ * "blank" when they encounter:
+ *   - an element with an announceable role (button, link, textbox, listitem,
+ *     progressbar, etc.) that has an empty accessible name (no aria-label, no
+ *     aria-labelledby, no associated <label>, and no own text content), OR
+ *   - a live region (`aria-live="polite"` / `aria-live="assertive"`) that is
+ *     mounted with empty text content (each tick announces "blank").
+ *
+ * This catcher walks several rendered LCW surfaces and asserts neither pattern
+ * is present. Deterministic DOM contract — no SR needed.
+ *
+ * Surfaces covered today:
+ *   - ChatButton (default props) — regression guard; passes today.
+ *   - ChatButton with notification bubble forced visible at unreadCount=0 —
+ *     regression guard for the empty-live-region path; passes today.
+ *   - LoadingPane (default props) — regression guard; passes today.
+ *
+ * Scope note: the original bug surfaces inside WebChat-rendered chat session
+ * content (message bubbles, attachments, agent-supplied HTML), which is not
+ * reachable from chat-components unit tests. The Playwright catcher
+ * `automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts` on
+ * `chore/a11y-tooling-foundation` walks the full a11y tree of a built
+ * `dist/out.js` and is the right vehicle for enumerating per-offender fixes.
+ * Promote additional surfaces here as they are wired into the catcher harness.
+ */
+
+beforeAll(() => {
+    BroadcastServiceInitialize("testChannel");
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+const ANNOUNCEABLE_ROLES = new Set([
+    "button",
+    "link",
+    "textbox",
+    "combobox",
+    "listbox",
+    "listitem",
+    "menu",
+    "menuitem",
+    "checkbox",
+    "radio",
+    "switch",
+    "tab",
+    "treeitem",
+    "option",
+    "searchbox",
+    "progressbar",
+    "alert",
+    "status"
+]);
+
+const ANNOUNCEABLE_TAGS = new Set([
+    "button",
+    "a",
+    "input",
+    "select",
+    "textarea"
+]);
+
+const isInsideAriaHidden = (el: Element | null): boolean => {
+    let cursor: Element | null = el;
+    while (cursor) {
+        if (cursor.getAttribute("aria-hidden") === "true") return true;
+        cursor = cursor.parentElement;
+    }
+    return false;
+};
+
+const accessibleNameOf = (el: Element): string => {
+    const ariaLabel = (el.getAttribute("aria-label") || "").trim();
+    if (ariaLabel) return ariaLabel;
+    const labelledBy = (el.getAttribute("aria-labelledby") || "").trim();
+    if (labelledBy) {
+        const referenced = labelledBy
+            .split(/\s+/)
+            .map((id) => document.getElementById(id)?.textContent || "")
+            .join(" ")
+            .trim();
+        if (referenced) return referenced;
+    }
+    if (el.tagName.toLowerCase() === "input") {
+        const id = el.id;
+        if (id) {
+            const label = document.querySelector<HTMLLabelElement>(`label[for="${CSS.escape(id)}"]`);
+            const labelText = label?.textContent?.trim();
+            if (labelText) return labelText;
+        }
+        const placeholder = (el.getAttribute("placeholder") || "").trim();
+        if (placeholder) return placeholder;
+    }
+    if (el.tagName.toLowerCase() === "a") {
+        const title = (el.getAttribute("title") || "").trim();
+        if (title) return title;
+    }
+    return (el.textContent || "").trim();
+};
+
+const isAnnounceable = (el: Element): boolean => {
+    if (isInsideAriaHidden(el)) return false;
+    const role = (el.getAttribute("role") || "").toLowerCase();
+    if (role === "presentation" || role === "none") return false;
+    if (role && ANNOUNCEABLE_ROLES.has(role)) return true;
+    if (ANNOUNCEABLE_TAGS.has(el.tagName.toLowerCase())) {
+        // <input type="hidden"> is not announceable.
+        if (el.tagName.toLowerCase() === "input" &&
+            (el.getAttribute("type") || "").toLowerCase() === "hidden") {
+            return false;
+        }
+        return true;
+    }
+    return false;
+};
+
+const findEmptyAnnounceable = (root: HTMLElement): Element[] => {
+    return Array.from(root.querySelectorAll("*")).filter(
+        (el) => isAnnounceable(el) && accessibleNameOf(el) === ""
+    );
+};
+
+const findEmptyLiveRegions = (root: HTMLElement): Element[] => {
+    return Array.from(root.querySelectorAll("[aria-live]")).filter((el) => {
+        if (isInsideAriaHidden(el)) return false;
+        const live = (el.getAttribute("aria-live") || "").toLowerCase();
+        if (live !== "polite" && live !== "assertive") return false;
+        return (el.textContent || "").trim() === "";
+    });
+};
+
+const summarize = (offenders: Element[]) =>
+    offenders.map((el) => ({
+        tag: el.tagName.toLowerCase(),
+        id: el.id,
+        role: el.getAttribute("role"),
+        ariaLabel: el.getAttribute("aria-label"),
+        ariaLabelledBy: el.getAttribute("aria-labelledby"),
+        classes: el.className
+    }));
+
+describe("ChatButton — 'blank' / empty-name announcements (AB#6003259 regression guard)", () => {
+    it("no announceable role/tag in the chat-button subtree may have an empty accessible name", () => {
+        const { container } = render(<ChatButton {...defaultChatButtonProps} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+        expect(summarize(findEmptyAnnounceable(button))).toEqual([]);
+    });
+
+    it("no live region (aria-live=polite/assertive) in the chat-button subtree may be mounted with empty text", () => {
+        const props: IChatButtonProps = {
+            ...defaultChatButtonProps,
+            controlProps: {
+                ...defaultChatButtonProps.controlProps,
+                unreadMessageCount: "0",
+                hideNotificationBubble: false
+            }
+        };
+        const { container } = render(<ChatButton {...props} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+        expect(summarize(findEmptyLiveRegions(button))).toEqual([]);
+    });
+});
+
+describe("LoadingPane — 'blank' / empty-name announcements (AB#6003259 regression guard)", () => {
+    it("no announceable role/tag in the loading-pane subtree may have an empty accessible name", () => {
+        const { container } = render(<LoadingPane {...defaultLoadingPaneProps} />);
+        const pane = container.firstElementChild as HTMLElement;
+        expect(pane).not.toBeNull();
+        expect(summarize(findEmptyAnnounceable(pane))).toEqual([]);
+    });
+
+    it("no live region (aria-live=polite/assertive) in the loading-pane subtree may be mounted with empty text", () => {
+        const { container } = render(<LoadingPane {...defaultLoadingPaneProps} />);
+        const pane = container.firstElementChild as HTMLElement;
+        expect(pane).not.toBeNull();
+        expect(summarize(findEmptyLiveRegions(pane))).toEqual([]);
+    });
+});
+

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "@testing-library/jest-dom/extend-expect";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { BroadcastServiceInitialize } from "../../services/BroadcastService";
+import ChatButton from "./ChatButton";
+import React from "react";
+import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonProps";
+
+/**
+ * Repro / catcher for AB#3412046 — NVDA / JAWS in browse mode (virtual cursor)
+ * land on "Let's Chat, We're Online" multiple times when navigating with the
+ * down-arrow key.
+ *
+ * Root cause in code: `ChatButton` renders a Fluent UI `<Stack role="button">`
+ * with `tabIndex={0}` whose accessible name is computed from its visible
+ * children — a `<Label>` for the title (e.g. "Let's Chat!") and a `<Label>`
+ * for the subtitle (e.g. "We're online."). In browse mode, NVDA / JAWS treat
+ * the button itself AND each inner text node as separate virtual-cursor stops,
+ * each carrying the same announceable name fragments. There is no
+ * `aria-label` set by default, and the inner labels are not marked
+ * `aria-hidden="true"` (which is what would collapse them into a single
+ * announcement under the button container).
+ *
+ * Catcher contract: in the rendered chat-button subtree, at most ONE element
+ * may expose each of the title / subtitle strings as an announceable name
+ * source. An "announceable name source" here is:
+ *   - an `aria-label` attribute on a focusable / role-bearing element, OR
+ *   - a visible `<Label>` (or other text-bearing element) that is NOT
+ *     `aria-hidden="true"` and is not nested inside an element that is
+ *     `aria-hidden="true"`.
+ *
+ * Expected to FAIL today: the rendered DOM contains BOTH the title text node
+ * AND the subtitle text node as bare visible text, and the parent Stack has
+ * no `aria-label` to consolidate them. Browse-mode therefore sees three
+ * stops (button, title, subtitle) all carrying the same combined name.
+ */
+
+beforeAll(() => {
+    BroadcastServiceInitialize("testChannel");
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+const isInsideAriaHidden = (el: Element | null): boolean => {
+    let cursor: Element | null = el;
+    while (cursor) {
+        if (cursor.getAttribute("aria-hidden") === "true") return true;
+        cursor = cursor.parentElement;
+    }
+    return false;
+};
+
+const visibleTextElementsMatching = (root: HTMLElement, text: string): Element[] => {
+    return Array.from(root.querySelectorAll("*")).filter((el) => {
+        if (isInsideAriaHidden(el)) return false;
+        // Only count leaf-ish text-bearing elements (don't double-count
+        // ancestors whose textContent obviously aggregates children).
+        const ownText = Array.from(el.childNodes)
+            .filter((n) => n.nodeType === Node.TEXT_NODE)
+            .map((n) => (n.textContent || "").trim())
+            .join(" ")
+            .trim();
+        return ownText === text;
+    });
+};
+
+describe("ChatButton — browse-mode duplicate stops (AB#3412046)", () => {
+    it("title text 'Let's Chat!' must appear as an announceable name source AT MOST ONCE in the chat-button subtree", () => {
+        const { container } = render(<ChatButton {...defaultChatButtonProps} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+
+        const titleStops = visibleTextElementsMatching(button, "Let's Chat!");
+        // Today: the <Label id="...-title"> carries the text AND its parent
+        // Stack has no aria-label, so screen readers see at least two stops
+        // (the button container + the inner label). The catcher allows ZERO
+        // visible duplicates because the consolidated name should come from
+        // a single aria-label on the button.
+        expect(titleStops.length).toBeLessThanOrEqual(0);
+    });
+
+    it("subtitle text 'We're online.' must appear as an announceable name source AT MOST ONCE in the chat-button subtree", () => {
+        const { container } = render(<ChatButton {...defaultChatButtonProps} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+
+        const subtitleStops = visibleTextElementsMatching(button, "We're online.");
+        expect(subtitleStops.length).toBeLessThanOrEqual(0);
+    });
+
+    it("the chat-button container must own a single consolidated aria-label so browse mode lands on it once", () => {
+        const { container } = render(<ChatButton {...defaultChatButtonProps} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+        // Either the container has a non-empty aria-label, OR every inner
+        // text-bearing descendant is aria-hidden so the computed name comes
+        // from the inner text exactly once with no extra browse-mode stops.
+        const hasAriaLabel = !!(button.getAttribute("aria-label") || "").trim();
+        const innerVisibleText = visibleTextElementsMatching(button, "Let's Chat!").length
+            + visibleTextElementsMatching(button, "We're online.").length;
+        // Today: hasAriaLabel === false (default ariaLabel is undefined) AND
+        // innerVisibleText > 0. The catcher requires at least one of these
+        // to flip.
+        expect(hasAriaLabel || innerVisibleText === 0).toBe(true);
+    });
+});

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
@@ -6,7 +6,11 @@ import { cleanup, render } from "@testing-library/react";
 import { BroadcastServiceInitialize } from "../../services/BroadcastService";
 import ChatButton from "./ChatButton";
 import React from "react";
+import { defaultChatButtonControlProps } from "./common/defaultProps/defaultChatButtonControlProps";
 import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonProps";
+
+const expectedTitle = defaultChatButtonControlProps.titleText as string;
+const expectedSubtitle = defaultChatButtonControlProps.subtitleText as string;
 
 /**
  * Repro / catcher for internal tracking — NVDA / JAWS in browse mode (virtual cursor)
@@ -23,9 +27,10 @@ import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonP
  * `aria-hidden="true"` (which is what would collapse them into a single
  * announcement under the button container).
  *
- * Catcher contract: in the rendered chat-button subtree, at most ONE element
- * may expose each of the title / subtitle strings as an announceable name
- * source. An "announceable name source" here is:
+ * Catcher contract: the title / subtitle strings must NOT appear as
+ * additional announceable name sources in the chat-button subtree (only the
+ * single consolidated aria-label on the role=button container should name the
+ * button). An "announceable name source" here is:
  *   - an `aria-label` attribute on a focusable / role-bearing element, OR
  *   - a visible `<Label>` (or other text-bearing element) that is NOT
  *     `aria-hidden="true"` and is not nested inside an element that is
@@ -74,12 +79,12 @@ const visibleTextElementsMatching = (root: HTMLElement, text: string): Element[]
  * source. Mirrors the chat-widget `*.unfixed.a11y.spec.tsx` convention.
  */
 describe.skip("ChatButton — browse-mode duplicate stops (internal tracking)", () => {
-    it("title text 'Let's Chat!' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree", () => {
+    it(`title text '${expectedTitle}' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree`, () => {
         const { container } = render(<ChatButton {...defaultChatButtonProps} />);
         const button = container.firstElementChild as HTMLElement;
         expect(button).not.toBeNull();
 
-        const titleStops = visibleTextElementsMatching(button, "Let's Chat!");
+        const titleStops = visibleTextElementsMatching(button, expectedTitle);
         // The visible title should be excluded from the accessibility tree
         // (e.g. via aria-hidden on the text container) so the announced name
         // comes solely from the consolidated aria-label on the button. Any
@@ -88,12 +93,12 @@ describe.skip("ChatButton — browse-mode duplicate stops (internal tracking)", 
         expect(titleStops.length).toBe(0);
     });
 
-    it("subtitle text 'We're online.' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree", () => {
+    it(`subtitle text '${expectedSubtitle}' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree`, () => {
         const { container } = render(<ChatButton {...defaultChatButtonProps} />);
         const button = container.firstElementChild as HTMLElement;
         expect(button).not.toBeNull();
 
-        const subtitleStops = visibleTextElementsMatching(button, "We're online.");
+        const subtitleStops = visibleTextElementsMatching(button, expectedSubtitle);
         expect(subtitleStops.length).toBe(0);
     });
 
@@ -105,8 +110,8 @@ describe.skip("ChatButton — browse-mode duplicate stops (internal tracking)", 
         // text-bearing descendant is aria-hidden so the computed name comes
         // from the inner text exactly once with no extra browse-mode stops.
         const hasAriaLabel = !!(button.getAttribute("aria-label") || "").trim();
-        const innerVisibleText = visibleTextElementsMatching(button, "Let's Chat!").length
-            + visibleTextElementsMatching(button, "We're online.").length;
+        const innerVisibleText = visibleTextElementsMatching(button, expectedTitle).length
+            + visibleTextElementsMatching(button, expectedSubtitle).length;
         // Today: hasAriaLabel === false (default ariaLabel is undefined) AND
         // innerVisibleText > 0. The catcher requires at least one of these
         // to flip.

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
@@ -68,7 +68,12 @@ const visibleTextElementsMatching = (root: HTMLElement, text: string): Element[]
     });
 };
 
-describe("ChatButton — browse-mode duplicate stops (AB#3412046)", () => {
+/**
+ * SKIPPED until the source fix lands. Un-skip the describe below to validate
+ * the fix to AB#3412046; the suite is expected to FAIL today against unfixed
+ * source. Mirrors the chat-widget `*.unfixed.a11y.spec.tsx` convention.
+ */
+describe.skip("ChatButton — browse-mode duplicate stops (AB#3412046)", () => {
     it("title text 'Let's Chat!' must appear as an announceable name source AT MOST ONCE in the chat-button subtree", () => {
         const { container } = render(<ChatButton {...defaultChatButtonProps} />);
         const button = container.firstElementChild as HTMLElement;

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
@@ -74,27 +74,27 @@ const visibleTextElementsMatching = (root: HTMLElement, text: string): Element[]
  * source. Mirrors the chat-widget `*.unfixed.a11y.spec.tsx` convention.
  */
 describe.skip("ChatButton — browse-mode duplicate stops (AB#3412046)", () => {
-    it("title text 'Let's Chat!' must appear as an announceable name source AT MOST ONCE in the chat-button subtree", () => {
+    it("title text 'Let's Chat!' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree", () => {
         const { container } = render(<ChatButton {...defaultChatButtonProps} />);
         const button = container.firstElementChild as HTMLElement;
         expect(button).not.toBeNull();
 
         const titleStops = visibleTextElementsMatching(button, "Let's Chat!");
-        // Today: the <Label id="...-title"> carries the text AND its parent
-        // Stack has no aria-label, so screen readers see at least two stops
-        // (the button container + the inner label). The catcher allows ZERO
-        // visible duplicates because the consolidated name should come from
-        // a single aria-label on the button.
-        expect(titleStops.length).toBeLessThanOrEqual(0);
+        // The visible title should be excluded from the accessibility tree
+        // (e.g. via aria-hidden on the text container) so the announced name
+        // comes solely from the consolidated aria-label on the button. Any
+        // exposed text-bearing element with this exact text creates an
+        // additional browse-mode stop and reproduces AB#3412046.
+        expect(titleStops.length).toBe(0);
     });
 
-    it("subtitle text 'We're online.' must appear as an announceable name source AT MOST ONCE in the chat-button subtree", () => {
+    it("subtitle text 'We're online.' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree", () => {
         const { container } = render(<ChatButton {...defaultChatButtonProps} />);
         const button = container.firstElementChild as HTMLElement;
         expect(button).not.toBeNull();
 
         const subtitleStops = visibleTextElementsMatching(button, "We're online.");
-        expect(subtitleStops.length).toBeLessThanOrEqual(0);
+        expect(subtitleStops.length).toBe(0);
     });
 
     it("the chat-button container must own a single consolidated aria-label so browse mode lands on it once", () => {

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.unfixed.a11y.spec.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonProps";
 
 /**
- * Repro / catcher for AB#3412046 — NVDA / JAWS in browse mode (virtual cursor)
+ * Repro / catcher for internal tracking — NVDA / JAWS in browse mode (virtual cursor)
  * land on "Let's Chat, We're Online" multiple times when navigating with the
  * down-arrow key.
  *
@@ -70,10 +70,10 @@ const visibleTextElementsMatching = (root: HTMLElement, text: string): Element[]
 
 /**
  * SKIPPED until the source fix lands. Un-skip the describe below to validate
- * the fix to AB#3412046; the suite is expected to FAIL today against unfixed
+ * the fix to internal tracking; the suite is expected to FAIL today against unfixed
  * source. Mirrors the chat-widget `*.unfixed.a11y.spec.tsx` convention.
  */
-describe.skip("ChatButton — browse-mode duplicate stops (AB#3412046)", () => {
+describe.skip("ChatButton — browse-mode duplicate stops (internal tracking)", () => {
     it("title text 'Let's Chat!' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree", () => {
         const { container } = render(<ChatButton {...defaultChatButtonProps} />);
         const button = container.firstElementChild as HTMLElement;
@@ -84,7 +84,7 @@ describe.skip("ChatButton — browse-mode duplicate stops (AB#3412046)", () => {
         // (e.g. via aria-hidden on the text container) so the announced name
         // comes solely from the consolidated aria-label on the button. Any
         // exposed text-bearing element with this exact text creates an
-        // additional browse-mode stop and reproduces AB#3412046.
+        // additional browse-mode stop and reproduces internal tracking.
         expect(titleStops.length).toBe(0);
     });
 

--- a/chat-widget/automation_tests/customlivechatwidgets/AgentProfileNameWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/AgentProfileNameWidget.html
@@ -10,7 +10,7 @@
 
 <body style="margin: 0">
   <script>
-    // Designer-mode widget for AB#3012996 — NVDA must read the agent's profile
+    // Designer-mode widget for internal tracking — NVDA must read the agent's profile
     // name when navigating to messages sent by the agent. The mock messages
     // arrive with `from.role: "agent"` and a real-looking display name so the
     // bot-initials middleware can update ACTIVITY_BOT_SAID_ALT to the agent's

--- a/chat-widget/automation_tests/customlivechatwidgets/AgentProfileNameWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/AgentProfileNameWidget.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Agent Profile Name Widget</title>
+</head>
+
+<body style="margin: 0">
+  <script>
+    // Designer-mode widget for AB#3012996 — NVDA must read the agent's profile
+    // name when navigating to messages sent by the agent. The mock messages
+    // arrive with `from.role: "agent"` and a real-looking display name so the
+    // bot-initials middleware can update ACTIVITY_BOT_SAID_ALT to the agent's
+    // name. The Playwright catcher (agentProfileName.spec.ts) asserts the
+    // rendered transcript carries the agent name on each agent message group.
+    function lcw() {
+      return {
+        styleProps: {
+          generalStyles: {
+            width: "360px",
+            height: "560px",
+            bottom: "20px",
+            right: "20px"
+          }
+        },
+        chatButtonProps: {
+          styleProps: {
+            generalStyleProps: {
+              position: "absolute"
+            }
+          }
+        },
+        mock: {
+          type: "designer",
+          mockMessages: [
+            {
+              text: "Hi, I'm Sara. How can I help you today?",
+              type: "message",
+              from: { id: "agent-1", name: "Sara Smith", role: "agent" }
+            },
+            {
+              text: "Let me check that for you.",
+              type: "message",
+              from: { id: "agent-1", name: "Sara Smith", role: "agent" }
+            }
+          ]
+        }
+      }
+    }
+
+    function setData(key, data, type) {
+      try {
+        if (type === "localStorage") {
+          localStorage.setItem(key, data);
+        } else {
+          sessionStorage.setItem(key, data);
+        }
+      } catch (error) {
+        console.error("logging to first party failed!")
+      }
+    }
+
+    function getData(key, type) {
+      if (type == "localStorage") {
+        return localStorage.getItem(key);
+      } else {
+        return sessionStorage.getItem(key);
+      }
+    }
+  </script>
+  <div id="oc-lcw-container" style="width: 370px; height: 100%; position: fixed; right: 0; bottom: 0"></div>
+  <script id="oc-lcw-script" src="../../dist/out.js" data-customization-callback="lcw" data-org-id="7d223c8d-6ef4-4eb9-9d96-47b5eea8afd2" data-app-id="aa10489e-a0c3-44d6-967c-f0a533653962"
+    data-org-url="https://unq7d223c8d6ef44eb99d9647b5eea8a-crm.oc.crmlivetie.com" set-data-callback="setData" get-data-callback="getData"></script>
+</body>
+
+</html>

--- a/chat-widget/automation_tests/customlivechatwidgets/AgentProfileNameWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/AgentProfileNameWidget.html
@@ -64,7 +64,7 @@
     }
 
     function getData(key, type) {
-      if (type == "localStorage") {
+      if (type === "localStorage") {
         return localStorage.getItem(key);
       } else {
         return sessionStorage.getItem(key);

--- a/chat-widget/automation_tests/customlivechatwidgets/BlankAnnouncementsWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/BlankAnnouncementsWidget.html
@@ -74,7 +74,7 @@
     }
 
     function getData(key, type) {
-      if (type == "localStorage") {
+      if (type === "localStorage") {
         return localStorage.getItem(key);
       } else {
         return sessionStorage.getItem(key);

--- a/chat-widget/automation_tests/customlivechatwidgets/BlankAnnouncementsWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/BlankAnnouncementsWidget.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Blank Announcements Widget</title>
+</head>
+
+<body style="margin: 0">
+  <script>
+    // Designer-mode widget for AB#6003259 — NVDA reads "blank" past empty
+    // live regions / unlabeled elements. This mock renders an actual
+    // transcript (bot + agent messages) so the WebChat surface, attachment
+    // surface and live regions are all instantiated. The Playwright catcher
+    // then walks the full a11y tree of #oc-lcw-container and asserts no
+    // announceable role has an empty accessible name.
+    function lcw() {
+      return {
+        styleProps: {
+          generalStyles: {
+            width: "360px",
+            height: "560px",
+            bottom: "20px",
+            right: "20px"
+          }
+        },
+        chatButtonProps: {
+          styleProps: {
+            generalStyleProps: {
+              position: "absolute"
+            }
+          }
+        },
+        mock: {
+          type: "designer",
+          mockMessages: [
+            {
+              text: "Hello! How can I help today?",
+              type: "message",
+              from: { id: "bot-1", name: "Contoso Bot", role: "bot" }
+            },
+            {
+              text: "Hi, I'm Sara. Let me take a look.",
+              type: "message",
+              from: { id: "agent-1", name: "Sara Smith", role: "agent" }
+            },
+            {
+              text: "Visit [our docs](https://microsoft.com) for more.",
+              type: "message",
+              from: { id: "agent-1", name: "Sara Smith", role: "agent" }
+            },
+            {
+              text: "Thanks!",
+              type: "message",
+              from: { id: "user-1", name: "Visitor", role: "user" }
+            }
+          ]
+        }
+      }
+    }
+
+    function setData(key, data, type) {
+      try {
+        if (type === "localStorage") {
+          localStorage.setItem(key, data);
+        } else {
+          sessionStorage.setItem(key, data);
+        }
+      } catch (error) {
+        console.error("logging to first party failed!")
+      }
+    }
+
+    function getData(key, type) {
+      if (type == "localStorage") {
+        return localStorage.getItem(key);
+      } else {
+        return sessionStorage.getItem(key);
+      }
+    }
+  </script>
+  <div id="oc-lcw-container" style="width: 370px; height: 100%; position: fixed; right: 0; bottom: 0"></div>
+  <script id="oc-lcw-script" src="../../dist/out.js" data-customization-callback="lcw" data-org-id="7d223c8d-6ef4-4eb9-9d96-47b5eea8afd2" data-app-id="aa10489e-a0c3-44d6-967c-f0a533653962"
+    data-org-url="https://unq7d223c8d6ef44eb99d9647b5eea8a-crm.oc.crmlivetie.com" set-data-callback="setData" get-data-callback="getData"></script>
+</body>
+
+</html>

--- a/chat-widget/automation_tests/customlivechatwidgets/BlankAnnouncementsWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/BlankAnnouncementsWidget.html
@@ -10,7 +10,7 @@
 
 <body style="margin: 0">
   <script>
-    // Designer-mode widget for AB#6003259 — NVDA reads "blank" past empty
+    // Designer-mode widget for internal tracking — NVDA reads "blank" past empty
     // live regions / unlabeled elements. This mock renders an actual
     // transcript (bot + agent messages) so the WebChat surface, attachment
     // surface and live regions are all instantiated. The Playwright catcher

--- a/chat-widget/automation_tests/customlivechatwidgets/FocusTrapAfterLinkWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/FocusTrapAfterLinkWidget.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Focus Trap After Link Widget</title>
+</head>
+
+<body style="margin: 0">
+  <button id="host-before-chat">Before chat</button>
+  <script>
+    // Designer-mode widget for AB#6093367 — after a user activates a link
+    // inside the chat transcript and the page reloads (persistent storage
+    // rehydrates the widget), focus is "trapped" inside the widget: pressing
+    // Tab from outside the widget doesn't enter, and pressing Tab inside
+    // never reaches the page's `host-after-chat` button.
+    //
+    // The mock renders a message containing a real link so the Playwright
+    // catcher can click it (preventDefault'd in the spec so no navigation),
+    // reload, and walk Tab order from the host page to verify the
+    // post-widget button is still reachable.
+    function lcw() {
+      return {
+        styleProps: {
+          generalStyles: {
+            width: "360px",
+            height: "560px",
+            bottom: "20px",
+            right: "20px"
+          }
+        },
+        chatButtonProps: {
+          styleProps: {
+            generalStyleProps: {
+              position: "absolute"
+            }
+          }
+        },
+        mock: {
+          type: "designer",
+          mockMessages: [
+            {
+              text: "See [our docs](https://microsoft.com) for details.",
+              type: "message",
+              from: { id: "bot-1", name: "Contoso Bot", role: "bot" }
+            }
+          ]
+        }
+      }
+    }
+
+    function setData(key, data, type) {
+      try {
+        if (type === "localStorage") {
+          localStorage.setItem(key, data);
+        } else {
+          sessionStorage.setItem(key, data);
+        }
+      } catch (error) {
+        console.error("logging to first party failed!")
+      }
+    }
+
+    function getData(key, type) {
+      if (type == "localStorage") {
+        return localStorage.getItem(key);
+      } else {
+        return sessionStorage.getItem(key);
+      }
+    }
+  </script>
+  <div id="oc-lcw-container" style="width: 370px; height: 100%; position: fixed; right: 0; bottom: 0"></div>
+  <button id="host-after-chat">After chat</button>
+  <script id="oc-lcw-script" src="../../dist/out.js" data-customization-callback="lcw" data-org-id="7d223c8d-6ef4-4eb9-9d96-47b5eea8afd2" data-app-id="aa10489e-a0c3-44d6-967c-f0a533653962"
+    data-org-url="https://unq7d223c8d6ef44eb99d9647b5eea8a-crm.oc.crmlivetie.com" set-data-callback="setData" get-data-callback="getData"></script>
+</body>
+
+</html>

--- a/chat-widget/automation_tests/customlivechatwidgets/FocusTrapAfterLinkWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/FocusTrapAfterLinkWidget.html
@@ -11,7 +11,7 @@
 <body style="margin: 0">
   <button id="host-before-chat">Before chat</button>
   <script>
-    // Designer-mode widget for AB#6093367 — after a user activates a link
+    // Designer-mode widget for internal tracking — after a user activates a link
     // inside the chat transcript and the page reloads (persistent storage
     // rehydrates the widget), focus is "trapped" inside the widget: pressing
     // Tab from outside the widget doesn't enter, and pressing Tab inside

--- a/chat-widget/automation_tests/customlivechatwidgets/FocusTrapAfterLinkWidget.html
+++ b/chat-widget/automation_tests/customlivechatwidgets/FocusTrapAfterLinkWidget.html
@@ -64,7 +64,7 @@
     }
 
     function getData(key, type) {
-      if (type == "localStorage") {
+      if (type === "localStorage") {
         return localStorage.getItem(key);
       } else {
         return sessionStorage.getItem(key);

--- a/chat-widget/automation_tests/e2e/areas/accessibility/agentProfileName.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/agentProfileName.spec.ts
@@ -1,0 +1,108 @@
+import { Browser, BrowserContext } from "playwright";
+import * as playwright from "playwright";
+import * as fs from "fs";
+import * as path from "path";
+import { TestSettings } from "../../../configuration/test-settings";
+import { BasePage } from "../../pages/base.page";
+import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
+
+// These tests require a built widget bundle (dist/out.js) and Microsoft Edge.
+// They are skipped on CI where the bundle is not available.
+const widgetBundlePath = path.resolve(__dirname, "../../../../dist/out.js");
+const widgetBundleExists = fs.existsSync(widgetBundlePath);
+const describeIfBuilt = widgetBundleExists ? describe : describe.skip;
+
+/**
+ * Repro / catcher for AB#3012996 — NVDA does NOT read the agent's profile
+ * name when navigating to messages sent by the agent.
+ *
+ * The bot-initials middleware (PR #907) updates ACTIVITY_BOT_SAID_ALT from the
+ * incoming activity's `from.name`. WebChat then renders that string into a
+ * visually-hidden `ScreenReaderText` element inside the message group's
+ * `role="group"` container, which screen readers announce when the user
+ * navigates onto each message.
+ *
+ * Catcher: load a designer-mode widget whose mock messages have
+ * `from.role: "agent"` and a known agent display name ("Sara Smith"),
+ * open the chat, and assert that:
+ *   1. At least one `[role='group']` exists in the transcript.
+ *   2. Every group that contains a "said:" / "attached:" SR fragment
+ *      includes the agent's profile name (not the avatar initials).
+ *   3. No group's SR fragment matches the bare-initials pattern
+ *      (e.g. "SS said:") that the original bug reported as the offender.
+ */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+describeIfBuilt("agent profile name accessibility (AB#3012996)", () => {
+    let newBrowser: Browser;
+    let context: BrowserContext;
+    let page: BasePage;
+
+    beforeEach(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        newBrowser = await playwright[TestSettings.Browsers as any].launch(
+            { ...TestSettings.LaunchBrowserSettings, channel: "msedge" }
+        );
+        context = await newBrowser.newContext({
+            viewport: TestSettings.Viewport,
+        });
+    });
+
+    afterEach(async () => {
+        if (context) {
+            await context.close();
+        }
+        if (newBrowser) {
+            await newBrowser.close();
+        }
+    });
+
+    test("agent messages must include the agent's profile name in screen-reader text", async () => {
+        page = new BasePage(await context.newPage());
+        await page.openLiveChatWidget("customlivechatwidgets/AgentProfileNameWidget.html");
+        await page.waitUntilLiveChatSelectorIsVisible(
+            CustomLiveChatWidgetConstants.LiveChatButtonId
+        );
+
+        const chatButton = await page.Page.$(CustomLiveChatWidgetConstants.LiveChatButtonId);
+        await chatButton!.click();
+
+        await page.waitUntilLiveChatSelectorIsVisible(
+            ".webchat__basic-transcript",
+            5,
+            undefined,
+            5000
+        );
+
+        // Wait until WebChat has rendered the role="group" wrappers with their
+        // ScreenReaderText "X said:" prefixes.
+        await page.Page.waitForFunction(() => {
+            const groups = document.querySelectorAll("[role='group']");
+            return Array.from(groups).some((g) => {
+                const text = (g.textContent || "").toLowerCase();
+                return text.includes("said") || text.includes("attached");
+            });
+        }, undefined, { timeout: 15000 });
+
+        const srTexts = await page.Page.evaluate(() => {
+            const groups = document.querySelectorAll("[role='group']");
+            const out: string[] = [];
+            groups.forEach((g) => {
+                const text = (g.textContent || "").trim();
+                if (text.toLowerCase().includes("said") || text.toLowerCase().includes("attached")) {
+                    const srText = g.firstElementChild?.textContent?.trim() || text;
+                    out.push(srText);
+                }
+            });
+            return out;
+        });
+
+        expect(srTexts.length).toBeGreaterThan(0);
+        for (const sr of srTexts) {
+            // Must NOT be bare initials like "SS said:" — that's the original
+            // 2022 bug. Must contain the agent's actual display name.
+            expect(sr).not.toMatch(/^[A-Z]{1,3} said:/);
+            expect(sr).not.toMatch(/^[A-Z]{1,3} attached:/);
+            expect(sr).toContain("Sara Smith");
+        }
+    });
+});

--- a/chat-widget/automation_tests/e2e/areas/accessibility/agentProfileName.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/agentProfileName.spec.ts
@@ -1,16 +1,11 @@
 import { Browser, BrowserContext } from "playwright";
 import * as playwright from "playwright";
-import * as fs from "fs";
-import * as path from "path";
 import { TestSettings } from "../../../configuration/test-settings";
 import { BasePage } from "../../pages/base.page";
 import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 
-// These tests require a built widget bundle (dist/out.js) and Microsoft Edge.
-// They are skipped on CI where the bundle is not available.
-const widgetBundlePath = path.resolve(__dirname, "../../../../dist/out.js");
-const widgetBundleExists = fs.existsSync(widgetBundlePath);
-const describeIfBuilt = widgetBundleExists ? describe : describe.skip;
+// SKIPPED until the source fix lands. Un-skip to validate fix to AB#3012996.
+const describeIfBuilt = describe.skip;
 
 /**
  * Repro / catcher for AB#3012996 — NVDA does NOT read the agent's profile

--- a/chat-widget/automation_tests/e2e/areas/accessibility/agentProfileName.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/agentProfileName.spec.ts
@@ -4,11 +4,11 @@ import { TestSettings } from "../../../configuration/test-settings";
 import { BasePage } from "../../pages/base.page";
 import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 
-// SKIPPED until the source fix lands. Un-skip to validate fix to AB#3012996.
+// SKIPPED until the source fix lands. Un-skip to validate fix to internal tracking.
 const describeIfBuilt = describe.skip;
 
 /**
- * Repro / catcher for AB#3012996 — NVDA does NOT read the agent's profile
+ * Repro / catcher for internal tracking — NVDA does NOT read the agent's profile
  * name when navigating to messages sent by the agent.
  *
  * The bot-initials middleware (PR #907) updates ACTIVITY_BOT_SAID_ALT from the
@@ -27,7 +27,7 @@ const describeIfBuilt = describe.skip;
  *      (e.g. "SS said:") that the original bug reported as the offender.
  */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-describeIfBuilt("agent profile name accessibility (AB#3012996)", () => {
+describeIfBuilt("agent profile name accessibility (internal tracking)", () => {
     let newBrowser: Browser;
     let context: BrowserContext;
     let page: BasePage;

--- a/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
@@ -8,7 +8,9 @@ import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 import { findAll, getA11yTree } from "../../utility/a11yTree";
 
 const widgetBundlePath = path.resolve(__dirname, "../../../../dist/out.js");
-const describeIfBuilt = fs.existsSync(widgetBundlePath) ? describe : describe.skip;
+// SKIPPED until the source fix lands. Un-skip to validate fix to AB#6003259.
+// (Repro upgraded from the previous passing assertion to a deterministic catcher.)
+const describeIfBuilt = describe.skip;
 
 /**
  * Repro catcher for blank-announcements — Screen reader announces blank / hidden

--- a/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
@@ -48,15 +48,19 @@ describeIfBuilt("blank announcements - empty accessible names (blank-announcemen
 
     test("no announceable a11y node should have an empty accessible name", async () => {
         page = new BasePage(await context.newPage());
-        await page.openLiveChatWidget("customlivechatwidgets/FocusTrapWidget.html");
+        // Use a designer-mode widget that renders a real transcript (bot,
+        // agent, user, link) so the WebChat surface, attachment surface,
+        // and live regions are all instantiated. The prior FocusTrapWidget
+        // mock did not exercise WebChat content where the bug actually lives.
+        await page.openLiveChatWidget("customlivechatwidgets/BlankAnnouncementsWidget.html");
         await page.waitUntilLiveChatSelectorIsVisible(
             CustomLiveChatWidgetConstants.LiveChatButtonId
         );
 
-        // Open the widget so prechat / loading / chat surfaces render.
         const chatButton = await page.Page.$(CustomLiveChatWidgetConstants.LiveChatButtonId);
         await chatButton!.click();
-        await page.Page.waitForTimeout(2500);
+        // Give WebChat enough time to render all mock messages.
+        await page.Page.waitForTimeout(4000);
 
         const tree = await getA11yTree(page.Page, "#oc-lcw-container");
         const offenders = findAll(tree, (n: any) => {
@@ -66,12 +70,32 @@ describeIfBuilt("blank announcements - empty accessible names (blank-announcemen
             return name.length === 0;
         });
 
-        if (offenders.length > 0) {
-            // Surface the first few for debugging.
+        // Additional check: aria-live regions (role="status" / "alert") that
+        // ARE in the a11y tree but have an empty accessible name will be
+        // announced as "blank" by NVDA when their content changes. They're
+        // not in ANNOUNCEABLE_ROLES because they're rarely focusable, but
+        // they are the textbook NVDA-"blank" source.
+        const LIVE_ROLES = new Set(["status", "alert", "log", "timer"]);
+        const liveOffenders = findAll(tree, (n: any) => {
+            if (!n || !n.role) return false;
+            if (!LIVE_ROLES.has(n.role)) return false;
+            const name = (n.name || "").trim();
+            return name.length === 0;
+        });
+
+        const allOffenders = [...offenders, ...liveOffenders];
+        if (allOffenders.length > 0) {
+            const summary = allOffenders.slice(0, 10).map((o: any) => ({ role: o.role, value: o.value, name: o.name }));
+            // Write to a file so jest's stdout truncation doesn't hide them.
+            try {
+                fs.writeFileSync(
+                    path.resolve(__dirname, "../../../reports/blankAnnouncements.offenders.json"),
+                    JSON.stringify(summary, null, 2)
+                );
+            } catch { /* ignore */ }
             // eslint-disable-next-line no-console
-            console.log("Empty-name offenders (first 5):",
-                offenders.slice(0, 5).map((o: any) => ({ role: o.role, value: o.value })));
+            console.log("Blank-name offenders (first 10):", JSON.stringify(summary));
         }
-        expect(offenders.length).toBe(0);
+        expect(allOffenders.length).toBe(0);
     });
 });

--- a/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
@@ -7,7 +7,7 @@ import { BasePage } from "../../pages/base.page";
 import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 import { findAll, getA11yTree } from "../../utility/a11yTree";
 
-// SKIPPED until the source fix lands. Un-skip to validate fix to AB#6003259.
+// SKIPPED until the source fix lands. Un-skip to validate fix to internal tracking.
 // (Repro upgraded from the previous passing assertion to a deterministic catcher.)
 const describeIfBuilt = describe.skip;
 

--- a/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/blankAnnouncements.spec.ts
@@ -7,7 +7,6 @@ import { BasePage } from "../../pages/base.page";
 import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 import { findAll, getA11yTree } from "../../utility/a11yTree";
 
-const widgetBundlePath = path.resolve(__dirname, "../../../../dist/out.js");
 // SKIPPED until the source fix lands. Un-skip to validate fix to AB#6003259.
 // (Repro upgraded from the previous passing assertion to a deterministic catcher.)
 const describeIfBuilt = describe.skip;

--- a/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
@@ -99,11 +99,15 @@ describeIfBuilt("focus trap after page reload (focus-trap-after-reload)", () => 
         await page.Page.reload({ waitUntil: "domcontentloaded" });
         await page.Page.waitForTimeout(2500);
 
-        // Precondition: widget rehydrated to the open state.
+        // Precondition: widget rehydrated to the open state. If this fails,
+        // the catcher cannot exercise the bug scenario (no modal pane = no
+        // focus trap to leak). Hard-fail here so a missed rehydration cannot
+        // produce a false green.
         const widgetOpen = await page.Page.evaluate(() => {
             return !!document.querySelector("#oc-lcw-container [role='log']")
                 || !!document.querySelector("#oc-lcw-container .webchat__basic-transcript");
         });
+        expect(widgetOpen).toBe(true);
 
         // Drive focus to the page's host-before-chat button, then Tab
         // forward through the widget. If focus is trapped inside the
@@ -119,7 +123,7 @@ describeIfBuilt("focus trap after page reload (focus-trap-after-reload)", () => 
 
         if (!landedOnAfter) {
             // eslint-disable-next-line no-console
-            console.log("Focus never reached host-after-chat after reload; widgetOpen =", widgetOpen);
+            console.log("Focus never reached host-after-chat after reload (widget rehydrated open).");
         }
         expect(landedOnAfter).toBe(true);
     });

--- a/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
@@ -49,33 +49,63 @@ describeIfBuilt("focus trap after page reload (focus-trap-after-reload)", () => 
         if (newBrowser) await newBrowser.close();
     });
 
-    test("after page reload, focus should land on a focusable element (not <body>) and Tab should respect the widget's focus trap", async () => {
+    test("after link activation + page reload, Tab from page should still reach controls outside the widget", async () => {
         page = new BasePage(await context.newPage());
-        await page.openLiveChatWidget("customlivechatwidgets/FocusTrapWidget.html");
+        // Use a widget mock that renders a real message containing a link AND
+        // exposes host-page buttons before/after the widget so we can walk
+        // the Tab order to prove focus isn't trapped inside the rehydrated
+        // widget.
+        await page.openLiveChatWidget("customlivechatwidgets/FocusTrapAfterLinkWidget.html");
         await page.waitUntilLiveChatSelectorIsVisible(
             CustomLiveChatWidgetConstants.LiveChatButtonId
         );
 
-        // Open the widget first so a non-trivial DOM is persisted.
+        // Open the widget and wait for the transcript to render.
         const chatButton = await page.Page.$(CustomLiveChatWidgetConstants.LiveChatButtonId);
         await chatButton!.click();
-        await page.Page.waitForTimeout(1500);
+        await page.Page.waitForTimeout(3000);
+
+        // Intercept the link click so it doesn't navigate. The bug
+        // surfaces from the *activation* + reload sequence, not from
+        // actual navigation.
+        await page.Page.evaluate(() => {
+            document.querySelectorAll<HTMLAnchorElement>("a[href]").forEach(a => {
+                a.addEventListener("click", e => e.preventDefault(), true);
+            });
+        });
+
+        const links = await page.Page.$$("#oc-lcw-container a[href]");
+        if (links.length > 0) {
+            await links[0].click();
+            await page.Page.waitForTimeout(500);
+        }
 
         // Reload — persistent storage should rehydrate widget state.
         await page.Page.reload({ waitUntil: "domcontentloaded" });
-        await page.Page.waitForTimeout(1500);
+        await page.Page.waitForTimeout(2500);
 
-        // After reload: focused element must NOT be <body>. A trapped focus
-        // would leave activeElement === body when no element claims focus.
-        const activeTag = await page.Page.evaluate(() => {
-            const a = document.activeElement as HTMLElement | null;
-            return a ? a.tagName.toLowerCase() : null;
+        // Precondition: widget rehydrated to the open state.
+        const widgetOpen = await page.Page.evaluate(() => {
+            return !!document.querySelector("#oc-lcw-container [role='log']")
+                || !!document.querySelector("#oc-lcw-container .webchat__basic-transcript");
         });
 
-        // Catcher assertion: today, after reload, activeElement is <body>
-        // and no focus ring is visible. After fix it should be the chat
-        // button (or another widget-owned focusable).
-        expect(activeTag).not.toBe("body");
-        expect(activeTag).not.toBeNull();
+        // Drive focus to the page's host-before-chat button, then Tab
+        // forward through the widget. If focus is trapped inside the
+        // rehydrated widget, Tab will NEVER land on host-after-chat.
+        await page.Page.focus("#host-before-chat");
+        let landedOnAfter = false;
+        for (let i = 0; i < 60; i++) {
+            await page.Page.keyboard.press("Tab");
+            const id = await page.Page.evaluate(() =>
+                (document.activeElement as HTMLElement | null)?.id || "");
+            if (id === "host-after-chat") { landedOnAfter = true; break; }
+        }
+
+        if (!landedOnAfter) {
+            // eslint-disable-next-line no-console
+            console.log("Focus never reached host-after-chat after reload; widgetOpen =", widgetOpen);
+        }
+        expect(landedOnAfter).toBe(true);
     });
 });

--- a/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
@@ -7,7 +7,9 @@ import { BasePage } from "../../pages/base.page";
 import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 
 const widgetBundlePath = path.resolve(__dirname, "../../../../dist/out.js");
-const describeIfBuilt = fs.existsSync(widgetBundlePath) ? describe : describe.skip;
+// SKIPPED until the source fix lands. Un-skip to validate fix to AB#6093367.
+// (Repro upgraded from the previous passing assertion to a deterministic catcher.)
+const describeIfBuilt = describe.skip;
 
 /**
  * Repro catcher for focus-trap-after-reload (AB#6093367) — After the user

--- a/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
@@ -10,25 +10,30 @@ const widgetBundlePath = path.resolve(__dirname, "../../../../dist/out.js");
 const describeIfBuilt = fs.existsSync(widgetBundlePath) ? describe : describe.skip;
 
 /**
- * Repro catcher for focus-trap-after-reload — After the user activates an external link
- * inside an open chat and the page reloads (persistent storage rehydrates
- * the widget into the open state), focus is "trapped" inside the widget
- * with no visible focus indicator AND Tab cannot move out. The widget
- * survives the reload (because of persistent storage) but its focus trap
- * never re-arms correctly.
+ * Repro catcher for focus-trap-after-reload (AB#6093367) — After the user
+ * activates a link inside an open chat and the page reloads (persistent
+ * storage rehydrates the widget into the open state), focus is "trapped"
+ * inside the widget with no escape via Tab.
  *
- * Catcher: open the widget, activate a link, reload the page, and assert
- * that:
- *   1. The widget rehydrates to the open state (precondition).
- *   2. `document.activeElement` is a focusable element WITH a visible
- *      focus ring (i.e. matches `:focus-visible` or has a non-zero
- *      outline / box-shadow).
- *   3. Pressing Tab moves focus to a different focusable element OR
- *      stays inside a properly-armed focus trap (i.e. NEVER lands on
- *      `<body>` with no focus indicator anywhere).
+ * Trigger condition discovered: the bug surfaces when a modal pane
+ * (Confirmation / Citation / EmailTranscript) is OPEN at reload time.
+ * The pane's `preventFocusToMoveOutOfElement` focus-trap effect
+ * re-installs on rehydrate, but the surrounding rehydrate flow leaves
+ * focus / Tab handlers in a state where Tab from the host page cannot
+ * traverse out of the widget.
  *
- * NOTE: Marked best-effort. Real verification needs NVDA/JAWS — see
- * BUG_STATUS.md.
+ * Sequence:
+ *   1. Open the widget so a transcript renders.
+ *   2. Click an in-chat link (preventDefault'd so no nav).
+ *   3. Click the header close ("X") button → opens the close-chat
+ *      confirmation pane → installs a focus trap.
+ *   4. Reload the page.
+ *   5. Drive focus to a host-page button BEFORE the widget, then
+ *      press Tab up to 60 times. Assert focus reaches the host-page
+ *      button AFTER the widget.
+ *
+ * Today the catcher FAILS deterministically: Tab never reaches the
+ * post-widget button — focus is trapped inside the rehydrated widget.
  */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -78,6 +83,17 @@ describeIfBuilt("focus trap after page reload (focus-trap-after-reload)", () => 
         if (links.length > 0) {
             await links[0].click();
             await page.Page.waitForTimeout(500);
+        }
+
+        // Trigger the close-chat confirmation pane so a focus trap is live
+        // across the reload. This is the production scenario that the
+        // designer-mode mock could not otherwise reproduce: a modal pane
+        // open at reload time forces the rehydrate path to re-install
+        // its `preventFocusToMoveOutOfElement` trap.
+        const closeBtn = await page.Page.$("#lcw-header-close-button");
+        if (closeBtn) {
+            await closeBtn.click();
+            await page.Page.waitForTimeout(800);
         }
 
         // Reload — persistent storage should rehydrate widget state.

--- a/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
@@ -4,12 +4,12 @@ import { TestSettings } from "../../../configuration/test-settings";
 import { BasePage } from "../../pages/base.page";
 import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 
-// SKIPPED until the source fix lands. Un-skip to validate fix to AB#6093367.
+// SKIPPED until the source fix lands. Un-skip to validate fix to internal tracking.
 // (Repro upgraded from the previous passing assertion to a deterministic catcher.)
 const describeIfBuilt = describe.skip;
 
 /**
- * Repro catcher for focus-trap-after-reload (AB#6093367) — After the user
+ * Repro catcher for focus-trap-after-reload (internal tracking) — After the user
  * activates a link inside an open chat and the page reloads (persistent
  * storage rehydrates the widget into the open state), focus is "trapped"
  * inside the widget with no escape via Tab.

--- a/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
@@ -1,12 +1,9 @@
 import { Browser, BrowserContext } from "playwright";
 import * as playwright from "playwright";
-import * as fs from "fs";
-import * as path from "path";
 import { TestSettings } from "../../../configuration/test-settings";
 import { BasePage } from "../../pages/base.page";
 import { CustomLiveChatWidgetConstants } from "e2e/utility/constants";
 
-const widgetBundlePath = path.resolve(__dirname, "../../../../dist/out.js");
 // SKIPPED until the source fix lands. Un-skip to validate fix to AB#6093367.
 // (Repro upgraded from the previous passing assertion to a deterministic catcher.)
 const describeIfBuilt = describe.skip;

--- a/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
+++ b/chat-widget/automation_tests/e2e/areas/accessibility/focusTrapAfterReload.spec.ts
@@ -31,8 +31,8 @@ const describeIfBuilt = describe.skip;
  *      press Tab up to 60 times. Assert focus reaches the host-page
  *      button AFTER the widget.
  *
- * Today the catcher FAILS deterministically: Tab never reaches the
- * post-widget button — focus is trapped inside the rehydrated widget.
+ * The source fix lands in a stacked PR. When un-skipped, this catcher should
+ * pass against the fix and fail against unfixed code.
  */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -89,11 +89,22 @@ describeIfBuilt("focus trap after page reload (focus-trap-after-reload)", () => 
         // designer-mode mock could not otherwise reproduce: a modal pane
         // open at reload time forces the rehydrate path to re-install
         // its `preventFocusToMoveOutOfElement` trap.
+        // Hard-assert the close button was found. A missed selector here would
+        // mean no confirmation pane opens, the widget rehydrates as the regular
+        // chat surface, the Tab walk traverses an open chat with no trap
+        // installed, and the catcher would go green for the wrong reason.
         const closeBtn = await page.Page.$("#lcw-header-close-button");
-        if (closeBtn) {
-            await closeBtn.click();
-            await page.Page.waitForTimeout(800);
-        }
+        expect(closeBtn).not.toBeNull();
+        await closeBtn!.click();
+        await page.Page.waitForTimeout(800);
+
+        // Verify the confirmation pane actually opened — this is the modal
+        // surface whose focus trap must survive the reload.
+        const paneOpened = await page.Page.evaluate(() => {
+            return !!document.querySelector("[id*='confirmation' i],[id*='ConfirmationPane' i]")
+                || !!document.querySelector("[role='dialog']");
+        });
+        expect(paneOpened).toBe(true);
 
         // Reload — persistent storage should rehydrate widget state.
         await page.Page.reload({ waitUntil: "domcontentloaded" });

--- a/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.focusTrapCleanup.a11y.spec.tsx
+++ b/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.focusTrapCleanup.a11y.spec.tsx
@@ -11,7 +11,7 @@ import { EmailTranscriptPaneStateful } from "../emailtranscriptpanestateful/Emai
 import React from "react";
 
 /**
- * Regression-guard catcher for AB#6093367 (focus trap after page reload).
+ * Regression-guard catcher for internal tracking (focus trap after page reload).
  *
  * The production repro path requires a modal pane (Confirmation, Citation,
  * EmailTranscript) to be open across a page reload — the persistent-storage
@@ -88,7 +88,7 @@ interface PaneCase {
     render: () => { unmount: () => void };
 }
 
-describe("Modal-pane focus traps must release on unmount (AB#6093367 regression guard)", () => {
+describe("Modal-pane focus traps must release on unmount (internal tracking regression guard)", () => {
     let preventSpy: jest.SpyInstance;
     let trapCleanups: jest.Mock[];
 

--- a/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.focusTrapCleanup.a11y.spec.tsx
+++ b/chat-widget/src/components/confirmationpanestateful/ConfirmationPaneStateful.focusTrapCleanup.a11y.spec.tsx
@@ -1,0 +1,182 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "@testing-library/jest-dom";
+
+import * as utils from "../../common/utils";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { ConfirmationPaneStateful } from "./ConfirmationPaneStateful";
+import { CitationPaneStateful } from "../citationpanestateful/CitationPaneStateful";
+import { EmailTranscriptPaneStateful } from "../emailtranscriptpanestateful/EmailTranscriptPaneStateful";
+import React from "react";
+
+/**
+ * Regression-guard catcher for AB#6093367 (focus trap after page reload).
+ *
+ * The production repro path requires a modal pane (Confirmation, Citation,
+ * EmailTranscript) to be open across a page reload — the persistent-storage
+ * rehydrate restores the pane, the pane re-installs its focus trap via
+ * `preventFocusToMoveOutOfElement`, but if the trap is *not* paired with a
+ * matching cleanup the trap will outlive the pane and Tab will be trapped
+ * inside the now-stale region (matching the bug report: "focus trapped in
+ * Live Chat after link activation + page reload").
+ *
+ * Designer-mode E2E (focusTrapAfterReload.spec.ts) cannot exercise the real
+ * rehydrate path. This unit catcher pins the invariant that the most
+ * likely fix-regression source — a pane forgetting to `return cleanup`
+ * from its focus-trap effect — fails loudly here.
+ *
+ * The contract under test:
+ *   1. On mount, the pane MUST call `preventFocusToMoveOutOfElement` so a
+ *      focus trap is installed for the modal lifetime.
+ *   2. On unmount, the cleanup function returned by
+ *      `preventFocusToMoveOutOfElement` MUST be invoked, releasing the
+ *      Tab/Shift+Tab keydown listeners on the pane's first/last focusable
+ *      elements. Without this, listeners outlive the pane and trap focus
+ *      in stale DOM after the pane is torn down (e.g. on rehydrate).
+ */
+
+const mockDispatch = jest.fn();
+const mockState: { current: any } = { current: undefined };
+const mockFacadeChatSDK = { emailLiveChatTranscript: jest.fn() };
+
+jest.mock("@microsoft/omnichannel-chat-components", () => ({
+    BroadcastService: {
+        postMessage: jest.fn(),
+        getMessageByEventName: jest.fn(() => ({
+            subscribe: () => ({ unsubscribe: jest.fn() })
+        }))
+    },
+    ConfirmationPane: () => null,
+    CitationPane: () => null,
+    InputValidationPane: () => null
+}));
+
+jest.mock("../../hooks/useChatContextStore", () => ({
+    __esModule: true,
+    default: () => [mockState.current, mockDispatch]
+}));
+
+jest.mock("../../hooks/useFacadeChatSDKStore", () => ({
+    __esModule: true,
+    default: () => [mockFacadeChatSDK]
+}));
+
+jest.mock("../dimlayer/DimLayer", () => ({
+    DimLayer: () => null
+}));
+
+jest.mock("../citationpanestateful/CitationDim", () => ({
+    __esModule: true,
+    default: () => null
+}));
+
+const buildState = () => ({
+    appStates: {
+        previousElementIdOnFocusBeforeModalOpen: "previous-button",
+        preChatResponseEmail: ""
+    },
+    domainStates: {
+        liveChatContext: {},
+        globalDir: "ltr",
+        middlewareLocalizedTexts: {}
+    }
+});
+
+interface PaneCase {
+    name: string;
+    render: () => { unmount: () => void };
+}
+
+describe("Modal-pane focus traps must release on unmount (AB#6093367 regression guard)", () => {
+    let preventSpy: jest.SpyInstance;
+    let trapCleanups: jest.Mock[];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockState.current = buildState();
+        trapCleanups = [];
+
+        // Capture each call's cleanup so we can assert it ran on unmount.
+        preventSpy = jest.spyOn(utils, "preventFocusToMoveOutOfElement")
+            .mockImplementation(() => {
+                const c = jest.fn();
+                trapCleanups.push(c);
+                return c;
+            });
+        jest.spyOn(utils, "findAllFocusableElement").mockReturnValue(null as any);
+        jest.spyOn(utils, "findParentFocusableElementsWithoutChildContainer").mockReturnValue([] as any);
+        jest.spyOn(utils, "setTabIndices").mockImplementation(() => undefined);
+        jest.spyOn(utils, "createTimer").mockReturnValue({ milliSecondsElapsed: 0 } as any);
+        jest.spyOn(utils, "setFocusOnElement").mockImplementation(() => undefined);
+        jest.spyOn(utils, "setFocusOnSendBox").mockImplementation(() => undefined);
+        jest.spyOn(utils, "announceMessageImmediately").mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        cleanup();
+        jest.restoreAllMocks();
+    });
+
+    const cases: PaneCase[] = [
+        {
+            name: "ConfirmationPaneStateful",
+            render: () => render(<ConfirmationPaneStateful />)
+        },
+        {
+            name: "CitationPaneStateful",
+            render: () => render(
+                <CitationPaneStateful
+                    id="ocw-citation-pane"
+                    title="Citation"
+                    contentHtml="<p>cite</p>"
+                    onClose={() => undefined}
+                />
+            )
+        },
+        {
+            name: "EmailTranscriptPaneStateful",
+            render: () => render(<EmailTranscriptPaneStateful />)
+        }
+    ];
+
+    for (const c of cases) {
+        describe(c.name, () => {
+            it("installs a focus trap on mount and releases it on unmount", () => {
+                const { unmount } = c.render();
+
+                // 1. The pane MUST install a focus trap on mount.
+                expect(preventSpy).toHaveBeenCalled();
+                expect(trapCleanups.length).toBeGreaterThanOrEqual(1);
+
+                const installedCleanup = trapCleanups[trapCleanups.length - 1];
+                expect(installedCleanup).not.toHaveBeenCalled();
+
+                // 2. On unmount, the cleanup MUST run — otherwise the Tab
+                //    handlers outlive the pane and trap focus in stale DOM.
+                unmount();
+                expect(installedCleanup).toHaveBeenCalledTimes(1);
+            });
+        });
+    }
+
+    it("multiple mount/unmount cycles do not leak trap cleanups", () => {
+        // Simulates the rehydrate scenario: pane comes and goes across
+        // reload-equivalent state transitions. Every install must be
+        // matched by a release; otherwise stale Tab handlers accumulate
+        // on the document and Tab is trapped after the pane is gone.
+        const r1 = render(<ConfirmationPaneStateful />);
+        r1.unmount();
+
+        const r2 = render(<ConfirmationPaneStateful />);
+        r2.unmount();
+
+        const r3 = render(<ConfirmationPaneStateful />);
+        r3.unmount();
+
+        expect(trapCleanups.length).toBe(3);
+        for (const c of trapCleanups) {
+            expect(c).toHaveBeenCalledTimes(1);
+        }
+    });
+});

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.unfixed.a11y.spec.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.unfixed.a11y.spec.tsx
@@ -324,7 +324,7 @@ describe("AdaptiveCardAccessibilityWrapper — compact dropdowns (dropdown-doubl
 // post-mutation output must expose at most one announce-able name source per
 // input. They are expected to FAIL today because the wrapper only handles
 // `input[type=radio]`.
-describe("AdaptiveCardAccessibilityWrapper — TalkBack duplicate labels on non-radio elements (AB#5929337)", () => {
+describe.skip("AdaptiveCardAccessibilityWrapper — TalkBack duplicate labels on non-radio elements (AB#5929337)", () => {
     const buildLabelledInput = (
         type: "text" | "date" | "number" | "checkbox",
         id: string,

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.unfixed.a11y.spec.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.unfixed.a11y.spec.tsx
@@ -313,50 +313,108 @@ describe("AdaptiveCardAccessibilityWrapper — compact dropdowns (dropdown-doubl
     });
 });
 
-describe.skip("AdaptiveCardAccessibilityWrapper — TalkBack labels on non-radio elements (talkback-duplicate-label regression guard)", () => {
-    it("talkback-duplicate-label: Input.Text fields inside an adaptive card must not have BOTH visible <label> and aria-label that duplicate (TalkBack reads twice)", async () => {
-        // Best-effort regression catcher: TalkBack double-reads when both an
-        // associated <label> AND aria-label resolve to the same string. This
-        // catcher is a DOM proxy — true verification requires a TalkBack pass.
+// AB#5929337 — TalkBack reads adaptive-card element labels TWICE.
+// PR #911 patched the radio case via `aria-hidden` on label/spacer siblings,
+// but every other Input.* type (Text, Date, Number, Toggle, ChoiceSet expanded
+// non-radio) is still rendered with BOTH an associated <label for> AND an
+// aria-label / aria-labelledby resolving to the same string. TalkBack walks
+// each accessibility node independently and reads the duplicated name.
+//
+// These cases are deterministic DOM-contract assertions: the wrapper's
+// post-mutation output must expose at most one announce-able name source per
+// input. They are expected to FAIL today because the wrapper only handles
+// `input[type=radio]`.
+describe("AdaptiveCardAccessibilityWrapper — TalkBack duplicate labels on non-radio elements (AB#5929337)", () => {
+    const buildLabelledInput = (
+        type: "text" | "date" | "number" | "checkbox",
+        id: string,
+        labelText: string
+    ): HTMLElement => {
+        // Mirrors what the AdaptiveCards renderer produces for Input.Text /
+        // Input.Date / Input.Number / Input.Toggle: a visible <label for="...">
+        // AND aria-label/aria-labelledby on the input that resolve to the same
+        // string.
+        const wrapper = document.createElement("div");
+        wrapper.className = "ac-input-container";
+        const label = document.createElement("label");
+        label.id = `${id}-lbl`;
+        label.setAttribute("for", id);
+        label.textContent = labelText;
+        const input = document.createElement("input");
+        input.type = type;
+        input.id = id;
+        input.className = "ac-input";
+        input.setAttribute("aria-label", labelText);
+        input.setAttribute("aria-labelledby", `${id}-lbl`);
+        wrapper.appendChild(label);
+        wrapper.appendChild(input);
+        return wrapper;
+    };
+
+    const countAnnouncedSources = (
+        container: HTMLElement,
+        inputId: string,
+        expectedName: string
+    ): number => {
+        const input = container.querySelector(`#${CSS.escape(inputId)}`) as HTMLElement | null;
+        if (!input) return 0;
+        const ariaLabel = input.getAttribute("aria-label");
+        const ariaLabelledBy = input.getAttribute("aria-labelledby");
+        const visibleLabel = container.querySelector(
+            `label[for="${CSS.escape(inputId)}"]:not([aria-hidden='true'])`
+        );
+        const sources: (string | undefined | null)[] = [
+            ariaLabel,
+            ariaLabelledBy
+                ? (document.getElementById(ariaLabelledBy)?.textContent || "").trim()
+                : undefined,
+            visibleLabel?.textContent?.trim()
+        ];
+        return sources.filter((s) => s === expectedName).length;
+    };
+
+    const renderCardWith = async (factory: () => HTMLElement) => {
         const { container } = render(
             <AdaptiveCardAccessibilityWrapper>
                 <div className="ac-adaptiveCard" />
             </AdaptiveCardAccessibilityWrapper>
         );
         const card = container.querySelector(".ac-adaptiveCard") as HTMLElement;
-
         await act(async () => {
-            const wrapper = document.createElement("div");
-            wrapper.className = "ac-input-container";
-            const label = document.createElement("label");
-            label.id = "name-lbl";
-            label.setAttribute("for", "name-input");
-            label.textContent = "Name";
-            const input = document.createElement("input");
-            input.type = "text";
-            input.id = "name-input";
-            input.setAttribute("aria-label", "Name");
-            input.setAttribute("aria-labelledby", "name-lbl");
-            wrapper.appendChild(label);
-            wrapper.appendChild(input);
-            card.appendChild(wrapper);
+            card.appendChild(factory());
             observerInstance.trigger();
         });
+        return container;
+    };
 
-        const input = container.querySelector("input#name-input") as HTMLElement;
-        // After fix: at most ONE of {aria-label, aria-labelledby pointing to
-        // a visible <label for=...>} resolves to "Name".
-        const ariaLabel = input.getAttribute("aria-label");
-        const ariaLabelledBy = input.getAttribute("aria-labelledby");
-        const visibleLabel = container.querySelector(
-            "label[for='name-input']:not([aria-hidden='true'])"
+    it("Input.Text: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("text", "name-input", "Name"));
+        expect(countAnnouncedSources(container, "name-input", "Name")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.Date: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("date", "dob-input", "Date of birth"));
+        expect(countAnnouncedSources(container, "dob-input", "Date of birth")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.Number: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("number", "qty-input", "Quantity"));
+        expect(countAnnouncedSources(container, "qty-input", "Quantity")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.Toggle: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("checkbox", "subscribe-input", "Subscribe"));
+        expect(countAnnouncedSources(container, "subscribe-input", "Subscribe")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.ChoiceSet (expanded, non-radio checkbox style): visible <label for> AND aria-labelledby must not duplicate", async () => {
+        // isMultiSelect: true on Input.ChoiceSet renders as <input type="checkbox">
+        // wrapped exactly like the radio case the wrapper already handles, but
+        // the wrapper's selector is scoped to input[type='radio'] so checkboxes
+        // are not patched.
+        const container = await renderCardWith(() =>
+            buildLabelledInput("checkbox", "topics-1", "Updates")
         );
-        const sources = [
-            ariaLabel,
-            ariaLabelledBy && (document.getElementById(ariaLabelledBy)?.textContent || "").trim(),
-            visibleLabel?.textContent?.trim()
-        ].filter(Boolean);
-        const duplicates = sources.filter((s) => s === "Name").length;
-        expect(duplicates).toBeLessThanOrEqual(1);
+        expect(countAnnouncedSources(container, "topics-1", "Updates")).toBeLessThanOrEqual(1);
     });
 });

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.unfixed.a11y.spec.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.unfixed.a11y.spec.tsx
@@ -313,7 +313,7 @@ describe("AdaptiveCardAccessibilityWrapper — compact dropdowns (dropdown-doubl
     });
 });
 
-// AB#5929337 — TalkBack reads adaptive-card element labels TWICE.
+// internal tracking — TalkBack reads adaptive-card element labels TWICE.
 // PR #911 patched the radio case via `aria-hidden` on label/spacer siblings,
 // but every other Input.* type (Text, Date, Number, Toggle, ChoiceSet expanded
 // non-radio) is still rendered with BOTH an associated <label for> AND an
@@ -324,7 +324,7 @@ describe("AdaptiveCardAccessibilityWrapper — compact dropdowns (dropdown-doubl
 // post-mutation output must expose at most one announce-able name source per
 // input. They are expected to FAIL today because the wrapper only handles
 // `input[type=radio]`.
-describe.skip("AdaptiveCardAccessibilityWrapper — TalkBack duplicate labels on non-radio elements (AB#5929337)", () => {
+describe.skip("AdaptiveCardAccessibilityWrapper — TalkBack duplicate labels on non-radio elements (internal tracking)", () => {
     const buildLabelledInput = (
         type: "text" | "date" | "number" | "checkbox",
         id: string,


### PR DESCRIPTION
## Summary
Introduces 5 deterministic, failing-by-design accessibility repro catchers for the remaining LCW a11y bugs (catchers cover: ChatButton browse-mode duplicate stops, blank live-region announcements, AdaptiveCard duplicate labels on non-radio inputs, agent profile name announcement, and focus-trap leak across page reload).

## Status
All 5 catchers are intentionally wrapped in `describe.skip` on this foundation branch so CI stays green. Each accompanying source-fix PR un-skips its own catcher.

## Companion fix PRs
- #946 - ChatButton browse-mode
- #947 - WebChat toaster live region label
- #948 - AdaptiveCard non-radio duplicate labels
- #949 - Agent profile name e2e regression guard
- #950 - Focus trap leak across page reload

## Notes
- Catcher specs include diagnostic offender JSON output to `reports/` for debugging when run locally with the sample bundle built.
- Internal tracking IDs intentionally redacted.