### PR TITLE
fix(prechat): iOS-only Safari blank-space fix for compact dropdown

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -809,6 +809,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- [Bug][iOS] Pre-chat survey compact `<select>` no longer renders a blank first row in the iOS Safari native picker. The placeholder option AdaptiveCards injects (which iOS cannot hide via CSS) is now removed from the DOM after the card is appended, the first real option is auto-selected, and the `ChoiceSetInput` value getter is patched on iOS so a `selectedIndex === 0` selection is recognised — fixing both the visual gap and the "field is required" validation error that appeared when a ChoiceSet had only one option. Fix is iOS-only; other platforms are unaffected.
 - [A11y] `ChatButton` no longer produces duplicate NVDA / JAWS browse-mode stops on the title / subtitle Labels — the text container is excluded from the accessibility tree and the button owns a consolidated `aria-label` (internal tracking)
 - Fixed XSS vulnerability in `replaceURLWithAnchor` by adding HTML escaping and URL protocol validation
 

--- a/chat-components/jest.setup.visual.js
+++ b/chat-components/jest.setup.visual.js
@@ -21,6 +21,11 @@ const browserNames = getEnabledBrowsers(playwright, process.env.STORYBOOK_BROWSE
 //Making Timeout to 50s
 jest.setTimeout(50000);
 
+// Hooks launch/close up to 3 browsers (chromium, firefox, webkit). On slow CI
+// agents that can exceed the 50s per-test timeout, so give the hooks more room.
+const HOOK_TIMEOUT_MS = 120000;
+const BROWSER_CLOSE_TIMEOUT_MS = 30000;
+
 beforeAll(async () => {
     for (const browserName of browserNames) {
         browser[browserName] = await playwright[browserName].launch();
@@ -83,11 +88,43 @@ beforeAll(async () => {
             }
         }
     });
-});
+}, HOOK_TIMEOUT_MS);
 
 afterAll(async () => {
-    const promises = Object.keys(browser).map((browserType) =>
-        browser[browserType].close(),
-    );
-    await Promise.all(promises);
-});
+    // Diagnostic: log leftover contexts/pages per browser before close. If
+    // `browser.close()` ever hangs again, this tells us which browser still
+    // has live pages pinning it open (likely an unclosed page from
+    // afterScreenshot or a pending route handler).
+    for (const browserType of Object.keys(browser)) {
+        const instance = browser[browserType];
+        if (!instance) continue;
+        try {
+            const contexts = instance.contexts();
+            const pageCount = contexts.reduce((sum, ctx) => sum + ctx.pages().length, 0);
+            console.log(`🧹 Teardown: ${browserType} has ${contexts.length} context(s), ${pageCount} open page(s)`);
+        } catch (err) {
+            console.warn(`Could not inspect "${browserType}" before close:`, err && err.message ? err.message : err);
+        }
+    }
+
+    const closeWithTimeout = (browserType) => {
+        const instance = browser[browserType];
+        if (!instance) {
+            return Promise.resolve();
+        }
+        const startedAt = Date.now();
+        return Promise.race([
+            instance.close().then(() => {
+                console.log(`✅ Closed "${browserType}" in ${Date.now() - startedAt}ms`);
+            }).catch((err) => {
+                console.warn(`Failed to close browser "${browserType}":`, err && err.message ? err.message : err);
+            }),
+            new Promise((resolve) => setTimeout(() => {
+                console.warn(`⏱️ Timed out closing browser "${browserType}" after ${BROWSER_CLOSE_TIMEOUT_MS}ms; continuing teardown.`);
+                resolve();
+            }, BROWSER_CLOSE_TIMEOUT_MS))
+        ]);
+    };
+
+    await Promise.all(Object.keys(browser).map(closeWithTimeout));
+}, HOOK_TIMEOUT_MS);

--- a/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
+++ b/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
@@ -26,10 +26,45 @@ const isIOSDevice = (): boolean => {
     return ua.includes("Mac") && typeof document !== "undefined" && "ontouchend" in document;
 };
 
+// iOS-only: AdaptiveCards' ChoiceSetInput value getter treats `selectedIndex > 0` as "user selected"
+// and returns undefined for index 0 (assuming it is always the injected placeholder).
+// On iOS we remove the placeholder to avoid a blank picker row, which shifts the first real
+// option to index 0 — so the original getter wrongly reports undefined and required-field
+// validation fails. Patch the prototype once to accept index >= 0.
+let iosChoiceSetValuePatched = false;
+const patchIOSChoiceSetValueGetter = () => {
+    if (iosChoiceSetValuePatched) {
+        return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ChoiceSetInput = (AdaptiveCards as any).ChoiceSetInput;
+    if (!ChoiceSetInput || !ChoiceSetInput.prototype) {
+        return;
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(ChoiceSetInput.prototype, "value");
+    if (!descriptor || !descriptor.get) {
+        return;
+    }
+    Object.defineProperty(ChoiceSetInput.prototype, "value", {
+        configurable: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        get: function (this: any) {
+            if (!this.isMultiSelect && this._selectElement) {
+                return this._selectElement.selectedIndex >= 0 ? this._selectElement.value : undefined;
+            }
+            return descriptor.get?.call(this);
+        }
+    });
+    iosChoiceSetValuePatched = true;
+};
+
 function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
 
     const elementId = props.controlProps?.id ?? defaultPreChatSurveyPaneControlProps.id as string;
     const isIOS = isIOSDevice();
+    if (isIOS) {
+        patchIOSChoiceSetValueGetter();
+    }
     let adpativeCardPayload;
     let adaptiveCardHostConfig;
 
@@ -83,17 +118,25 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
     addNoreferrerNoopenerTag(renderedCard);
 
     // Fix iOS Safari blank space in <select> dropdowns. iOS-only; other platforms render correctly.
-    if (isIOS && renderedCard) {
-        const selectElements = renderedCard.querySelectorAll<HTMLSelectElement>("select.ac-choiceSetInput-compact");
+    // The placeholder option that AdaptiveCards injects renders as a blank row in the iOS
+    // native picker (CSS display/hidden are ignored on <option>). Removing it from the DOM
+    // is the only reliable workaround. After removal, we select the first remaining option
+    // and notify AdaptiveCards so required-field validation reads the visible value.
+    const applyIOSPrechatFix = (container: HTMLElement) => {
+        const selectElements = container.querySelectorAll<HTMLSelectElement>("select.ac-choiceSetInput-compact");
         selectElements.forEach((select) => {
-            // Remove the placeholder option that causes blank space in iOS native picker.
-            // iOS UIPickerView ignores CSS (display/hidden) on <option>, so DOM removal is required.
             const firstOption = select.options[0];
             if (firstOption && firstOption.disabled && firstOption.hidden && firstOption.value === "") {
                 firstOption.remove();
+                if (select.options.length > 0) {
+                    select.selectedIndex = 0;
+                    select.value = select.options[0].value;
+                    select.dispatchEvent(new Event("input", { bubbles: true }));
+                    select.dispatchEvent(new Event("change", { bubbles: true }));
+                }
             }
         });
-    }
+    };
 
     return (
         <>
@@ -163,6 +206,9 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
                             ref={(n) => { // Returns React element
                                 renderedCard && n && n.appendChild(renderedCard);
                                 n && (n.childElementCount > 1) && n.lastChild && n.removeChild(n.lastChild); // Removes duplicates fix
+                                if (isIOS && n) {
+                                    applyIOSPrechatFix(n);
+                                }
                             }} />
                     </Stack>
 

--- a/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
+++ b/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
@@ -86,14 +86,11 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
     if (isIOS && renderedCard) {
         const selectElements = renderedCard.querySelectorAll<HTMLSelectElement>("select.ac-choiceSetInput-compact");
         selectElements.forEach((select) => {
-            // Hide the placeholder option that causes blank space on iOS
+            // Remove the placeholder option that causes blank space in iOS native picker.
+            // iOS UIPickerView ignores CSS (display/hidden) on <option>, so DOM removal is required.
             const firstOption = select.options[0];
             if (firstOption && firstOption.disabled && firstOption.hidden && firstOption.value === "") {
-                firstOption.style.display = "none";
-                // Select the next valid option so the dropdown doesn't appear blank
-                if (select.options.length > 1) {
-                    select.selectedIndex = 1;
-                }
+                firstOption.remove();
             }
         });
     }
@@ -151,22 +148,6 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
                 color: ${props.styleProps?.customButtonStyleProps?.color ?? defaultPreChatSurveyPaneStyles.customButtonStyleProps?.color};
                 background-color: ${props.styleProps?.customButtonStyleProps?.backgroundColor ?? defaultPreChatSurveyPaneStyles.customButtonStyleProps?.backgroundColor};
             }`}</style>
-            {isIOS && <style>{`
-            .ac-input.ac-multichoiceInput {
-                box-sizing: border-box;
-            }
-            .ac-input.ac-multichoiceInput.ac-choiceSetInput-compact {
-                height: auto;
-                min-height: 31px;
-                max-height: 45px;
-                -webkit-appearance: none;
-                appearance: none;
-                background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
-                background-repeat: no-repeat;
-                background-position: right 8px center;
-                background-size: 16px;
-                padding-right: 30px;
-            }`}</style>}
             {!props.controlProps?.hidePreChatSurveyPane &&
                 <Stack
                     id={elementId}

--- a/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
+++ b/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
@@ -83,14 +83,17 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
     addNoreferrerNoopenerTag(renderedCard);
 
     // Fix iOS Safari blank space in <select> dropdowns. iOS-only; other platforms render correctly.
-    // Only the hidden placeholder option needs to be removed — do NOT override -webkit-appearance,
-    // since that prevents the native iOS picker from opening on some iOS versions.
     if (isIOS && renderedCard) {
         const selectElements = renderedCard.querySelectorAll<HTMLSelectElement>("select.ac-choiceSetInput-compact");
         selectElements.forEach((select) => {
+            // Hide the placeholder option that causes blank space on iOS
             const firstOption = select.options[0];
             if (firstOption && firstOption.disabled && firstOption.hidden && firstOption.value === "") {
-                select.removeChild(firstOption);
+                firstOption.style.display = "none";
+                // Select the next valid option so the dropdown doesn't appear blank
+                if (select.options.length > 1) {
+                    select.selectedIndex = 1;
+                }
             }
         });
     }

--- a/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
+++ b/chat-components/src/components/prechatsurveypane/PreChatSurveyPane.tsx
@@ -13,9 +13,23 @@ import { defaultPreChatSurveyPaneControlProps } from "./common/defaultProps/defa
 import { defaultPreChatSurveyPaneGeneralStyles } from "./common/defaultProps/defaultStyles/defaultPreChatSurveyPaneGeneralStyles";
 import { defaultPreChatSurveyPaneStyles } from "./common/defaultProps/defaultStyles/defaultPreChatSurveyPaneStyles";
 
+// Detect iOS (iPhone/iPad/iPod) including iPadOS 13+ which reports as Mac with touch support.
+// Used to scope iOS-only Safari workarounds; must not match other platforms.
+const isIOSDevice = (): boolean => {
+    if (typeof navigator === "undefined") {
+        return false;
+    }
+    const ua = navigator.userAgent || "";
+    if (/iPad|iPhone|iPod/.test(ua)) {
+        return true;
+    }
+    return ua.includes("Mac") && typeof document !== "undefined" && "ontouchend" in document;
+};
+
 function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
 
     const elementId = props.controlProps?.id ?? defaultPreChatSurveyPaneControlProps.id as string;
+    const isIOS = isIOSDevice();
     let adpativeCardPayload;
     let adaptiveCardHostConfig;
 
@@ -67,6 +81,19 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
     // Render the card
     const renderedCard = adaptiveCard.render();
     addNoreferrerNoopenerTag(renderedCard);
+
+    // Fix iOS Safari blank space in <select> dropdowns. iOS-only; other platforms render correctly.
+    // Only the hidden placeholder option needs to be removed — do NOT override -webkit-appearance,
+    // since that prevents the native iOS picker from opening on some iOS versions.
+    if (isIOS && renderedCard) {
+        const selectElements = renderedCard.querySelectorAll<HTMLSelectElement>("select.ac-choiceSetInput-compact");
+        selectElements.forEach((select) => {
+            const firstOption = select.options[0];
+            if (firstOption && firstOption.disabled && firstOption.hidden && firstOption.value === "") {
+                select.removeChild(firstOption);
+            }
+        });
+    }
 
     return (
         <>
@@ -121,6 +148,22 @@ function PreChatSurveyPane(props: IPreChatSurveyPaneProps) {
                 color: ${props.styleProps?.customButtonStyleProps?.color ?? defaultPreChatSurveyPaneStyles.customButtonStyleProps?.color};
                 background-color: ${props.styleProps?.customButtonStyleProps?.backgroundColor ?? defaultPreChatSurveyPaneStyles.customButtonStyleProps?.backgroundColor};
             }`}</style>
+            {isIOS && <style>{`
+            .ac-input.ac-multichoiceInput {
+                box-sizing: border-box;
+            }
+            .ac-input.ac-multichoiceInput.ac-choiceSetInput-compact {
+                height: auto;
+                min-height: 31px;
+                max-height: 45px;
+                -webkit-appearance: none;
+                appearance: none;
+                background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+                background-repeat: no-repeat;
+                background-position: right 8px center;
+                background-size: 16px;
+                padding-right: 30px;
+            }`}</style>}
             {!props.controlProps?.hidePreChatSurveyPane &&
                 <Stack
                     id={elementId}

--- a/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
@@ -1,7 +1,7 @@
 import { HtmlAttributeNames, Regex } from "../../common/Constants";
 import { ConversationStage, LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, FocusEvent, useEffect, useRef, useState } from "react";
-import { createTimer, extractPreChatSurveyResponseValues, findAllFocusableElement, getDeviceType, getStateFromCache, getWidgetCacheId, isUndefinedOrEmpty, parseAdaptiveCardPayload } from "../../common/utils";
+import { createTimer, extractPreChatSurveyResponseValues, findAllFocusableElement, getStateFromCache, getWidgetCacheId, isUndefinedOrEmpty, parseAdaptiveCardPayload } from "../../common/utils";
 
 import { ConversationState } from "../../contexts/common/ConversationState";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
@@ -77,10 +77,7 @@ export const PreChatSurveyPaneStateful = (props: IPreChatSurveyPaneStatefulParam
     const { surveyProps, initStartChat } = props;
     const [preChatFocusAnnouncement, setPreChatFocusAnnouncement] = useState("");
     const liveRegionUpdateTimeout = useRef<number | undefined>();
-    // iOS-only: prevent Safari rubber-band overscroll from scrolling the survey out of view.
-    // No-op on other platforms.
-    const iosOnlyStyles: IStyle = getDeviceType() === "ios" ? { overscrollBehavior: "none" } : {};
-    const generalStyleProps: IStyle = Object.assign({}, defaultGeneralPreChatSurveyPaneStyleProps, iosOnlyStyles, surveyProps?.styleProps?.generalStyleProps,
+    const generalStyleProps: IStyle = Object.assign({}, defaultGeneralPreChatSurveyPaneStyleProps, surveyProps?.styleProps?.generalStyleProps,
         { display: state.appStates.isMinimized ? "none" : "" });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
+++ b/chat-widget/src/components/prechatsurveypanestateful/PreChatSurveyPaneStateful.tsx
@@ -1,7 +1,7 @@
 import { HtmlAttributeNames, Regex } from "../../common/Constants";
 import { ConversationStage, LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, FocusEvent, useEffect, useRef, useState } from "react";
-import { createTimer, extractPreChatSurveyResponseValues, findAllFocusableElement, getStateFromCache, getWidgetCacheId, isUndefinedOrEmpty, parseAdaptiveCardPayload } from "../../common/utils";
+import { createTimer, extractPreChatSurveyResponseValues, findAllFocusableElement, getDeviceType, getStateFromCache, getWidgetCacheId, isUndefinedOrEmpty, parseAdaptiveCardPayload } from "../../common/utils";
 
 import { ConversationState } from "../../contexts/common/ConversationState";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
@@ -77,7 +77,10 @@ export const PreChatSurveyPaneStateful = (props: IPreChatSurveyPaneStatefulParam
     const { surveyProps, initStartChat } = props;
     const [preChatFocusAnnouncement, setPreChatFocusAnnouncement] = useState("");
     const liveRegionUpdateTimeout = useRef<number | undefined>();
-    const generalStyleProps: IStyle = Object.assign({}, defaultGeneralPreChatSurveyPaneStyleProps, surveyProps?.styleProps?.generalStyleProps,
+    // iOS-only: prevent Safari rubber-band overscroll from scrolling the survey out of view.
+    // No-op on other platforms.
+    const iosOnlyStyles: IStyle = getDeviceType() === "ios" ? { overscrollBehavior: "none" } : {};
+    const generalStyleProps: IStyle = Object.assign({}, defaultGeneralPreChatSurveyPaneStyleProps, iosOnlyStyles, surveyProps?.styleProps?.generalStyleProps,
         { display: state.appStates.isMinimized ? "none" : "" });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

Re-applies the iOS prechat dropdown fix on top of the recent revert (#959), gated strictly to iOS so non-iOS browsers behave identically to today.

## Problem

On iPhone/iPad Safari, the prechat survey's compact ChoiceSet `<select>` renders a large blank space at the top of the native picker. Cause: a hidden placeholder `<option disabled hidden value="">` that iOS still reserves space for. Safari also rubber-band overscrolls the survey out of view.

## Fix

**chat-components / `PreChatSurveyPane.tsx`**
- Add `isIOSDevice()` helper (matches iPhone/iPad/iPod **and** iPadOS 13+ Macs with touch support).
- After `adaptiveCard.render()`, when iOS is detected, imperatively remove the leading hidden placeholder `<option>` from `select.ac-choiceSetInput-compact` elements. This is the actual root cause of the blank space.
- Add an **iOS-only** `<style>` block: `box-sizing: border-box` plus `-webkit-appearance: none` with a custom SVG chevron on the compact ChoiceSet, so the control looks consistent after placeholder removal.

**chat-widget / `PreChatSurveyPaneStateful.tsx`**
- Apply `overscrollBehavior: 'none'` to the survey container **only** when `getDeviceType() === 'ios'`. No-op on other platforms.

## Why iOS-only?

The earlier unconditional revert (#959) restored the bug for everyone because the styling overrides affected non-iOS rendering. This change scopes every workaround behind an iOS check, so:
- Android / desktop Chromium / Firefox / Edge: byte-for-byte identical rendering to today.
- iOS Safari: blank space gone, picker still opens natively.

## Testing

- Verified on physical iPhone (iOS Safari) via local sample with placeholder build of `@microsoft/omnichannel-chat-widget` aliased to local `lib/esm` — blank space gone, picker opens and selection works.
- Non-iOS platforms get no new CSS, no DOM mutation, no `overscrollBehavior` override.

Windows:
<img width="1702" height="882" alt="Screenshot 2026-06-22 at 11 18 52 PM" src="https://github.com/user-attachments/assets/0206f5e7-649a-4420-b5ab-abfa7890181b" />
<img width="1713" height="965" alt="Screenshot 2026-06-22 at 11 20 22 PM" src="https://github.com/user-attachments/assets/e5af7a00-91ad-4d72-a542-e559d5e29dbb" />

Mac:
<img width="1688" height="958" alt="Screenshot 2026-06-22 at 10 47 40 PM" src="https://github.com/user-attachments/assets/ccfe2b05-ead9-449e-b357-8337edb7fe4a" />
<img width="1725" height="957" alt="Screenshot 2026-06-22 at 10 47 55 PM" src="https://github.com/user-attachments/assets/85292c93-c42e-4549-bfe7-4dea86048726" />

iPhone browser
<img width="473" height="1024" alt="Image (3)" src="https://github.com/user-attachments/assets/9b2e82d3-273b-47ed-8435-4d1aaf1b4d77" />
<img width="473" height="1024" alt="Image (1)" src="https://github.com/user-attachments/assets/e90705bb-e07d-4572-8201-44f794095fca" />
<img width="473" height="1024" alt="Image (2)" src="https://github.com/user-attachments/assets/34d4d147-5ba8-4569-9fc1-a6cf55680f10" />

## Checklist
- [x] Code changes scoped to iOS via runtime UA check
- [x] No public API changes
- [x] No breaking changes for chat-widget / chat-components consumers
- [x] Tested on iPhone Safari

 What's in this commit (only  chat-components/jest.setup.visual.js ):

 • 120s timeout for  beforeAll / afterAll  hooks (per-hook override)
 • 30s per-browser close race, errors caught
 • New diagnostics that will show in the next CI log:
   •  🧹 Teardown: chromium has N context(s), M open page(s)  — before close, per browser
   •  ✅ Closed "firefox" in 1234ms  — on successful close
   •  ⏱️ Timed out closing browser "webkit"...  — if one hangs