### PR TITLE
fix(deps): bump omnichannel-chat-sdk to 1.11.9-main.a5570e5

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Bumped `@microsoft/omnichannel-chat-sdk` to `1.11.9-main.a5570e5`. This pulls in the upstream fix that pins the ACS WebChat adapter to exact `0.0.1-beta.8` (instead of `^0.0.1-beta.6` which resolved to the rogue `0.0.1-beta-1` per semver §11), restoring the fast-poll path for the first bot reply.
+
 ### Tests
 - [A11y] Added deterministic repro catchers (skipped by default; un-skip to validate fixes) for internal tracking (AdaptiveCard TalkBack non-radio duplicate labels), internal tracking (ChatButton browse-mode duplicate stops), internal tracking (agent profile name not announced), internal tracking (blank announcement live regions), internal tracking (focus trap leak across page reload), plus a passing regression guard for ConfirmationPane focus-trap install/cleanup symmetry
 

--- a/chat-widget/jest.setup.js
+++ b/chat-widget/jest.setup.js
@@ -9,3 +9,17 @@ global.WritableStream = class {
         };
     }
 };
+
+// jsdom does not expose Node's Web Crypto API on the global, but the ACS WebChat
+// adapter (>= 0.0.1-beta.8) reads `crypto.subtle` at module-load time. Without
+// this polyfill, any test that transitively imports `@microsoft/omnichannel-chat-sdk`
+// fails with: "TypeError: Cannot read properties of undefined (reading 'subtle')".
+if (typeof global.crypto === "undefined" || typeof global.crypto.subtle === "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { webcrypto } = require("crypto");
+    Object.defineProperty(global, "crypto", {
+        value: webcrypto,
+        configurable: true,
+        writable: true,
+    });
+}

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -96,7 +96,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
     "@microsoft/omnichannel-chat-components": "1.1.17-main.f21df63",
-    "@microsoft/omnichannel-chat-sdk": "1.11.9-main.da8219b",
+    "@microsoft/omnichannel-chat-sdk": "1.11.9-main.a5570e5",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",
     "abort-controller-es5": "^2.0.1",

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -90,6 +90,18 @@
     axe-core "~4.11.4"
     requestidlecallback "^0.3.0"
 
+"@azure-rest/core-client@^2.3.3":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@azure-rest/core-client/-/core-client-2.6.0.tgz#f797099b76f8f9d3acb3d8dac52785e2ec95e341"
+  integrity sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.10.0"
+    "@azure/core-rest-pipeline" "^1.22.0"
+    "@azure/core-tracing" "^1.3.0"
+    "@typespec/ts-http-runtime" "^0.3.0"
+    tslib "^2.6.2"
+
 "@azure/abort-controller@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-1.1.0.tgz#788ee78457a55af8a1ad342acb182383d2119249"
@@ -122,14 +134,14 @@
     tslib "^2.2.0"
     uuid "^8.3.0"
 
-"@azure/communication-chat@^1.5.4":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@azure/communication-chat/-/communication-chat-1.6.0.tgz#6cbb787584e0ed3e395342dddf9436e97443c13d"
-  integrity sha512-VnWa6krGE3tVkjlsW8gvg7orsJyFe0P5BAJvV03/QeOKfPTI2hZiOquvlPbk5ukSlMke9aj2mSO/sszHC2j81w==
+"@azure/communication-chat@1.6.0-beta.5":
+  version "1.6.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@azure/communication-chat/-/communication-chat-1.6.0-beta.5.tgz#962db5f0de5b6c60095221520b0b3da10b8c7081"
+  integrity sha512-8R+s998qshBKnbSomlhnofljuwd/DNg8hhQvKQWOHqtCUvoWsyDGjCem5bcqq6wBXnVSBsg+GjOU4m05B/6PuA==
   dependencies:
     "@azure/abort-controller" "^2.1.2"
     "@azure/communication-common" "^2.3.1"
-    "@azure/communication-signaling" "1.0.0-beta.34"
+    "@azure/communication-signaling" "1.0.0-beta.32"
     "@azure/core-auth" "^1.9.0"
     "@azure/core-client" "^1.9.2"
     "@azure/core-paging" "^1.1.1"
@@ -153,6 +165,21 @@
     jwt-decode "^4.0.0"
     tslib "^2.2.0"
 
+"@azure/communication-common@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/communication-common/-/communication-common-2.4.0.tgz#f77ef90bab8b7803bfbddc84f0aa418d46d4c86b"
+  integrity sha512-wwn4AoOgTgoA9OZkO34SKBpQg7/kfcABnzbaYEbc+9bCkBtwwjgMEk6xM+XLEE/uuODZ8q8jidUoNcZHQyP5AQ==
+  dependencies:
+    "@azure-rest/core-client" "^2.3.3"
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.9.0"
+    "@azure/core-rest-pipeline" "^1.17.0"
+    "@azure/core-tracing" "^1.2.0"
+    "@azure/core-util" "^1.11.0"
+    events "^3.3.0"
+    jwt-decode "^4.0.0"
+    tslib "^2.8.1"
+
 "@azure/communication-signaling@1.0.0-beta.29":
   version "1.0.0-beta.29"
   resolved "https://registry.yarnpkg.com/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.29.tgz#20175ef9b74a91414d7c65735fb5d2c033f6c045"
@@ -169,10 +196,10 @@
     tslib "^2.2.0"
     uuid "^8.3.0"
 
-"@azure/communication-signaling@1.0.0-beta.34":
-  version "1.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.34.tgz#4b52a84609cf7107c4f7ddd9d727a2210b616e51"
-  integrity sha512-nlbkQzD2Jrkwwj01tGETQEj4HV28WXdqIt45DkHtamVeoFFNem/uJIri4dUymzAwgK7c1czGoVobuft8UH5Eig==
+"@azure/communication-signaling@1.0.0-beta.32":
+  version "1.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@azure/communication-signaling/-/communication-signaling-1.0.0-beta.32.tgz#7cb1252600a63b9c09bb649c67886d593a1ea782"
+  integrity sha512-ChhJXblgILpnuZd6cQlf1EDBNSTJ5cGUtvMQkxNjdlMa0qYKOXUN0Ugz6clw6jcrcMorXJlbda6tI7iGmgDPuQ==
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     "@azure/core-auth" "^1.3.0"
@@ -3603,17 +3630,19 @@
     "@nevware21/ts-async" ">= 0.5.4 < 2.x"
     "@nevware21/ts-utils" ">= 0.11.8 < 2.x"
 
-"@microsoft/botframework-webchat-adapter-azure-communication-chat@^0.0.1-beta.6":
-  version "0.0.1-beta-1"
-  resolved "https://registry.yarnpkg.com/@microsoft/botframework-webchat-adapter-azure-communication-chat/-/botframework-webchat-adapter-azure-communication-chat-0.0.1-beta-1.tgz#9aae9cb7c34a59eb2ee69d809330e82ded58b4d8"
-  integrity sha512-vcpoztqbko6R2qlzlw8zCbtrNasSEKtu1JtrJguW5dG6Sddvxs+/3oC8oZMIOa5FrmZ+knVPfVJ+guUPu7NM/A==
+"@microsoft/botframework-webchat-adapter-azure-communication-chat@0.0.1-beta.8":
+  version "0.0.1-beta.8"
+  resolved "https://registry.yarnpkg.com/@microsoft/botframework-webchat-adapter-azure-communication-chat/-/botframework-webchat-adapter-azure-communication-chat-0.0.1-beta.8.tgz#22ab9c28642d4d119fd90a378be1d715cb85a972"
+  integrity sha512-0F6ZuNlC5cEn1jGmNQ580IPsMjpr77ehRKvz9x26xwPWHFNhc1li/+nlthamRYUhS3jhxhP250ckaR8XLjbJvQ==
   dependencies:
-    "@azure/communication-chat" "^1.5.4"
-    "@azure/communication-common" "^2.3.1"
-    core-js "^3.6.5"
-    http-status-codes "^2.1.4"
+    "@azure/communication-chat" "1.6.0-beta.5"
+    "@azure/communication-common" "^2.4.0"
+    core-js "^3.43.0"
+    event-target-shim "^6.0.2"
+    http-status-codes "^2.3.0"
+    p-defer "^4.0.1"
     redux "^4.0.5"
-    regenerator-runtime "^0.13.7"
+    regenerator-runtime "^0.14.1"
 
 "@microsoft/dynamicproto-js@^2.0.3":
   version "2.0.3"
@@ -3627,10 +3656,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/load-themed-styles/-/load-themed-styles-1.10.295.tgz#d3c8d7ab186f422727ba112d6ebe5fe8e41051d9"
   integrity sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==
 
-"@microsoft/ocsdk@0.5.22-main.27b39ce":
-  version "0.5.22-main.27b39ce"
-  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.5.22-main.27b39ce.tgz#68954f6990bdbd19cdf7ee3eaaad196de19e95aa"
-  integrity sha512-MwXzPu7BPweguN/n1jKRbQr3L9b/nDGM8hBHvh6bv9izri3Lb9+F9YOWRPHP+Wv3BH5SeVs8ypNU0o2mucGSZw==
+"@microsoft/ocsdk@0.5.22-main.8dbdcd5":
+  version "0.5.22-main.8dbdcd5"
+  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.5.22-main.8dbdcd5.tgz#8b5556e76a18234b0d76d504e4b789f281a6f4cc"
+  integrity sha512-nVy89H6eC4Ch/PZzL48cEgcE8Gnj4N9eTpiwK+qJ6wGqd2ZqRn4r9SmRWFCzllmyJxCVuWchs4DoEc3MUDnsEg==
   dependencies:
     "@babel/runtime" "^7.26.10"
     "@types/node" "^22.13.10"
@@ -3653,15 +3682,15 @@
     broadcast-channel "^4.5.0"
     rxjs "^5.0.3"
 
-"@microsoft/omnichannel-chat-sdk@1.11.9-main.da8219b":
-  version "1.11.9-main.da8219b"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-1.11.9-main.da8219b.tgz#c18900b3ed534a5f23828415e69582bdb1a09658"
-  integrity sha512-OFhtRi2Ra1No0pOIiKejI4xDuFgm6NxHBtyoi8Jn0HTAjf+/sb9HAESApYhgVwH84Y0DLfg0DqukoCHwDK+/Bg==
+"@microsoft/omnichannel-chat-sdk@1.11.9-main.a5570e5":
+  version "1.11.9-main.a5570e5"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-1.11.9-main.a5570e5.tgz#31a493c249ea00af0c4084015e79816253626749"
+  integrity sha512-mZl80WAua5hGPcQZb3SzGXbnk0EPuUjCg2Hk2ptEnj+PQ8sP4WbvY4n+Ql5zP7YqRYgSajcJc96/F5HysO120w==
   dependencies:
     "@azure/communication-chat" "1.5.4"
     "@azure/communication-common" "2.3.1"
-    "@microsoft/botframework-webchat-adapter-azure-communication-chat" "^0.0.1-beta.6"
-    "@microsoft/ocsdk" "0.5.22-main.27b39ce"
+    "@microsoft/botframework-webchat-adapter-azure-communication-chat" "0.0.1-beta.8"
+    "@microsoft/ocsdk" "0.5.22-main.8dbdcd5"
     "@microsoft/omnichannel-amsclient" "0.1.14-main.9951e38"
     "@microsoft/omnichannel-ic3core" "^0.1.5"
 
@@ -9469,6 +9498,11 @@ core-js@^3.0.4, core-js@^3.12.1, core-js@^3.6.5, core-js@^3.8.2:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.29.0.tgz#0273e142b67761058bcde5615c503c7406b572d6"
   integrity sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==
 
+core-js@^3.43.0:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.49.0.tgz#8b4d520ac034311fa21aa616f017ada0e0dbbddd"
+  integrity sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -11171,7 +11205,7 @@ events-universal@^1.0.0:
   dependencies:
     bare-events "^2.7.0"
 
-events@^3.0.0, events@^3.2.0:
+events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -12782,7 +12816,7 @@ http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
     agent-base "^7.1.0"
     debug "^4.3.4"
 
-http-status-codes@^2.1.4:
+http-status-codes@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.3.0.tgz#987fefb28c69f92a43aecc77feec2866349a8bfc"
   integrity sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==
@@ -18397,7 +18431,7 @@ regenerator-runtime@^0.13.11, regenerator-runtime@^0.13.4, regenerator-runtime@^
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
-regenerator-runtime@^0.14.0:
+regenerator-runtime@^0.14.0, regenerator-runtime@^0.14.1:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
   integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==


### PR DESCRIPTION
## Summary

Bumps `@microsoft/omnichannel-chat-sdk` from `1.11.9-main.da8219b` to `1.11.9-main.a5570e5` to pick up the upstream fix in [microsoft/omnichannel-chat-sdk#564](https://github.com/microsoft/omnichannel-chat-sdk/pull/564) that pins the ACS WebChat adapter to exact `0.0.1-beta.8`.

## Why

The previous chat-sdk declared the adapter as `^0.0.1-beta.6`. Per [semver §11](https://semver.org/#spec-item-11), that range resolved to the rogue prerelease **`0.0.1-beta-1`** (single pre-release identifier `beta-1` sorts higher than dot-separated `beta.N`). The `0.0.1-beta-1` build is an orphaned publish that ships an older adapter binary whose ACS polling is gated on a 15-second watchdog timer, producing a visible ~15s delay before the first bot reply renders in LCW.

The upstream fix pins the adapter to exact `0.0.1-beta.8`, which contains the fast-poll bypass (`iteration <= 45 ? 1000 : delaytm`). With this bump, this repo's `yarn.lock` now resolves the adapter to `0.0.1-beta.8` instead of `0.0.1-beta-1`.

## What changed

| File | Change |
|---|---|
| `chat-widget/package.json` | chat-sdk dep bumped to `1.11.9-main.a5570e5` |
| `chat-widget/yarn.lock` | regenerated; chat-sdk + transitive adapter now resolve correctly |
| `CHANGE_LOG.md` | `[Unreleased] → Changed` entry added |

## Validation

Locally verified that the LCW dev bundle (built from the chat-widget package consumed via yarn link) contains the fast-poll branch and the first bot reply renders within ~1s of the trouter handshake.
