### PR TITLE
fix(security): pin DOMPurify 3.4.13 and PostCSS 8.5.19

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+- Pin `dompurify` to `3.4.13` (GHSA-55q2-fjhq-7xh7).
+- Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
+
 ### Changed
 - Removed leftover Chat Widget tag and manual release workflows. Official `w-v*` tags now start only `npm-release.yml`.
 - Stopped Storybook deploy from running on `w-v*` tags. Pushes to `main` still deploy Storybook.
@@ -713,6 +717,9 @@ All notable changes to this project will be documented in this file.
 # Chat-Components
 
 ## [Unreleased]
+
+### Security
+- Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
 
 ## [1.2.0] - 2026-08-18
 

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,16 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+- Pin `dompurify` to `3.4.13` (GHSA-55q2-fjhq-7xh7).
+- Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
+
 ### Changed
 - Removed leftover Chat Widget tag and manual release workflows. Official `w-v*` tags now start only `npm-release.yml`.
 - Stopped Storybook deploy from running on `w-v*` tags. Pushes to `main` still deploy Storybook.
 - Consolidated the Chat Widget 2.0.0 notes into one Breaking, Changed, Added, Tests, Fixed, and Security section and removed mid-auth entries.
-
-## [2.0.1] - 2026-08-20
-
-### Security
-- Pin `dompurify` to `3.4.13` (GHSA-55q2-fjhq-7xh7).
-- Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
 
 ## [2.0.0] - 2026-08-18
 
@@ -719,8 +717,6 @@ All notable changes to this project will be documented in this file.
 # Chat-Components
 
 ## [Unreleased]
-
-## [1.2.1] - 2026-08-20
 
 ### Security
 - Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -6,14 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Security
-- Pin `dompurify` to `3.4.13` (GHSA-55q2-fjhq-7xh7).
-- Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
-
 ### Changed
 - Removed leftover Chat Widget tag and manual release workflows. Official `w-v*` tags now start only `npm-release.yml`.
 - Stopped Storybook deploy from running on `w-v*` tags. Pushes to `main` still deploy Storybook.
 - Consolidated the Chat Widget 2.0.0 notes into one Breaking, Changed, Added, Tests, Fixed, and Security section and removed mid-auth entries.
+
+## [2.0.1] - 2026-08-20
+
+### Security
+- Pin `dompurify` to `3.4.13` (GHSA-55q2-fjhq-7xh7).
+- Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
 
 ## [2.0.0] - 2026-08-18
 
@@ -717,6 +719,8 @@ All notable changes to this project will be documented in this file.
 # Chat-Components
 
 ## [Unreleased]
+
+## [1.2.1] - 2026-08-20
 
 ### Security
 - Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).

--- a/chat-components/package.json
+++ b/chat-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-components",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Microsoft Omnichannel Chat Components",
   "main": "lib/cjs/index.js",
   "types": "lib/types/index.d.ts",

--- a/chat-components/package.json
+++ b/chat-components/package.json
@@ -61,7 +61,7 @@
     "@axe-core/playwright": "^4.10.2",
     "@axe-core/react": "^4.10.2",
     "accessibility-insights-scan": "^3.0.0",
-    "postcss": "^8.3.9",
+    "postcss": "8.5.19",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-test-renderer": "^18.3.1",
@@ -106,6 +106,7 @@
     "**/@types/glob": "7.2.0",
     "**/@types/minimatch": "3.0.5",
     "**/glob-parent": "5.1.2",
-    "**/join-images": "1.1.5"
+    "**/join-images": "1.1.5",
+    "**/nanoid": "3.3.18"
   }
 }

--- a/chat-components/package.json
+++ b/chat-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-components",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "Microsoft Omnichannel Chat Components",
   "main": "lib/cjs/index.js",
   "types": "lib/types/index.d.ts",

--- a/chat-components/yarn.lock
+++ b/chat-components/yarn.lock
@@ -12428,7 +12428,7 @@ nano-css@^5.6.2:
     stacktrace-js "^2.0.2"
     stylis "^4.3.0"
 
-nanoid@^3.1.18, nanoid@^3.3.1, nanoid@^3.3.17, nanoid@^3.3.4:
+nanoid@3.3.18, nanoid@^3.1.18, nanoid@^3.3.1, nanoid@^3.3.17, nanoid@^3.3.4:
   version "3.3.18"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
@@ -13547,7 +13547,16 @@ postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.2.15, postcss@^8.3.9:
+postcss@8.5.19:
+  version "8.5.19"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.19.tgz#45ad5cfde499408e20147348237551381a922037"
+  integrity sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==
+  dependencies:
+    nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.2.15:
   version "8.5.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
   integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-widget",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Microsoft Omnichannel Chat Widget",
   "main": "lib/cjs/index.js",
   "types": "lib/types/index.d.ts",
@@ -92,7 +92,7 @@
   "dependencies": {
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
-    "@microsoft/omnichannel-chat-components": "1.2.0",
+    "@microsoft/omnichannel-chat-components": "1.2.1",
     "@microsoft/omnichannel-chat-sdk": "2.0.0",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -72,7 +72,7 @@
     "@axe-core/react": "^4.10.2",
     "accessibility-insights-scan": "^3.0.0",
     "@guidepup/guidepup": "^0.24.1",
-    "postcss": "^8.3.9",
+    "postcss": "8.5.19",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-native-web": "^0.21.2",
@@ -98,7 +98,7 @@
     "abort-controller": "^3",
     "botframework-webchat": "4.18.1-hotfix.20260308.b15b405",
     "core-js-pure": "^3.42.0",
-    "dompurify": "^3.4.12",
+    "dompurify": "3.4.13",
     "markdown-it": "^14.3.0",
     "markdown-it-attrs": "^4.1.6",
     "markdown-it-for-inline": "^0.1.1",
@@ -163,7 +163,8 @@
     "**/@types/minimatch": "3.0.5",
     "**/@types/trusted-types": "2.0.7",
     "**/join-images": "1.1.5",
-    "**/valibot": "1.4.2"
+    "**/valibot": "1.4.2",
+    "**/nanoid": "3.3.18"
   },
   "jest": {
     "verbose": true,

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/omnichannel-chat-widget",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Microsoft Omnichannel Chat Widget",
   "main": "lib/cjs/index.js",
   "types": "lib/types/index.d.ts",
@@ -92,7 +92,7 @@
   "dependencies": {
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
-    "@microsoft/omnichannel-chat-components": "1.2.1",
+    "@microsoft/omnichannel-chat-components": "1.2.0",
     "@microsoft/omnichannel-chat-sdk": "2.0.0",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -9338,7 +9338,7 @@ domhandler@^6.0.0:
   dependencies:
     domelementtype "^3.0.0"
 
-dompurify@^3.4.12:
+dompurify@3.4.13:
   version "3.4.13"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
   integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
@@ -14751,7 +14751,7 @@ nano-css@^5.6.2:
     stacktrace-js "^2.0.2"
     stylis "^4.3.0"
 
-nanoid@^3.1.18, nanoid@^3.3.1, nanoid@^3.3.17, nanoid@^3.3.4:
+nanoid@3.3.18, nanoid@^3.1.18, nanoid@^3.3.1, nanoid@^3.3.17, nanoid@^3.3.4:
   version "3.3.18"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
@@ -15963,7 +15963,16 @@ postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.2.15, postcss@^8.3.11, postcss@^8.3.9:
+postcss@8.5.19:
+  version "8.5.19"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.19.tgz#45ad5cfde499408e20147348237551381a922037"
+  integrity sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==
+  dependencies:
+    nanoid "^3.3.12"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+postcss@^8.2.15, postcss@^8.3.11:
   version "8.5.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
   integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==


### PR DESCRIPTION
## Summary
- Pin `@microsoft/omnichannel-chat-widget` runtime `dompurify` to `3.4.13` (GHSA-55q2-fjhq-7xh7). `^3.4.12` still allows the vulnerable 3.4.12.
- Pin `postcss` to `8.5.19` in both packages (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).

## Storybook
Did **not** force `postcss@8.5.19` across the whole tree. Storybook 6.5 still depends on `postcss@^7`. Fixing that is a Storybook 7/8 migration (knobs is gone, `storybook-addon-playwright@4.9.2` is SB6-only, VRT baselines). Out of scope here.

## Test plan
- [ ] CI unit tests / package build
- [ ] Confirm `yarn.lock` on CI resolves `dompurify@3.4.13` and `postcss@8.5.19` for the direct deps