### PR TITLE
fix(a11y): consolidate ChatButton browse-mode announcement

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -32,7 +32,7 @@ All notable changes to this project will be documented in this file.
 - [A11y] Phase 2 utilities (`chat-widget/automation_tests/e2e/utility/`): `liveRegionObserver` (aria-live mutation observer), `keyboardLoop` (Tab/Shift+Tab traversal helpers), `a11yTree` (accessibility-tree shape assertions), `axeOnPage` (live-page axe runs)
 - [A11y] Phase 2 specs (`chat-widget/automation_tests/e2e/areas/accessibility/`): `citationCard` (link `title` attribute + single-link guarantee), `markdownAnchorMerge` (adjacent same-href anchors collapse to one tab stop), `mobileFocusTrap` (Pixel 5 emulation of the focus-trap regression class)
 - [A11y] Phase 3 utilities + scaffolding for screen-reader and keyboard layers: `expectTabOrder` (named tab-order assertion), `srAssert` (Guidepup-backed NVDA assertion + `phraseFor` lookup), `tools/accessibility/nvda-phrases.json` (event→phrase catalog with NVDA version pin), `tools/accessibility/setupNvda.ps1` (silent NVDA install for Windows runners), `focus-ring` and `focus-ring-forced-colors` Storybook screenshot profiles, `.github/workflows/accessibility-sr.yml` (soak-only, concurrency-limited NVDA spec workflow)
-- [A11y] Phase 3 specs: `keyboard/keyboardFlows.spec.ts` (6 critical-flow keyboard tests: open chat, send, attachment cycle, header reachability, Esc/close, re-open), `keyboard/skipLink.spec.ts` (`test.todo` placeholders documenting the skip-link / landmark gap), `sr-nvda/nvdaCriticalFlows.spec.ts` (10 NVDA spec sweep — auto-skips off-Windows / no-NVDA / no-`@guidepup/guidepup`), and `NotDeliveredTimestamp.a11y.test.tsx` RTL unit test asserting the retry control is a native `<button>` (regression catcher for AB#5376198)
+- [A11y] Phase 3 specs: `keyboard/keyboardFlows.spec.ts` (6 critical-flow keyboard tests: open chat, send, attachment cycle, header reachability, Esc/close, re-open), `keyboard/skipLink.spec.ts` (`test.todo` placeholders documenting the skip-link / landmark gap), `sr-nvda/nvdaCriticalFlows.spec.ts` (10 NVDA spec sweep — auto-skips off-Windows / no-NVDA / no-`@guidepup/guidepup`), and `NotDeliveredTimestamp.a11y.test.tsx` RTL unit test asserting the retry control is a native `<button>` (regression catcher for internal tracking)
 - [A11y] Per-package axe rule disable list (`accessibility-disable-rules.json`) covering 7 story-isolation rules (`landmark-one-main`, `page-has-heading-one`, `region`, `html-has-lang`, `html-lang-valid`, `document-title`, `bypass`) so axe results highlight real component issues instead of canvas artifacts. Drives chat-widget Storybook violations from 19 → 1 (the lone real `aria-command-name` finding remains as a tracked work item).
 - [A11y] `axeScan.cjs` extended with `--disable-rules`, `--gate-rules`, and `A11Y_SCAN_DISABLE_RULES` env support; new `yarn scan:a11y:axe:gated` script gates `image-alt` and `button-name` (currently 0 violations across both packages).
 - [Security] Added monitor-only HTML sanitization to gather telemetry before enforcing stricter allowlist rules (Phase 1). Tracks OrganizationId, ConversationId, RemovedTags, RemovedAttributes, and ExecutionTimeMs when content would be blocked by strict allowlist. Runs asynchronously to avoid message latency. Includes 27 unit tests.
@@ -66,7 +66,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed email transcript dialog persisting across conversations by resetting `showEmailTranscriptPane` state during chat close cleanup
-- [A11Y] Replace `<span role="button">` with native `<button>` for Retry element in failed message timestamp so screen readers announce "Retry, button" (AB#5376198)
+- [A11Y] Replace `<span role="button">` with native `<button>` for Retry element in failed message timestamp so screen readers announce "Retry, button" (internal tracking)
 - Fix iOS Safari auto-zoom on prechat survey input fields by setting default font-size to 16px for text input, multiline text input, and multichoice input elements
 - Fix iOS Safari blank space in prechat survey dropdown caused by hidden placeholder `<option>` in adaptive card `<select>` elements
 - Resolved underscores in a system message renders the text weirdly in iOS
@@ -795,6 +795,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- [A11y] `ChatButton` no longer produces duplicate NVDA / JAWS browse-mode stops on the title / subtitle Labels — the text container is excluded from the accessibility tree and the button owns a consolidated `aria-label` (internal tracking)
 - Fixed XSS vulnerability in `replaceURLWithAnchor` by adding HTML escaping and URL protocol validation
 
 ### Security

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import "@testing-library/jest-dom/extend-expect";
+
+import { cleanup, render } from "@testing-library/react";
+
+import { BroadcastServiceInitialize } from "../../services/BroadcastService";
+import ChatButton from "./ChatButton";
+import React from "react";
+import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonProps";
+
+/**
+ * Repro / catcher for internal tracking — NVDA / JAWS in browse mode (virtual cursor)
+ * land on "Let's Chat, We're Online" multiple times when navigating with the
+ * down-arrow key.
+ *
+ * Root cause in code: `ChatButton` renders a Fluent UI `<Stack role="button">`
+ * with `tabIndex={0}` whose accessible name is computed from its visible
+ * children — a `<Label>` for the title (e.g. "Let's Chat!") and a `<Label>`
+ * for the subtitle (e.g. "We're online."). In browse mode, NVDA / JAWS treat
+ * the button itself AND each inner text node as separate virtual-cursor stops,
+ * each carrying the same announceable name fragments. There is no
+ * `aria-label` set by default, and the inner labels are not marked
+ * `aria-hidden="true"` (which is what would collapse them into a single
+ * announcement under the button container).
+ *
+ * Catcher contract: in the rendered chat-button subtree, at most ONE element
+ * may expose each of the title / subtitle strings as an announceable name
+ * source. An "announceable name source" here is:
+ *   - an `aria-label` attribute on a focusable / role-bearing element, OR
+ *   - a visible `<Label>` (or other text-bearing element) that is NOT
+ *     `aria-hidden="true"` and is not nested inside an element that is
+ *     `aria-hidden="true"`.
+ *
+ * Expected to FAIL today: the rendered DOM contains BOTH the title text node
+ * AND the subtitle text node as bare visible text, and the parent Stack has
+ * no `aria-label` to consolidate them. Browse-mode therefore sees three
+ * stops (button, title, subtitle) all carrying the same combined name.
+ */
+
+beforeAll(() => {
+    BroadcastServiceInitialize("testChannel");
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+const isInsideAriaHidden = (el: Element | null): boolean => {
+    let cursor: Element | null = el;
+    while (cursor) {
+        if (cursor.getAttribute("aria-hidden") === "true") return true;
+        cursor = cursor.parentElement;
+    }
+    return false;
+};
+
+const visibleTextElementsMatching = (root: HTMLElement, text: string): Element[] => {
+    return Array.from(root.querySelectorAll("*")).filter((el) => {
+        if (isInsideAriaHidden(el)) return false;
+        // Only count leaf-ish text-bearing elements (don't double-count
+        // ancestors whose textContent obviously aggregates children).
+        const ownText = Array.from(el.childNodes)
+            .filter((n) => n.nodeType === Node.TEXT_NODE)
+            .map((n) => (n.textContent || "").trim())
+            .join(" ")
+            .trim();
+        return ownText === text;
+    });
+};
+
+/**
+ * Regression guard for internal tracking — ChatButton must not produce duplicate
+ * NVDA / JAWS browse-mode stops. Visible title / subtitle text is excluded
+ * from the accessibility tree (aria-hidden) and the button container owns a
+ * single consolidated aria-label.
+ */
+describe("ChatButton — browse-mode duplicate stops (internal tracking)", () => {
+    it("title text 'Let's Chat!' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree", () => {
+        const { container } = render(<ChatButton {...defaultChatButtonProps} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+
+        const titleStops = visibleTextElementsMatching(button, "Let's Chat!");
+        // The visible title should be excluded from the accessibility tree
+        // (e.g. via aria-hidden on the text container) so the announced name
+        // comes solely from the consolidated aria-label on the button. Any
+        // exposed text-bearing element with this exact text creates an
+        // additional browse-mode stop and reproduces internal tracking.
+        expect(titleStops.length).toBe(0);
+    });
+
+    it("subtitle text 'We're online.' must NOT appear as a visible (non-aria-hidden) name source in the chat-button subtree", () => {
+        const { container } = render(<ChatButton {...defaultChatButtonProps} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+
+        const subtitleStops = visibleTextElementsMatching(button, "We're online.");
+        expect(subtitleStops.length).toBe(0);
+    });
+
+    it("the chat-button container must own a single consolidated aria-label so browse mode lands on it once", () => {
+        const { container } = render(<ChatButton {...defaultChatButtonProps} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button).not.toBeNull();
+        // Either the container has a non-empty aria-label, OR every inner
+        // text-bearing descendant is aria-hidden so the computed name comes
+        // from the inner text exactly once with no extra browse-mode stops.
+        const hasAriaLabel = !!(button.getAttribute("aria-label") || "").trim();
+        const innerVisibleText = visibleTextElementsMatching(button, "Let's Chat!").length
+            + visibleTextElementsMatching(button, "We're online.").length;
+        // Today: hasAriaLabel === false (default ariaLabel is undefined) AND
+        // innerVisibleText > 0. The catcher requires at least one of these
+        // to flip.
+        expect(hasAriaLabel || innerVisibleText === 0).toBe(true);
+    });
+});

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
@@ -31,10 +31,13 @@ import { defaultChatButtonProps } from "./common/defaultProps/defaultChatButtonP
  *     `aria-hidden="true"` and is not nested inside an element that is
  *     `aria-hidden="true"`.
  *
- * Expected to FAIL today: the rendered DOM contains BOTH the title text node
- * AND the subtitle text node as bare visible text, and the parent Stack has
- * no `aria-label` to consolidate them. Browse-mode therefore sees three
- * stops (button, title, subtitle) all carrying the same combined name.
+ * Regression guard: in the rendered DOM, the parent role=button Stack owns a
+ * single consolidated aria-label (synthesized from title + subtitle, plus
+ * unread-count fragment when applicable) and the inner Labels live inside an
+ * aria-hidden text container so browse-mode lands on the button exactly once.
+ * Override paths (componentOverrides.title/subtitle/textContainer or a
+ * consumer-supplied controlProps.ariaLabel) are preserved unchanged so
+ * customers who manage their own accessible names are not affected.
  */
 
 beforeAll(() => {
@@ -112,5 +115,79 @@ describe("ChatButton — browse-mode duplicate stops (internal tracking)", () =>
         // innerVisibleText > 0. The catcher requires at least one of these
         // to flip.
         expect(hasAriaLabel || innerVisibleText === 0).toBe(true);
+    });
+
+    it("the synthesized aria-label includes the unread-count fragment when hideNotificationBubble=false and unreadMessageCount > 0", () => {
+        const props = {
+            ...defaultChatButtonProps,
+            controlProps: {
+                ...defaultChatButtonProps.controlProps,
+                hideNotificationBubble: false,
+                unreadMessageCount: "3",
+                ariaLabelUnreadMessageString: "you have new messages",
+                titleText: "Let's Chat!",
+                subtitleText: "We're online."
+            }
+        };
+        const { container } = render(<ChatButton {...props} />);
+        const button = container.firstElementChild as HTMLElement;
+        const ariaLabel = button.getAttribute("aria-label") || "";
+        expect(ariaLabel).toContain("3");
+        expect(ariaLabel).toContain("you have new messages");
+        expect(ariaLabel).toContain("Let's Chat!");
+        expect(ariaLabel).toContain("We're online.");
+    });
+
+    it("a consumer-supplied controlProps.ariaLabel wins over the synthesized label", () => {
+        const props = {
+            ...defaultChatButtonProps,
+            controlProps: {
+                ...defaultChatButtonProps.controlProps,
+                ariaLabel: "Talk to a live agent"
+            }
+        };
+        const { container } = render(<ChatButton {...props} />);
+        const button = container.firstElementChild as HTMLElement;
+        expect(button.getAttribute("aria-label")).toBe("Talk to a live agent");
+    });
+
+    it("componentOverrides.textContainer preserves consumer-rendered visible text (synthesis is skipped)", () => {
+        const customText = "My custom chat text";
+        const props = {
+            ...defaultChatButtonProps,
+            componentOverrides: {
+                textContainer: (
+                    <div id="my-custom-text">{customText}</div>
+                ) as unknown as string
+            }
+        };
+        const { container } = render(<ChatButton {...props} />);
+        const button = container.firstElementChild as HTMLElement;
+        // The custom text MUST remain visible in the a11y tree so consumers
+        // who replace the text container keep their announced text.
+        const customStops = visibleTextElementsMatching(button, customText);
+        expect(customStops.length).toBeGreaterThan(0);
+        // And the button must NOT carry a synthesized aria-label that would
+        // override the consumer's content.
+        const ariaLabel = (button.getAttribute("aria-label") || "").trim();
+        expect(ariaLabel).toBe("");
+    });
+
+    it("componentOverrides.title preserves consumer-rendered visible title (synthesis is skipped)", () => {
+        const customTitle = "Custom override title";
+        const props = {
+            ...defaultChatButtonProps,
+            componentOverrides: {
+                title: (
+                    <span id="my-custom-title">{customTitle}</span>
+                ) as unknown as string
+            }
+        };
+        const { container } = render(<ChatButton {...props} />);
+        const button = container.firstElementChild as HTMLElement;
+        const customStops = visibleTextElementsMatching(button, customTitle);
+        expect(customStops.length).toBeGreaterThan(0);
+        const ariaLabel = (button.getAttribute("aria-label") || "").trim();
+        expect(ariaLabel).toBe("");
     });
 });

--- a/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.browseMode.a11y.spec.tsx
@@ -190,4 +190,50 @@ describe("ChatButton — browse-mode duplicate stops (internal tracking)", () =>
         const ariaLabel = (button.getAttribute("aria-label") || "").trim();
         expect(ariaLabel).toBe("");
     });
+
+    // Regression guard for the strict string-equality slip-throughs that
+    // brittle `unreadMessageCount !== "0"` allowed: values that coerce to
+    // numeric 0 (or non-numeric noise) must NOT render the bubble nor pollute
+    // the synthesized aria-label with a "0 you have new messages" fragment.
+    describe.each([
+        ["padded zero (' 0 ')", " 0 "],
+        ["decimal zero ('0.0')", "0.0"],
+        ["empty string ('')", ""],
+        ["non-numeric ('abc')", "abc"]
+    ])("zero-equivalent unreadMessageCount: %s", (_label, value) => {
+        it("does NOT render the notification bubble", () => {
+            const props = {
+                ...defaultChatButtonProps,
+                controlProps: {
+                    ...defaultChatButtonProps.controlProps,
+                    hideNotificationBubble: false,
+                    unreadMessageCount: value,
+                    ariaLabelUnreadMessageString: "you have new messages"
+                }
+            };
+            const { container } = render(<ChatButton {...props} />);
+            const bubble = container.querySelector("[id$='-notification-bubble']");
+            expect(bubble).toBeNull();
+        });
+
+        it("does NOT inject the unread-count fragment into the synthesized aria-label", () => {
+            const props = {
+                ...defaultChatButtonProps,
+                controlProps: {
+                    ...defaultChatButtonProps.controlProps,
+                    hideNotificationBubble: false,
+                    unreadMessageCount: value,
+                    ariaLabelUnreadMessageString: "you have new messages"
+                }
+            };
+            const { container } = render(<ChatButton {...props} />);
+            const button = container.firstElementChild as HTMLElement;
+            const ariaLabel = button.getAttribute("aria-label") || "";
+            expect(ariaLabel).not.toContain("you have new messages");
+            // and the raw zero-equivalent must not leak into the label
+            if (value.trim().length > 0) {
+                expect(ariaLabel).not.toContain(value.trim());
+            }
+        });
+    });
 });

--- a/chat-components/src/components/chatbutton/ChatButton.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.tsx
@@ -14,13 +14,25 @@ import { defaultChatButtonSubTitleStyles } from "./common/defaultStyles/defaultC
 import { defaultChatButtonTextContainerStyles } from "./common/defaultStyles/defaultChatButtonTextContainerStyles";
 import { defaultChatButtonTitleStyles } from "./common/defaultStyles/defaultChatButtonTitleStyles";
 
+// Returns true when the unread-message count represents a positive number.
+// Defensive against non-strict callers that may pass " 0 ", "0.0", "" or a
+// stringified numeric 0; only a finite count strictly greater than zero counts
+// as "unread" for both the notification bubble and the synthesized aria-label.
+function hasUnreadMessages(unreadMessageCount: string | undefined): boolean {
+    if (unreadMessageCount === undefined || unreadMessageCount === null) {
+        return false;
+    }
+    const parsed = Number(unreadMessageCount);
+    return Number.isFinite(parsed) && parsed > 0;
+}
+
 function NotificationBubble(props: IChatButtonProps, parentId: string) {
     const notificationBubbleStyles: ILabelStyles = {
         root: Object.assign({}, defaultChatButtonNotificationBubbleStyles, props.styleProps?.notificationBubbleStyleProps)
     };
 
     const unreadMessageCount = props.controlProps?.unreadMessageCount ?? defaultChatButtonControlProps?.unreadMessageCount  ;
-    if (unreadMessageCount !== "0") {
+    if (hasUnreadMessages(unreadMessageCount)) {
         return (decodeComponentString(props.componentOverrides?.notificationBubble) || 
             <Stack
                 aria-live="polite" 
@@ -135,7 +147,7 @@ function ChatButton(props: IChatButtonProps) {
         && !props.componentOverrides?.subtitle;
     const synthesizedAriaLabel = canSynthesizeAriaLabel
         ? [
-            !hideNotificationBubble && unreadMessageCount && unreadMessageCount !== "0"
+            !hideNotificationBubble && hasUnreadMessages(unreadMessageCount)
                 ? `${unreadMessageCount} ${ariaLabelUnreadMessageString ?? ""}`.trim()
                 : "",
             !hideChatTitle ? titleText : "",

--- a/chat-components/src/components/chatbutton/ChatButton.tsx
+++ b/chat-components/src/components/chatbutton/ChatButton.tsx
@@ -69,12 +69,22 @@ function TextContainer(props: IChatButtonProps, parentId: string) {
     const titleText = props.controlProps?.titleText ?? defaultChatButtonControlProps?.titleText;
     const subtitleDir = props.controlProps?.dir ?? defaultChatButtonControlProps?.dir;
     const subtitleText = props.controlProps?.subtitleText ?? defaultChatButtonControlProps?.subtitleText;
-        
-    return (decodeComponentString(props.componentOverrides?.textContainer) ||         
+
+    // internal tracking: when the default title / subtitle Labels are used, hide the
+    // text container subtree from the accessibility tree. The button container
+    // owns a consolidated aria-label that already announces the same text, so
+    // exposing the inner Labels causes NVDA / JAWS browse-mode to land on the
+    // same announcement multiple times. Customer overrides for title /
+    // subtitle keep their default a11y behavior so they can manage their own
+    // accessible names.
+    const hideTextFromA11yTree = !props.componentOverrides?.title && !props.componentOverrides?.subtitle;
+
+    return (decodeComponentString(props.componentOverrides?.textContainer) ||
         <Stack
             styles={textContainerStyles}
             className={props.styleProps?.classNames?.textContainerClassName}
             id={parentId + "-text-container"}
+            aria-hidden={hideTextFromA11yTree || undefined}
         >
                 
             {!hideChatTitle && (decodeComponentString(props.componentOverrides?.title) || 
@@ -100,13 +110,41 @@ function TextContainer(props: IChatButtonProps, parentId: string) {
 
 function ChatButton(props: IChatButtonProps) {
     const elementId = props.controlProps?.id ?? Ids.DefaultChatButtonId;
-    const defaultAriaLabel = props.controlProps?.ariaLabel ?? defaultChatButtonControlProps.ariaLabel;
     const defaultRole = props.controlProps?.role ?? defaultChatButtonControlProps?.role;
     const containersDir = props.controlProps?.dir ?? defaultChatButtonControlProps?.dir;
     const hideChatButton = props.controlProps?.hideChatButton ?? defaultChatButtonControlProps?.hideChatButton;
     const hideChatIcon = props.controlProps?.hideChatIcon ?? defaultChatButtonControlProps?.hideChatIcon;
     const hideChatTextContainer = props.controlProps?.hideChatTextContainer ?? defaultChatButtonControlProps?.hideChatTextContainer;
     const hideNotificationBubble = props.controlProps?.hideNotificationBubble ?? defaultChatButtonControlProps?.hideNotificationBubble;
+
+    // internal tracking: when the consumer has not supplied a custom aria-label and
+    // the default title / subtitle Labels are in play, synthesize a single
+    // consolidated aria-label from the visible text so NVDA / JAWS browse
+    // mode lands on the role=button container exactly once. The text
+    // container is also marked aria-hidden in TextContainer so the inner
+    // labels do not produce additional virtual-cursor stops.
+    const titleText = props.controlProps?.titleText ?? defaultChatButtonControlProps?.titleText;
+    const subtitleText = props.controlProps?.subtitleText ?? defaultChatButtonControlProps?.subtitleText;
+    const hideChatTitle = props.controlProps?.hideChatTitle ?? defaultChatButtonControlProps?.hideChatTitle;
+    const hideChatSubtitle = props.controlProps?.hideChatSubtitle ?? defaultChatButtonControlProps?.hideChatSubtitle;
+    const unreadMessageCount = props.controlProps?.unreadMessageCount ?? defaultChatButtonControlProps?.unreadMessageCount;
+    const ariaLabelUnreadMessageString = props.controlProps?.ariaLabelUnreadMessageString ?? defaultChatButtonControlProps?.ariaLabelUnreadMessageString;
+    const canSynthesizeAriaLabel = !hideChatTextContainer
+        && !props.componentOverrides?.textContainer
+        && !props.componentOverrides?.title
+        && !props.componentOverrides?.subtitle;
+    const synthesizedAriaLabel = canSynthesizeAriaLabel
+        ? [
+            !hideNotificationBubble && unreadMessageCount && unreadMessageCount !== "0"
+                ? `${unreadMessageCount} ${ariaLabelUnreadMessageString ?? ""}`.trim()
+                : "",
+            !hideChatTitle ? titleText : "",
+            !hideChatSubtitle ? subtitleText : ""
+        ].filter(Boolean).join(" ").trim()
+        : "";
+    const defaultAriaLabel = props.controlProps?.ariaLabel
+        ?? defaultChatButtonControlProps.ariaLabel
+        ?? (synthesizedAriaLabel || undefined);
 
     const chatButtonGroupStyles: IStackStyles = {
         root: Object.assign({}, defaultChatButtonGeneralStyles, props.styleProps?.generalStyleProps)


### PR DESCRIPTION
## Summary
In screen-reader browse mode (NVDA/JAWS arrow-key navigation, Forms mode off) the ChatButton announces both the visible Title/Subtitle text AND the synthesized aria-label, producing duplicate stops in the reading order.

## Fix
- TextContainer outer Stack gets `aria-hidden` when no title/subtitle componentOverrides are present, so the visible text is hidden from the a11y tree.
- ChatButton synthesizes its aria-label from unread fragment + titleText + subtitleText so the button has a single, deterministic accessible name.
- Override-safe: when consumers supply title/subtitle componentOverrides, the gating skips so consumer-provided markup keeps its native a11y semantics.
- Falls through `controlProps?.ariaLabel` and `defaultChatButtonControlProps.ariaLabel` before applying the synthesized name.

## Verification
- Un-skipped catcher (renamed `.unfixed.a11y.spec.tsx` to `.a11y.spec.tsx`); 3/3 catcher tests pass.
- 13/13 broader chatbutton tests pass.
- `yarn build` clean.

## Related
- Catcher introduced in #945.
- Part of the a11y-bug fix series.
- Internal tracking ID redacted.