### PR TITLE
Bump @microsoft/omnichannel-chat-components to 1.1.17-main.05edfd3

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
-- Bumped `@microsoft/omnichannel-chat-components` to `1.1.17-main.5b3f077`.
+- Bumped `@microsoft/omnichannel-chat-components` to `1.1.17-main.05edfd3`.
 - Bumped `@microsoft/omnichannel-chat-sdk` to `1.11.9-main.47a6498`. This includes diagnostic telemetry fields in ChatConfigRetrievalFailure events and pulls in the upstream fix that pins the ACS WebChat adapter to exact `0.0.1-beta.8` (instead of `^0.0.1-beta.6` which resolved to the rogue `0.0.1-beta-1` per semver §11), restoring the fast-poll path for the first bot reply.
 
 ### Tests

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
-    "@microsoft/omnichannel-chat-components": "1.1.17-main.5b3f077",
+    "@microsoft/omnichannel-chat-components": "1.1.17-main.05edfd3",
     "@microsoft/omnichannel-chat-sdk": "1.11.9-main.47a6498",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -3672,10 +3672,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.1.14-main.9951e38.tgz#199903715de20373dbddbbf18b5d4ee9fc1b5a08"
   integrity sha512-bbgMmYmCKBzOrs/VGd/yPCn7bOoU0f2kTwAlX8Fl3MdfMgXL2DVGBJo5EsF4M3bFQDJITavTAbyii07aro4Mtw==
 
-"@microsoft/omnichannel-chat-components@1.1.17-main.5b3f077":
-  version "1.1.17-main.5b3f077"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-1.1.17-main.5b3f077.tgz#447588b9bc867291fd3c3698bd0890cfe86e48b1"
-  integrity sha512-1f6K/OZPcDlPvOsiYfXPPyILBeEdehFFxYSpXhKc4xwqZA/TjJcICkK2awg4fJIhZL65tDCasOqRfK9C93aKwQ==
+"@microsoft/omnichannel-chat-components@1.1.17-main.05edfd3":
+  version "1.1.17-main.05edfd3"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-1.1.17-main.05edfd3.tgz#9930502cfc09cbcf1a741b8e879a0ad7bd88c236"
+  integrity sha512-U1KqTS+4Mg6xcV+ov9oKtIaEGSn3vqxVtqhKNXewjjo5CBgiSaxR4M/S0MgvKxCc8e7QJqqKh6n202bF6cuNfA==
   dependencies:
     "@fluentui/react" "^8.46.0"
     adaptivecards "^2.10.0"


### PR DESCRIPTION
## Summary
Bumps `@microsoft/omnichannel-chat-components` from `1.1.17-main.5b3f077` to `1.1.17-main.05edfd3` in `chat-widget`.

## Changes
- `chat-widget/package.json` — version bump
- `chat-widget/yarn.lock` — regenerated via `yarn install`

## Validation
- `yarn install` succeeded; `node_modules/@microsoft/omnichannel-chat-components/package.json` reports `1.1.17-main.05edfd3`.
- typescript-sample (`samples/typescript-sample`) bundles cleanly with `npm start` and runs locally on desktop + iPhone (LAN).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>