### PR TITLE
Uptake chat SDK 2.0.0-main.2749962

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
 
 ### Changed
+- Bumped `@microsoft/omnichannel-chat-sdk` to `2.0.0-main.2749962` in Chat Widget and automation tests.
 - Removed leftover Chat Widget tag and manual release workflows. Official `w-v*` tags now start only `npm-release.yml`.
 - Stopped Storybook deploy from running on `w-v*` tags. Pushes to `main` still deploy Storybook.
 - Consolidated the Chat Widget 2.0.0 notes into one Breaking, Changed, Added, Tests, Fixed, and Security section and removed mid-auth entries.

--- a/chat-widget/automation_tests/package.json
+++ b/chat-widget/automation_tests/package.json
@@ -38,7 +38,7 @@
     "@azure/identity": "^1.2.3",
     "@azure/keyvault-secrets": "^4.1.0",
     "@azure/service-bus": "^1.1.10",
-    "@microsoft/omnichannel-chat-sdk": "2.0.0",
+    "@microsoft/omnichannel-chat-sdk": "2.0.0-main.2749962",
     "@types/jest": "^25.2.1",
     "@types/jest-image-snapshot": "^2.12.0",
     "adal-node": "^0.2.2",

--- a/chat-widget/automation_tests/yarn.lock
+++ b/chat-widget/automation_tests/yarn.lock
@@ -1129,10 +1129,9 @@
   resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-amsclient/-/omnichannel-amsclient-0.2.0.tgz#999d7d5c74d08641ab4a6677603c95b75cbcd218"
   integrity sha512-wIubYjfzovWv2+P+AInxhOfB1MwVoR7veljAreHbq0Y+6haPMCxtY2LhIq8UGzGVk/UdcUXe3laV0AZdwBxSCw==
 
-"@microsoft/omnichannel-chat-sdk@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0.tgz#7f14ad36b33fa9ce6191f03acf7182bec705dbc0"
-  integrity sha512-HyKvjAUp8YmwyznW6Kyk1PoD4QPaC/N6V0dU7Pup18JNYAgRfi0QS9GSybrWtycwUY0iYw3PG99KonJVWj9KBQ==
+"@microsoft/omnichannel-chat-sdk@2.0.0-main.2749962":
+  version "2.0.0-main.2749962"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.2749962.tgz"
   dependencies:
     "@azure/communication-chat" "1.6.0-beta.7"
     "@azure/communication-common" "2.4.2"

--- a/chat-widget/automation_tests/yarn.lock
+++ b/chat-widget/automation_tests/yarn.lock
@@ -1131,7 +1131,8 @@
 
 "@microsoft/omnichannel-chat-sdk@2.0.0-main.2749962":
   version "2.0.0-main.2749962"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.2749962.tgz"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.2749962.tgz#a07af8cbc5765b20ddc8e04707e36b06e3732e8d"
+  integrity sha512-LX96zq2kI/z6FRci4eUfSnKXApVat0EC06Rj8O0p1RHDOlB+ZUMoXV65JKhllMaBAtHSLRvnVqBB5hVCmWidig==
   dependencies:
     "@azure/communication-chat" "1.6.0-beta.7"
     "@azure/communication-common" "2.4.2"

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -93,7 +93,7 @@
     "@azure/core-tracing": "^1.2.0",
     "@microsoft/applicationinsights-web": "^3.3.6",
     "@microsoft/omnichannel-chat-components": "1.2.0",
-    "@microsoft/omnichannel-chat-sdk": "2.0.0",
+    "@microsoft/omnichannel-chat-sdk": "2.0.0-main.2749962",
     "@opentelemetry/api": "^1.9.0",
     "abort-controller": "^3",
     "botframework-webchat": "4.18.1-hotfix.20260308.b15b405",

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2920,10 +2920,9 @@
     rxjs "^5.0.3"
     swiper "12.1.2"
 
-"@microsoft/omnichannel-chat-sdk@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0.tgz#7f14ad36b33fa9ce6191f03acf7182bec705dbc0"
-  integrity sha512-HyKvjAUp8YmwyznW6Kyk1PoD4QPaC/N6V0dU7Pup18JNYAgRfi0QS9GSybrWtycwUY0iYw3PG99KonJVWj9KBQ==
+"@microsoft/omnichannel-chat-sdk@2.0.0-main.2749962":
+  version "2.0.0-main.2749962"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.2749962.tgz"
   dependencies:
     "@azure/communication-chat" "1.6.0-beta.7"
     "@azure/communication-common" "2.4.2"

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -2922,7 +2922,8 @@
 
 "@microsoft/omnichannel-chat-sdk@2.0.0-main.2749962":
   version "2.0.0-main.2749962"
-  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.2749962.tgz"
+  resolved "https://registry.yarnpkg.com/@microsoft/omnichannel-chat-sdk/-/omnichannel-chat-sdk-2.0.0-main.2749962.tgz#a07af8cbc5765b20ddc8e04707e36b06e3732e8d"
+  integrity sha512-LX96zq2kI/z6FRci4eUfSnKXApVat0EC06Rj8O0p1RHDOlB+ZUMoXV65JKhllMaBAtHSLRvnVqBB5hVCmWidig==
   dependencies:
     "@azure/communication-chat" "1.6.0-beta.7"
     "@azure/communication-common" "2.4.2"


### PR DESCRIPTION
## Summary
- Pin `@microsoft/omnichannel-chat-sdk` to `2.0.0-main.2749962` in `chat-widget/package.json`.
- Update the corresponding entry in `chat-widget/yarn.lock` while preserving its transitive dependencies.
- Pin the same SDK version in `chat-widget/automation_tests/package.json`.
- Update the corresponding automation-test Yarn lock entry.

## Validation
- Parsed and asserted both package manifests with Node.js.
- Ran Yarn 1.22.22 `generate-lock-entry` in both package directories.
- Verified both lock selectors, versions, and transitive dependency blocks.
- Ran `git diff --check` and verified a clean committed worktree.

Full install/build validation could not run because dependencies are not installed in this worktree, the configured Microsoft npm proxy returns E404 for this prerelease, and public npm TLS is unavailable from the environment.