### PR TITLE
Prepare Chat Widget 2.0.0 and pin chat-components 1.2.0

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Bumped `@microsoft/omnichannel-chat-widget` from 1.8.4 to 2.0.0.
 - Bumped `@microsoft/omnichannel-chat-components` to `1.2.0`.
-- Bumped `@microsoft/omnichannel-chat-sdk` to `2.0.0-main.b82e941`.
+- Bumped `@microsoft/omnichannel-chat-sdk` to `2.0.0`, which uses `@microsoft/ocsdk@0.6.0` and `@microsoft/omnichannel-amsclient@0.2.0`.
 - Retained required product hotfix `botframework-webchat@4.18.1-hotfix.20260308.b15b405`.
 - Added a PR check that rejects changes to the required Bot Framework Web Chat hotfix version.
 - Updated Markdown-It, DOMPurify, and `sanitize-html` to patched compatible releases.

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [2.0.0] - 2026-08-13
+## [2.0.0] - 2026-08-18
 
 ### Breaking
 
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Bumped `@microsoft/omnichannel-chat-widget` from 1.8.4 to 2.0.0.
-- Bumped `@microsoft/omnichannel-chat-components` to `1.2.0-main.5692126`.
+- Bumped `@microsoft/omnichannel-chat-components` to `1.2.0`.
 - Bumped `@microsoft/omnichannel-chat-sdk` to `2.0.0-main.b82e941`.
 - Retained required product hotfix `botframework-webchat@4.18.1-hotfix.20260308.b15b405`.
 - Added a PR check that rejects changes to the required Bot Framework Web Chat hotfix version.
@@ -826,7 +826,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [1.2.0] - 2026-08-13
+## [1.2.0] - 2026-08-18
 
 GitHub Release automation starts with `1.2.0`. Versions `1.1.17`, `1.1.18`, and `1.1.19` were published to npm without matching GitHub Releases. Their notes are listed below.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > NEW! Check out our new [Developer Guide](https://github.com/microsoft/omnichannel-chat-widget/blob/main/docs/customizations/getstarted.md), which has detailed explanations of all component interfaces accompanied with sample code.
 
-> NEW! Version 1.2.0 introduces draggable widget, allowing the widget panel to move anywhere in the browser window. Set `draggableChatWidgetProps.disabled` to `true` to disable this behavior. See [interface](https://github.com/microsoft/omnichannel-chat-widget/blob/main/chat-widget/src/components/livechatwidget/interfaces/ILiveChatWidgetProps.ts#L68).
+> NEW! Version 2.0.0 requires Node.js `>=22.12.0` and uses `@microsoft/omnichannel-chat-components@1.2.0`. Pin exact stable versions in production.
 
 ## Table of Contents
 
@@ -38,6 +38,27 @@ Read the [release procedure](docs/RELEASING.md) before you prepare or publish a 
 Starting with `c-v1.2.0` and `w-v2.0.0`, each official tag publishes one tarball to npm and a matching GitHub Release.
 
 Pushes to `main` publish prerelease versions with the npm tag `latest`. Production applications must pin an exact stable version.
+
+Official versions receive support for 12 months after the release date.
+
+### Chat Widget
+
+| Version | Docs | Release Date | End of Support |
+| -- | -- | -- | -- |
+| 2.0.0 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/w-v2.0.0) | 2026-08-18 | 2027-08-18 |
+| 1.8.7 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/w-v1.8.7) | 2026-01-26 | 2027-01-26 |
+| 1.8.6 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/w-v1.8.6) | 2026-01-25 | 2027-01-25 |
+| 1.8.5 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/w-v1.8.5) | 2026-01-22 | 2027-01-22 |
+| 1.8.3 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/w-v1.8.3) | 2025-10-07 | 2026-10-07 |
+
+### Chat Components
+
+| Version | Docs | Release Date | End of Support |
+| -- | -- | -- | -- |
+| 1.2.0 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/c-v1.2.0) | 2026-08-18 | 2027-08-18 |
+| 1.1.19 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/c-v1.1.19) | 2026-01-23 | 2027-01-23 |
+| 1.1.18 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/c-v1.1.18) | 2026-01-20 | 2027-01-20 |
+| 1.1.17 | [Release Notes](https://github.com/microsoft/omnichannel-chat-widget/releases/tag/c-v1.1.17) | 2026-01-16 | 2027-01-16 |
 
 ## Installation
 

--- a/chat-components/README.md
+++ b/chat-components/README.md
@@ -128,6 +128,8 @@ yarn test:visual --forceExit
 
 Official Chat Components tags use `c-v<version>`. Starting with `c-v1.2.0`, each tag publishes the same tarball to npm and GitHub.
 
+`1.2.0` was released on 2026-08-18. Official support ends on 2027-08-18. See the [root support table](https://github.com/microsoft/omnichannel-chat-widget#chat-components).
+
 ## Support and security
 
 - Use [GitHub Issues](https://github.com/microsoft/omnichannel-chat-widget/issues) for reproducible product defects.

--- a/chat-widget/README.md
+++ b/chat-widget/README.md
@@ -53,7 +53,7 @@ This package requires Node.js `>=22.12.0` for consumer builds. Node 20 is not su
 For a production application, pin the exact stable versions:
 
 ```bash
-npm install --save-exact @microsoft/omnichannel-chat-widget@2.0.0 @microsoft/omnichannel-chat-components@1.2.0
+npm install --save-exact @microsoft/omnichannel-chat-widget@2.0.0 @microsoft/omnichannel-chat-components@1.2.0 @microsoft/omnichannel-chat-sdk@2.0.0
 ```
 
 `2.0.0` release date is 2026-08-18. Official support ends on 2027-08-18. See the [root support table](https://github.com/microsoft/omnichannel-chat-widget#chat-widget).

--- a/chat-widget/README.md
+++ b/chat-widget/README.md
@@ -50,6 +50,14 @@ yarn add @microsoft/omnichannel-chat-components
 
 This package requires Node.js `>=22.12.0` for consumer builds. Node 20 is not supported.
 
+For a production application, pin the exact stable versions:
+
+```bash
+npm install --save-exact @microsoft/omnichannel-chat-widget@2.0.0 @microsoft/omnichannel-chat-components@1.2.0
+```
+
+`2.0.0` release date is 2026-08-18. Official support ends on 2027-08-18. See the [root support table](https://github.com/microsoft/omnichannel-chat-widget#chat-widget).
+
 TypeScript consumers that imported the exported Web Chat middleware factories now receive Redux 5 `unknown` actions. Narrow with `isWebChatAction` before reading `type` or `payload`. Runtime behavior is unchanged.
 
 ## WebChat dependency constraint

--- a/chat-widget/automation_tests/package.json
+++ b/chat-widget/automation_tests/package.json
@@ -38,7 +38,7 @@
     "@azure/identity": "^1.2.3",
     "@azure/keyvault-secrets": "^4.1.0",
     "@azure/service-bus": "^1.1.10",
-    "@microsoft/omnichannel-chat-sdk": "2.0.0-main.b82e941",
+    "@microsoft/omnichannel-chat-sdk": "2.0.0",
     "@types/jest": "^25.2.1",
     "@types/jest-image-snapshot": "^2.12.0",
     "adal-node": "^0.2.2",

--- a/chat-widget/automation_tests/yarn.lock
+++ b/chat-widget/automation_tests/yarn.lock
@@ -1113,10 +1113,10 @@
     redux "^4.0.5"
     regenerator-runtime "^0.14.1"
 
-"@microsoft/ocsdk@0.6.0-main.dcb2d46":
-  version "0.6.0-main.dcb2d46"
-  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.6.0-main.dcb2d46.tgz#4295dbfb42b6792fd71f2a367273418ff4ff1529"
-  integrity sha512-J67spHVLqtY20r67agMPy2cZm/gXImgYb1oie89rf4/DOxJ/XZQFaeuBlWeAycni5AhXcKkQZXRBZEx/bIlG6g==
+"@microsoft/ocsdk@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.6.0.tgz#0ad682a70ecfbf75ee252bd21d47c975f446aa18"
+  integrity sha512-mV6YZz+SKb1ASwYnNtmVLjPQo5DqyIwA6zeMt4ie7F293s4dDUVkhWi8/oTvWJPFjO8EUU7sRuS1mwrWb8p59g==
   dependencies:
     "@babel/runtime" "^7.26.10"
     "@types/node" "^22.13.10"
@@ -1124,21 +1124,21 @@
     axios-retry "^3.9.1"
     crypto-js "^4.2.0"
 
-"@microsoft/omnichannel-amsclient@0.2.0-main.3e03701":
-  version "0.2.0-main.3e03701"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0-main.3e03701.tgz#da8b1f91fffc4e4cfe341c1c491c460ce5322ce8"
-  integrity sha512-j8Rg60ru6O3cW/lXqxxjTQY0qFXyS9XqWLRRjFgoqUYDn39+UA34sATO2br8e40jAMlu6cYIPzNKdU6Nyx6LYQ==
+"@microsoft/omnichannel-amsclient@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0.tgz#999d7d5c74d08641ab4a6677603c95b75cbcd218"
+  integrity sha512-wIubYjfzovWv2+P+AInxhOfB1MwVoR7veljAreHbq0Y+6haPMCxtY2LhIq8UGzGVk/UdcUXe3laV0AZdwBxSCw==
 
-"@microsoft/omnichannel-chat-sdk@2.0.0-main.b82e941":
-  version "2.0.0-main.b82e941"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.b82e941.tgz#ecb4c7992a958ec06a9fb0719623e3c556c675e1"
-  integrity sha512-GC7Qbj2pTI8zvFnxRDSBU3K+iG34nfCEdJ61QBUfeWI6mqQijKzWL1LgWtKx76I+BT0ekl8hcYhZHqdYKslicA==
+"@microsoft/omnichannel-chat-sdk@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0.tgz#7f14ad36b33fa9ce6191f03acf7182bec705dbc0"
+  integrity sha512-HyKvjAUp8YmwyznW6Kyk1PoD4QPaC/N6V0dU7Pup18JNYAgRfi0QS9GSybrWtycwUY0iYw3PG99KonJVWj9KBQ==
   dependencies:
     "@azure/communication-chat" "1.6.0-beta.7"
     "@azure/communication-common" "2.4.2"
     "@microsoft/botframework-webchat-adapter-azure-communication-chat" "0.0.1-beta.8"
-    "@microsoft/ocsdk" "0.6.0-main.dcb2d46"
-    "@microsoft/omnichannel-amsclient" "0.2.0-main.3e03701"
+    "@microsoft/ocsdk" "0.6.0"
+    "@microsoft/omnichannel-amsclient" "0.2.0"
     "@microsoft/omnichannel-ic3core" "^0.1.5"
 
 "@microsoft/omnichannel-ic3core@^0.1.5":

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
-    "@microsoft/omnichannel-chat-components": "1.2.0-main.5692126",
+    "@microsoft/omnichannel-chat-components": "1.2.0",
     "@microsoft/omnichannel-chat-sdk": "2.0.0-main.b82e941",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -93,7 +93,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
     "@microsoft/omnichannel-chat-components": "1.2.0",
-    "@microsoft/omnichannel-chat-sdk": "2.0.0-main.b82e941",
+    "@microsoft/omnichannel-chat-sdk": "2.0.0",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",
     "botframework-webchat": "4.18.1-hotfix.20260308.b15b405",

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2893,10 +2893,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/load-themed-styles/-/load-themed-styles-1.10.295.tgz#d3c8d7ab186f422727ba112d6ebe5fe8e41051d9"
   integrity sha512-W+IzEBw8a6LOOfRJM02dTT7BDZijxm+Z7lhtOAz1+y9vQm1Kdz9jlAO+qCEKsfxtUOmKilW8DIRqFw2aUgKeGg==
 
-"@microsoft/ocsdk@0.6.0-main.dcb2d46":
-  version "0.6.0-main.dcb2d46"
-  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.6.0-main.dcb2d46.tgz#4295dbfb42b6792fd71f2a367273418ff4ff1529"
-  integrity sha512-J67spHVLqtY20r67agMPy2cZm/gXImgYb1oie89rf4/DOxJ/XZQFaeuBlWeAycni5AhXcKkQZXRBZEx/bIlG6g==
+"@microsoft/ocsdk@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/ocsdk/-/ocsdk-0.6.0.tgz#0ad682a70ecfbf75ee252bd21d47c975f446aa18"
+  integrity sha512-mV6YZz+SKb1ASwYnNtmVLjPQo5DqyIwA6zeMt4ie7F293s4dDUVkhWi8/oTvWJPFjO8EUU7sRuS1mwrWb8p59g==
   dependencies:
     "@babel/runtime" "^7.26.10"
     "@types/node" "^22.13.10"
@@ -2904,10 +2904,10 @@
     axios-retry "^3.9.1"
     crypto-js "^4.2.0"
 
-"@microsoft/omnichannel-amsclient@0.2.0-main.3e03701":
-  version "0.2.0-main.3e03701"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0-main.3e03701.tgz#da8b1f91fffc4e4cfe341c1c491c460ce5322ce8"
-  integrity sha512-j8Rg60ru6O3cW/lXqxxjTQY0qFXyS9XqWLRRjFgoqUYDn39+UA34sATO2br8e40jAMlu6cYIPzNKdU6Nyx6LYQ==
+"@microsoft/omnichannel-amsclient@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0.tgz#999d7d5c74d08641ab4a6677603c95b75cbcd218"
+  integrity sha512-wIubYjfzovWv2+P+AInxhOfB1MwVoR7veljAreHbq0Y+6haPMCxtY2LhIq8UGzGVk/UdcUXe3laV0AZdwBxSCw==
 
 "@microsoft/omnichannel-chat-components@1.2.0":
   version "1.2.0"
@@ -2920,16 +2920,16 @@
     rxjs "^5.0.3"
     swiper "12.1.2"
 
-"@microsoft/omnichannel-chat-sdk@2.0.0-main.b82e941":
-  version "2.0.0-main.b82e941"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.b82e941.tgz#ecb4c7992a958ec06a9fb0719623e3c556c675e1"
-  integrity sha512-GC7Qbj2pTI8zvFnxRDSBU3K+iG34nfCEdJ61QBUfeWI6mqQijKzWL1LgWtKx76I+BT0ekl8hcYhZHqdYKslicA==
+"@microsoft/omnichannel-chat-sdk@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0.tgz#7f14ad36b33fa9ce6191f03acf7182bec705dbc0"
+  integrity sha512-HyKvjAUp8YmwyznW6Kyk1PoD4QPaC/N6V0dU7Pup18JNYAgRfi0QS9GSybrWtycwUY0iYw3PG99KonJVWj9KBQ==
   dependencies:
     "@azure/communication-chat" "1.6.0-beta.7"
     "@azure/communication-common" "2.4.2"
     "@microsoft/botframework-webchat-adapter-azure-communication-chat" "0.0.1-beta.8"
-    "@microsoft/ocsdk" "0.6.0-main.dcb2d46"
-    "@microsoft/omnichannel-amsclient" "0.2.0-main.3e03701"
+    "@microsoft/ocsdk" "0.6.0"
+    "@microsoft/omnichannel-amsclient" "0.2.0"
     "@microsoft/omnichannel-ic3core" "^0.1.5"
 
 "@microsoft/omnichannel-ic3core@^0.1.5":

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2909,10 +2909,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0-main.3e03701.tgz#da8b1f91fffc4e4cfe341c1c491c460ce5322ce8"
   integrity sha512-j8Rg60ru6O3cW/lXqxxjTQY0qFXyS9XqWLRRjFgoqUYDn39+UA34sATO2br8e40jAMlu6cYIPzNKdU6Nyx6LYQ==
 
-"@microsoft/omnichannel-chat-components@1.2.0-main.5692126":
-  version "1.2.0-main.5692126"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-1.2.0-main.5692126.tgz#1e5f42179c55cb7d70b948e0a9cbc9dafa5062d9"
-  integrity sha512-c9FhCU3wRkGoXHT8DqdOBxy0g02vAn5OPyyeTrNbjqvW7BOeGUgoBQwxN2125fNrw1hTWfvCLJSt+qRutGvjIg==
+"@microsoft/omnichannel-chat-components@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-components/-/omnichannel-chat-components-1.2.0.tgz#6bbe6c2a06232c6f260c74149e7e503357bb9827"
+  integrity sha512-qzyPluBZZFRoFEMffCilc8fyWpZ42J1+4KKuXRXWg7DYolIklo6hOavjyka96/pDvUcTLl7sg93SHFS3er63dw==
   dependencies:
     "@fluentui/react" "^8.125.7"
     adaptivecards "3.0.6"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,7 +37,8 @@ Use this procedure for `@microsoft/omnichannel-chat-components`.
 5. Change the prior component `Unreleased` section to `## [<version>] - YYYY-MM-DD`.
 6. Use no more than one `Added`, `Changed`, `Fixed`, or `Security` section.
 7. Update `chat-components/README.md` and the release information in the root `README.md`.
-8. Update this document when the release process changes.
+8. Add the official version to the root README support table. Use the tag date as the release date. Set the end of support to 12 months later.
+9. Update this document when the release process changes.
 
 Make sure that the version does not exist on npm:
 
@@ -153,7 +154,8 @@ If a release pull request already exists, do not create a second version or chan
 5. Change the prior widget `Unreleased` section to `## [<version>] - YYYY-MM-DD`.
 6. Use no more than one `Added`, `Changed`, `Fixed`, or `Security` section.
 7. Update `chat-widget/README.md` and the release information in the root `README.md`.
-8. Update migration documentation for every breaking release.
+8. Add the official version to the root README support table. Use the tag date as the release date. Set the end of support to 12 months later.
+9. Update migration documentation for every breaking release.
 
 Make sure that the version does not exist on npm:
 


### PR DESCRIPTION
## Summary

Prepare the official Chat Widget `2.0.0` release after #971 and #973.

- Pin `@microsoft/omnichannel-chat-components` from `1.2.0-main.5692126` to official `1.2.0`.
- Keep `chat-widget/package.json` at stable `2.0.0`.
- Record the official components uptake in the `# Chat-Widget` `2.0.0` notes.
- Set the official `1.2.0` and `2.0.0` dates to `2026-08-18`.
- Restore the root README support table that #973 replaced with process-only text.
- Use a 12-month support window and the correct `c-v*` / `w-v*` tag links.
- Point package READMEs and `docs/RELEASING.md` at that table.

This PR does not create `w-v2.0.0`. Tag the merge commit after review.

## Why the support table

#973 documented the new tag workflow but dropped the Version / Release Date / End of Support table. That was the public support-date record for both packages. This PR puts a current table back, including official Chat Components `1.2.0`.

## Validation

- Confirmed `@microsoft/omnichannel-chat-widget@2.0.0` is not on npm.
- Confirmed no `w-v2.0.0` tag exists.
- Lockfile `1.2.0` integrity matches the `c-v1.2.0` GitHub Release tarball (SHA-1 `6bbe6c2a06232c6f260c74149e7e503357bb9827`).
- Local `yarn install` cannot reach `registry.yarnpkg.com` from this network (TLS handshake alert 40). GitHub Actions is the install/build/test gate.

AB#6562437