### PR TITLE
fix(a11y): strip duplicate labels on non-radio AdaptiveCard inputs

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- [A11y] AdaptiveCard wrapper now strips redundant `aria-label` / `aria-labelledby` from non-radio inputs (Input.Text, Input.Date, Input.Number, Input.Toggle, multi-select ChoiceSet checkbox) when a visible `<label for>` already names the control, eliminating TalkBack duplicate-label announcements (internal tracking)
 - [VRT] Stabilized post-chat survey pane snapshots by intercepting external survey iframe requests with a deterministic fixture
 - [A11y] Transfer system messages now reset cached agent names so later bot messages do not announce stale agents
 - [A11y] Pre-chat survey pane now owns a managed polite live region so stale focus text is not re-announced
@@ -32,7 +33,7 @@ All notable changes to this project will be documented in this file.
 - [A11y] Phase 2 utilities (`chat-widget/automation_tests/e2e/utility/`): `liveRegionObserver` (aria-live mutation observer), `keyboardLoop` (Tab/Shift+Tab traversal helpers), `a11yTree` (accessibility-tree shape assertions), `axeOnPage` (live-page axe runs)
 - [A11y] Phase 2 specs (`chat-widget/automation_tests/e2e/areas/accessibility/`): `citationCard` (link `title` attribute + single-link guarantee), `markdownAnchorMerge` (adjacent same-href anchors collapse to one tab stop), `mobileFocusTrap` (Pixel 5 emulation of the focus-trap regression class)
 - [A11y] Phase 3 utilities + scaffolding for screen-reader and keyboard layers: `expectTabOrder` (named tab-order assertion), `srAssert` (Guidepup-backed NVDA assertion + `phraseFor` lookup), `tools/accessibility/nvda-phrases.json` (event→phrase catalog with NVDA version pin), `tools/accessibility/setupNvda.ps1` (silent NVDA install for Windows runners), `focus-ring` and `focus-ring-forced-colors` Storybook screenshot profiles, `.github/workflows/accessibility-sr.yml` (soak-only, concurrency-limited NVDA spec workflow)
-- [A11y] Phase 3 specs: `keyboard/keyboardFlows.spec.ts` (6 critical-flow keyboard tests: open chat, send, attachment cycle, header reachability, Esc/close, re-open), `keyboard/skipLink.spec.ts` (`test.todo` placeholders documenting the skip-link / landmark gap), `sr-nvda/nvdaCriticalFlows.spec.ts` (10 NVDA spec sweep — auto-skips off-Windows / no-NVDA / no-`@guidepup/guidepup`), and `NotDeliveredTimestamp.a11y.test.tsx` RTL unit test asserting the retry control is a native `<button>` (regression catcher for AB#5376198)
+- [A11y] Phase 3 specs: `keyboard/keyboardFlows.spec.ts` (6 critical-flow keyboard tests: open chat, send, attachment cycle, header reachability, Esc/close, re-open), `keyboard/skipLink.spec.ts` (`test.todo` placeholders documenting the skip-link / landmark gap), `sr-nvda/nvdaCriticalFlows.spec.ts` (10 NVDA spec sweep — auto-skips off-Windows / no-NVDA / no-`@guidepup/guidepup`), and `NotDeliveredTimestamp.a11y.test.tsx` RTL unit test asserting the retry control is a native `<button>` (regression catcher for internal tracking)
 - [A11y] Per-package axe rule disable list (`accessibility-disable-rules.json`) covering 7 story-isolation rules (`landmark-one-main`, `page-has-heading-one`, `region`, `html-has-lang`, `html-lang-valid`, `document-title`, `bypass`) so axe results highlight real component issues instead of canvas artifacts. Drives chat-widget Storybook violations from 19 → 1 (the lone real `aria-command-name` finding remains as a tracked work item).
 - [A11y] `axeScan.cjs` extended with `--disable-rules`, `--gate-rules`, and `A11Y_SCAN_DISABLE_RULES` env support; new `yarn scan:a11y:axe:gated` script gates `image-alt` and `button-name` (currently 0 violations across both packages).
 - [Security] Added monitor-only HTML sanitization to gather telemetry before enforcing stricter allowlist rules (Phase 1). Tracks OrganizationId, ConversationId, RemovedTags, RemovedAttributes, and ExecutionTimeMs when content would be blocked by strict allowlist. Runs asynchronously to avoid message latency. Includes 27 unit tests.
@@ -66,7 +67,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed email transcript dialog persisting across conversations by resetting `showEmailTranscriptPane` state during chat close cleanup
-- [A11Y] Replace `<span role="button">` with native `<button>` for Retry element in failed message timestamp so screen readers announce "Retry, button" (AB#5376198)
+- [A11Y] Replace `<span role="button">` with native `<button>` for Retry element in failed message timestamp so screen readers announce "Retry, button" (internal tracking)
 - Fix iOS Safari auto-zoom on prechat survey input fields by setting default font-size to 16px for text input, multiline text input, and multichoice input elements
 - Fix iOS Safari blank space in prechat survey dropdown caused by hidden placeholder `<option>` in adaptive card `<select>` elements
 - Resolved underscores in a system message renders the text weirdly in iOS

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.a11y.spec.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.a11y.spec.tsx
@@ -417,4 +417,28 @@ describe("AdaptiveCardAccessibilityWrapper — TalkBack duplicate labels on non-
         );
         expect(countAnnouncedSources(container, "topics-1", "Updates")).toBeLessThanOrEqual(1);
     });
+
+    it("Input.Text (isMultiline=true): textarea.ac-input must not expose duplicate label sources", async () => {
+        // Input.Text with isMultiline: true renders as <textarea class="ac-input ac-textInput ac-multichoiceInput">
+        // with the same visible <label for> + aria-label + aria-labelledby triple
+        // as the single-line case. The selector must include textarea or TalkBack
+        // will still double-read.
+        const container = await renderCardWith(() => {
+            const wrapper = document.createElement("div");
+            wrapper.className = "ac-input-container";
+            const label = document.createElement("label");
+            label.id = "comments-input-lbl";
+            label.setAttribute("for", "comments-input");
+            label.textContent = "Comments";
+            const textarea = document.createElement("textarea");
+            textarea.id = "comments-input";
+            textarea.className = "ac-input ac-textInput ac-multichoiceInput";
+            textarea.setAttribute("aria-label", "Comments");
+            textarea.setAttribute("aria-labelledby", "comments-input-lbl");
+            wrapper.appendChild(label);
+            wrapper.appendChild(textarea);
+            return wrapper;
+        });
+        expect(countAnnouncedSources(container, "comments-input", "Comments")).toBeLessThanOrEqual(1);
+    });
 });

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.a11y.spec.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.a11y.spec.tsx
@@ -313,50 +313,108 @@ describe("AdaptiveCardAccessibilityWrapper — compact dropdowns (dropdown-doubl
     });
 });
 
-describe.skip("AdaptiveCardAccessibilityWrapper — TalkBack labels on non-radio elements (talkback-duplicate-label regression guard)", () => {
-    it("talkback-duplicate-label: Input.Text fields inside an adaptive card must not have BOTH visible <label> and aria-label that duplicate (TalkBack reads twice)", async () => {
-        // Best-effort regression catcher: TalkBack double-reads when both an
-        // associated <label> AND aria-label resolve to the same string. This
-        // catcher is a DOM proxy — true verification requires a TalkBack pass.
+// internal tracking — TalkBack reads adaptive-card element labels TWICE.
+// PR #911 patched the radio case via `aria-hidden` on label/spacer siblings,
+// but every other Input.* type (Text, Date, Number, Toggle, ChoiceSet expanded
+// non-radio) is still rendered with BOTH an associated <label for> AND an
+// aria-label / aria-labelledby resolving to the same string. TalkBack walks
+// each accessibility node independently and reads the duplicated name.
+//
+// These cases are deterministic DOM-contract assertions: the wrapper's
+// post-mutation output must expose at most one announce-able name source per
+// input. They are expected to FAIL today because the wrapper only handles
+// `input[type=radio]`.
+describe("AdaptiveCardAccessibilityWrapper — TalkBack duplicate labels on non-radio elements (internal tracking)", () => {
+    const buildLabelledInput = (
+        type: "text" | "date" | "number" | "checkbox",
+        id: string,
+        labelText: string
+    ): HTMLElement => {
+        // Mirrors what the AdaptiveCards renderer produces for Input.Text /
+        // Input.Date / Input.Number / Input.Toggle: a visible <label for="...">
+        // AND aria-label/aria-labelledby on the input that resolve to the same
+        // string.
+        const wrapper = document.createElement("div");
+        wrapper.className = "ac-input-container";
+        const label = document.createElement("label");
+        label.id = `${id}-lbl`;
+        label.setAttribute("for", id);
+        label.textContent = labelText;
+        const input = document.createElement("input");
+        input.type = type;
+        input.id = id;
+        input.className = "ac-input";
+        input.setAttribute("aria-label", labelText);
+        input.setAttribute("aria-labelledby", `${id}-lbl`);
+        wrapper.appendChild(label);
+        wrapper.appendChild(input);
+        return wrapper;
+    };
+
+    const countAnnouncedSources = (
+        container: HTMLElement,
+        inputId: string,
+        expectedName: string
+    ): number => {
+        const input = container.querySelector(`#${CSS.escape(inputId)}`) as HTMLElement | null;
+        if (!input) return 0;
+        const ariaLabel = input.getAttribute("aria-label");
+        const ariaLabelledBy = input.getAttribute("aria-labelledby");
+        const visibleLabel = container.querySelector(
+            `label[for="${CSS.escape(inputId)}"]:not([aria-hidden='true'])`
+        );
+        const sources: (string | undefined | null)[] = [
+            ariaLabel,
+            ariaLabelledBy
+                ? (document.getElementById(ariaLabelledBy)?.textContent || "").trim()
+                : undefined,
+            visibleLabel?.textContent?.trim()
+        ];
+        return sources.filter((s) => s === expectedName).length;
+    };
+
+    const renderCardWith = async (factory: () => HTMLElement) => {
         const { container } = render(
             <AdaptiveCardAccessibilityWrapper>
                 <div className="ac-adaptiveCard" />
             </AdaptiveCardAccessibilityWrapper>
         );
         const card = container.querySelector(".ac-adaptiveCard") as HTMLElement;
-
         await act(async () => {
-            const wrapper = document.createElement("div");
-            wrapper.className = "ac-input-container";
-            const label = document.createElement("label");
-            label.id = "name-lbl";
-            label.setAttribute("for", "name-input");
-            label.textContent = "Name";
-            const input = document.createElement("input");
-            input.type = "text";
-            input.id = "name-input";
-            input.setAttribute("aria-label", "Name");
-            input.setAttribute("aria-labelledby", "name-lbl");
-            wrapper.appendChild(label);
-            wrapper.appendChild(input);
-            card.appendChild(wrapper);
+            card.appendChild(factory());
             observerInstance.trigger();
         });
+        return container;
+    };
 
-        const input = container.querySelector("input#name-input") as HTMLElement;
-        // After fix: at most ONE of {aria-label, aria-labelledby pointing to
-        // a visible <label for=...>} resolves to "Name".
-        const ariaLabel = input.getAttribute("aria-label");
-        const ariaLabelledBy = input.getAttribute("aria-labelledby");
-        const visibleLabel = container.querySelector(
-            "label[for='name-input']:not([aria-hidden='true'])"
+    it("Input.Text: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("text", "name-input", "Name"));
+        expect(countAnnouncedSources(container, "name-input", "Name")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.Date: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("date", "dob-input", "Date of birth"));
+        expect(countAnnouncedSources(container, "dob-input", "Date of birth")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.Number: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("number", "qty-input", "Quantity"));
+        expect(countAnnouncedSources(container, "qty-input", "Quantity")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.Toggle: visible <label for> AND aria-label/aria-labelledby must not all resolve to the same name", async () => {
+        const container = await renderCardWith(() => buildLabelledInput("checkbox", "subscribe-input", "Subscribe"));
+        expect(countAnnouncedSources(container, "subscribe-input", "Subscribe")).toBeLessThanOrEqual(1);
+    });
+
+    it("Input.ChoiceSet (expanded, non-radio checkbox style): visible <label for> AND aria-labelledby must not duplicate", async () => {
+        // isMultiSelect: true on Input.ChoiceSet renders as <input type="checkbox">
+        // wrapped exactly like the radio case the wrapper already handles, but
+        // the wrapper's selector is scoped to input[type='radio'] so checkboxes
+        // are not patched.
+        const container = await renderCardWith(() =>
+            buildLabelledInput("checkbox", "topics-1", "Updates")
         );
-        const sources = [
-            ariaLabel,
-            ariaLabelledBy && (document.getElementById(ariaLabelledBy)?.textContent || "").trim(),
-            visibleLabel?.textContent?.trim()
-        ].filter(Boolean);
-        const duplicates = sources.filter((s) => s === "Name").length;
-        expect(duplicates).toBeLessThanOrEqual(1);
+        expect(countAnnouncedSources(container, "topics-1", "Updates")).toBeLessThanOrEqual(1);
     });
 });

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.tsx
@@ -45,6 +45,44 @@ const AdaptiveCardAccessibilityWrapper: React.FC<{
                 }
             });
 
+            // internal tracking: non-radio inputs (Input.Text, Input.Date, Input.Number,
+            // Input.Toggle, Input.ChoiceSet multi-select checkbox) rendered by
+            // adaptivecards can have THREE accessible-name sources resolving to
+            // the same string: a visible <label for>, aria-label, AND
+            // aria-labelledby. TalkBack walks each accessibility node
+            // independently and reads the duplicated name. When a visible
+            // <label for> exists and names the control, strip the redundant
+            // aria-label / aria-labelledby on the input so only one announceable
+            // source remains.
+            const labelledInputs = container.querySelectorAll<HTMLInputElement>(
+                ".ac-input-container input.ac-input[id]:not([type='radio'])"
+            );
+            labelledInputs.forEach((input) => {
+                const id = input.id;
+                if (!id) return;
+                const visibleLabel = container.querySelector<HTMLLabelElement>(
+                    `label[for="${CSS.escape(id)}"]:not([aria-hidden='true'])`
+                );
+                if (!visibleLabel) return;
+                const labelText = (visibleLabel.textContent || "").trim();
+                if (!labelText) return;
+                const ariaLabel = input.getAttribute("aria-label");
+                if (ariaLabel && ariaLabel.trim() === labelText) {
+                    input.removeAttribute("aria-label");
+                }
+                const labelledBy = (input.getAttribute("aria-labelledby") || "").trim();
+                if (labelledBy) {
+                    const ids = labelledBy.split(/\s+/);
+                    const resolved = ids
+                        .map((rid) => (document.getElementById(rid)?.textContent || "").trim())
+                        .filter(Boolean)
+                        .join(" ");
+                    if (resolved === labelText) {
+                        input.removeAttribute("aria-labelledby");
+                    }
+                }
+            });
+
             // action-button-toggle / login-button-toggle: submit/login action buttons can be
             // rendered with toggle-only ARIA that causes screen readers to announce them as
             // switches instead of plain push buttons. Preserve Action.ToggleVisibility buttons,

--- a/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/webchatcontroller/middlewares/renderingmiddlewares/attachments/AdaptiveCardAccessibilityWrapper.tsx
@@ -45,17 +45,18 @@ const AdaptiveCardAccessibilityWrapper: React.FC<{
                 }
             });
 
-            // internal tracking: non-radio inputs (Input.Text, Input.Date, Input.Number,
-            // Input.Toggle, Input.ChoiceSet multi-select checkbox) rendered by
-            // adaptivecards can have THREE accessible-name sources resolving to
-            // the same string: a visible <label for>, aria-label, AND
-            // aria-labelledby. TalkBack walks each accessibility node
-            // independently and reads the duplicated name. When a visible
-            // <label for> exists and names the control, strip the redundant
-            // aria-label / aria-labelledby on the input so only one announceable
-            // source remains.
-            const labelledInputs = container.querySelectorAll<HTMLInputElement>(
-                ".ac-input-container input.ac-input[id]:not([type='radio'])"
+            // internal tracking: non-radio inputs (Input.Text including
+            // isMultiline=true which renders as <textarea>, Input.Date,
+            // Input.Number, Input.Toggle, Input.ChoiceSet multi-select
+            // checkbox) rendered by adaptivecards can have THREE accessible-
+            // name sources resolving to the same string: a visible
+            // <label for>, aria-label, AND aria-labelledby. TalkBack walks
+            // each accessibility node independently and reads the duplicated
+            // name. When a visible <label for> exists and names the control,
+            // strip the redundant aria-label / aria-labelledby on the input
+            // so only one announceable source remains.
+            const labelledInputs = container.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>(
+                ".ac-input-container input.ac-input[id]:not([type='radio']), .ac-input-container textarea.ac-input[id]"
             );
             labelledInputs.forEach((input) => {
                 const id = input.id;


### PR DESCRIPTION
## Summary
TalkBack announces non-radio AdaptiveCard inputs (Input.Text, Input.Date, Input.Number, Input.Toggle, multi-select Input.ChoiceSet) up to three times because the renderer emits a visible `<label for>` AND `aria-label` AND `aria-labelledby` all resolving to the same string. TalkBack walks each accessibility node independently and reads the duplicate name.

## Fix
`AdaptiveCardAccessibilityWrapper` now also patches non-radio inputs in `.ac-input-container`: when a visible `<label for=id>` already names the control, the redundant `aria-label` / `aria-labelledby` on the input are removed so only one accessible-name source remains.

## Verification
- Un-skipped catcher: `AdaptiveCardAccessibilityWrapper.a11y.spec.tsx` (renamed from `.unfixed.a11y.spec.tsx`).
- 13/13 catcher tests pass (5 new non-radio cases + 8 existing radio / compact-dropdown / action-button assertions).
- 19/19 existing `AdaptiveCardAccessibilityWrapper.test.tsx` tests still pass.
- `yarn lint` clean.

## Related
- Catcher introduced in #945.
- Internal tracking ID redacted.