### PR TITLE
fix(chat-widget): iPhone keyboard gets stuck hidden after SendBox icon send (ICM 845629087)

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16,6 +16,12 @@ All notable changes to this project will be documented in this file.
 - Stopped Storybook deploy from running on `w-v*` tags. Pushes to `main` still deploy Storybook.
 - Consolidated the Chat Widget 2.0.0 notes into one Breaking, Changed, Added, Tests, Fixed, and Security section and removed mid-auth entries.
 
+### Fixed
+- [ICM 845629087] iPhone (iOS 26+) users could not type after tapping the SendBox icon (airplane) button following an advocate/bot reply: the on-screen keyboard would disappear and never reopen, showing only "Paste/AutoFill" options on subsequent taps (Enter-key send was unaffected; iPad/Android were unaffected). Root cause: `botframework-webchat`'s Send button issues `submit({ setFocus: 'sendBoxWithoutKeyboard' })`, and a newer WebChat release inserted an `await` (next animation frame) before re-focusing the textarea in that code path, breaking the synchronous "trusted user gesture" chain iOS requires to auto-show the keyboard. `WebChatContainerStateful` now intercepts the Send button's click in the capture phase, iPhone-only, and re-issues the send via WebChat's public `hooks.useSubmitSendBox()` using the `'sendBox'` method — the same method Enter-key send already uses safely — instead of `'sendBoxWithoutKeyboard'`. Android, iPad, and desktop are untouched by this change.
+
+### Tests
+- [ICM 845629087] Added unit tests for the new `isIPhoneDevice()` device check and the extracted, pure `createIOSSendBoxKeyboardFixHandler()` click-interception factory in `src/common/utils.test.ts` (8 device-detection cases + 3 handler-behavior cases: send-button click intercepted and re-submitted via `'sendBox'`, non-send-button clicks ignored, missing/detached target handled without throwing). Full existing `test:unit` suite (59 suites / 718 tests) re-verified to pass unchanged.
+
 ## [2.0.0] - 2026-08-18
 
 ### Breaking

--- a/chat-widget/src/common/Constants.ts
+++ b/chat-widget/src/common/Constants.ts
@@ -190,6 +190,7 @@ export class HtmlClassNames {
 
 export class HtmlElementSelectors {
     public static readonly sendBoxSelector = "textarea[data-id=\"webchat-sendbox-input\"]"
+    public static readonly sendButtonSelector = ".webchat__send-button"
 }
 
 export class HtmlAttributeNames {

--- a/chat-widget/src/common/utils.test.ts
+++ b/chat-widget/src/common/utils.test.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { changeLanguageCodeFormatForWebChat, escapeHtml, extractPreChatSurveyResponseValues, findParentFocusableElementsWithoutChildContainer, formatTemplateString, getBroadcastChannelName, getDomain, getIconText, getLocaleDirection, getTimestampHourMinute, getWidgetCacheId, getWidgetEndChatEventName, isNullOrEmptyString, isUndefinedOrEmpty, newGuid, parseAdaptiveCardPayload, parseLowerCaseString, setAriaHiddenForSiblings, preventFocusToMoveOutOfElement, setTabIndices } from "./utils";
+import { changeLanguageCodeFormatForWebChat, createIOSSendBoxKeyboardFixHandler, escapeHtml, extractPreChatSurveyResponseValues, findParentFocusableElementsWithoutChildContainer, formatTemplateString, getBroadcastChannelName, getDomain, getIconText, getLocaleDirection, getTimestampHourMinute, getWidgetCacheId, getWidgetEndChatEventName, isIPhoneDevice, isNullOrEmptyString, isUndefinedOrEmpty, newGuid, parseAdaptiveCardPayload, parseLowerCaseString, setAriaHiddenForSiblings, preventFocusToMoveOutOfElement, setTabIndices } from "./utils";
 import { AriaTelemetryConstants } from "./Constants";
 import { Md5 } from "md5-typescript";
 import { cleanup } from "@testing-library/react";
@@ -467,5 +467,105 @@ describe("utils unit test", () => {
         document.body.innerHTML = "<div id=\"other\">content</div>";
         const stateMap: Map<Element, string | null> = new Map();
         expect(() => setAriaHiddenForSiblings("nonexistent-id", true, stateMap)).not.toThrow();
+    });
+
+    describe("isIPhoneDevice (ICM 845629087 - iOS SendBox keyboard fix)", () => {
+        const iphoneUA = "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1";
+        const ipadUA = "Mozilla/5.0 (iPad; CPU OS 18_7_9 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Mobile/15E148 Safari/604.1";
+        const androidUA = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36";
+        const desktopUA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+        const bingAppOnIphoneUA = "Mozilla/5.0 (iPhone; CPU iPhone OS 26_5_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 BingWeb/26.5.0";
+
+        it("returns true for an iPhone Safari user agent", () => {
+            expect(isIPhoneDevice(iphoneUA)).toBe(true);
+        });
+
+        it("returns true for an iPhone user agent inside the Bing app WebView", () => {
+            expect(isIPhoneDevice(bingAppOnIphoneUA)).toBe(true);
+        });
+
+        it("returns false for an iPad user agent (iPad is not affected by ICM 845629087)", () => {
+            expect(isIPhoneDevice(ipadUA)).toBe(false);
+        });
+
+        it("returns false for an Android user agent", () => {
+            expect(isIPhoneDevice(androidUA)).toBe(false);
+        });
+
+        it("returns false for a desktop user agent", () => {
+            expect(isIPhoneDevice(desktopUA)).toBe(false);
+        });
+
+        it("is case-insensitive", () => {
+            expect(isIPhoneDevice(iphoneUA.toUpperCase())).toBe(true);
+        });
+
+        it("falls back to navigator.userAgent when no override is provided", () => {
+            const originalUserAgent = navigator.userAgent;
+            Object.defineProperty(navigator, "userAgent", { value: iphoneUA, configurable: true });
+            expect(isIPhoneDevice()).toBe(true);
+            Object.defineProperty(navigator, "userAgent", { value: originalUserAgent, configurable: true });
+        });
+
+        it("returns false when userAgent is an empty string", () => {
+            expect(isIPhoneDevice("")).toBe(false);
+        });
+    });
+
+    describe("createIOSSendBoxKeyboardFixHandler (ICM 845629087 - iOS SendBox keyboard fix)", () => {
+        const sendButtonSelector = ".webchat__send-button";
+
+        const buildClickEvent = (target: HTMLElement): MouseEvent => {
+            const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+            Object.defineProperty(event, "target", { value: target, configurable: true });
+            jest.spyOn(event, "preventDefault");
+            jest.spyOn(event, "stopImmediatePropagation");
+            return event;
+        };
+
+        afterEach(() => {
+            document.body.innerHTML = "";
+        });
+
+        it("intercepts a click on the send button: prevents default, stops propagation, and re-submits via 'sendBox'", () => {
+            document.body.innerHTML = "<button class=\"webchat__send-button\"><svg><path /></svg></button>";
+            const sendButton = document.querySelector(".webchat__send-button") as HTMLElement;
+            const svgPath = sendButton.querySelector("path") as unknown as HTMLElement; // simulate click landing on an inner icon element
+
+            const submitSendBox = jest.fn();
+            const handler = createIOSSendBoxKeyboardFixHandler(submitSendBox, sendButtonSelector);
+
+            const event = buildClickEvent(svgPath);
+            handler(event);
+
+            expect(event.preventDefault).toHaveBeenCalledTimes(1);
+            expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+            expect(submitSendBox).toHaveBeenCalledTimes(1);
+            expect(submitSendBox).toHaveBeenCalledWith("sendBox");
+        });
+
+        it("does nothing when the click target is not the send button (or a descendant of it)", () => {
+            document.body.innerHTML = "<button class=\"webchat__send-button\"></button><button class=\"webchat__upload-button\"></button>";
+            const uploadButton = document.querySelector(".webchat__upload-button") as HTMLElement;
+
+            const submitSendBox = jest.fn();
+            const handler = createIOSSendBoxKeyboardFixHandler(submitSendBox, sendButtonSelector);
+
+            const event = buildClickEvent(uploadButton);
+            handler(event);
+
+            expect(event.preventDefault).not.toHaveBeenCalled();
+            expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+            expect(submitSendBox).not.toHaveBeenCalled();
+        });
+
+        it("does nothing when the click target has no closest() (e.g. a detached/text node)", () => {
+            const submitSendBox = jest.fn();
+            const handler = createIOSSendBoxKeyboardFixHandler(submitSendBox, sendButtonSelector);
+
+            const event = buildClickEvent(null as unknown as HTMLElement);
+            expect(() => handler(event)).not.toThrow();
+            expect(submitSendBox).not.toHaveBeenCalled();
+        });
     });
 });

--- a/chat-widget/src/common/utils.ts
+++ b/chat-widget/src/common/utils.ts
@@ -570,6 +570,56 @@ export function getDeviceType(): string {
     }
 }
 
+/**
+ * Detects iPhone specifically (excluding iPad/iPod), to scope platform-specific
+ * workarounds as narrowly as possible. Used by the iOS SendBox keyboard fix
+ * (ICM 845629087) so that iPad, which is not affected, remains untouched.
+ * @param userAgentOverride - optional user agent string, primarily for testing.
+ */
+export function isIPhoneDevice(userAgentOverride?: string): boolean {
+    const userAgent = (userAgentOverride ?? navigator.userAgent ?? "").toLowerCase();
+    return /iphone/.test(userAgent);
+}
+
+// ICM 845629087 - iOS SendBox keyboard-stuck fix.
+//
+// WebChat's default Send button issues `submit({ setFocus: 'sendBoxWithoutKeyboard' })`,
+// which sets `inputmode="none"` on the textarea and hides the keyboard after send. The
+// built-in recovery path (the textarea's own onClick handler resets `inputmode` back to
+// "text" on the user's next tap, expecting the keyboard to reopen) can fail on iPhone
+// (iOS 26+), leaving the textarea focused but keyboard-suppressed after the first send.
+//
+// Sending via the Enter key already calls `submit('sendBox')` instead (keeps the keyboard
+// open) and does not exhibit this bug on the same devices. This factory builds a
+// capture-phase click handler - meant to be attached to a WebChat root ancestor - that
+// intercepts the Send button's click before WebChat's own handler runs, and re-issues the
+// submit using that same already-safe 'sendBox' method, reusing WebChat's own submit/focus
+// pipeline rather than re-implementing it.
+//
+// Extracted as a standalone, pure factory (rather than being inlined in a component
+// useEffect) specifically so it can be unit tested directly with a mock MouseEvent and a
+// mock submitSendBox function, without needing to mount the full WebChatContainerStateful
+// component tree.
+export function createIOSSendBoxKeyboardFixHandler(
+    submitSendBox: (method?: string) => void,
+    sendButtonSelector: string
+): (event: MouseEvent) => void {
+    return (event: MouseEvent) => {
+        const target = event.target as HTMLElement | null;
+        const sendButton = target?.closest?.(sendButtonSelector);
+        if (!sendButton) {
+            return;
+        }
+
+        // Prevent WebChat's default 'sendBoxWithoutKeyboard' handler (and the native form
+        // submit it would otherwise trigger) from running, then re-issue the send using the
+        // already-safe 'sendBox' method.
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        submitSendBox("sendBox");
+    };
+}
+
 //Bots expect a payload containing:
 //1. customEventName: this should be string describe the event name
 //2. customEventValue: given the value is from customer with unknown type, it is required to stringify the payload later

--- a/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
+++ b/chat-widget/src/components/webchatcontainerstateful/WebChatContainerStateful.tsx
@@ -1,12 +1,12 @@
-import { Constants, HtmlAttributeNames, HtmlClassNames } from "../../common/Constants";
+import { Constants, HtmlAttributeNames, HtmlClassNames, HtmlElementSelectors } from "../../common/Constants";
 import { IRawStyle, IStackStyles, Stack } from "@fluentui/react";
 import { LogLevel, TelemetryEvent } from "../../common/telemetry/TelemetryConstants";
 import React, { Dispatch, useEffect, useRef, useState } from "react";
-import { createTimer, getDeviceType, setFocusOnSendBox } from "../../common/utils";
+import { createIOSSendBoxKeyboardFixHandler, createTimer, getDeviceType, isIPhoneDevice, setFocusOnSendBox } from "../../common/utils";
 
 import { BotMagicCodeStore } from "./webchatcontroller/BotMagicCodeStore";
 import CitationPaneStateful from "../citationpanestateful/CitationPaneStateful";
-import { Components } from "botframework-webchat";
+import { Components, hooks } from "botframework-webchat";
 import { ExtendedChatConfig } from "./interfaces/IExtendedChatConffig";
 import { FacadeChatSDK } from "../../common/facades/FacadeChatSDK";
 import { ILiveChatWidgetAction } from "../../contexts/common/ILiveChatWidgetAction";
@@ -94,6 +94,8 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
 
 
     const { BasicWebChat } = Components;
+    const { useSubmitSendBox } = hooks;
+    const submitSendBox = useSubmitSendBox();
     const [ state, dispatch ]: [ILiveChatWidgetContext, Dispatch<ILiveChatWidgetAction>] = useChatContextStore();
     const { webChatContainerProps, contextDataStore } = props;
 
@@ -374,6 +376,40 @@ export const WebChatContainerStateful = (props: ILiveChatWidgetProps) => {
             setFocusOnSendBox();
         }
     }, [state.appStates.isMinimized]);
+
+    // iPhone SendBox keyboard-stuck fix (ICM 845629087).
+    //
+    // Root cause: WebChat's default Send button issues
+    // `submit({ setFocus: 'sendBoxWithoutKeyboard' })`, which deliberately sets
+    // `inputmode="none"` on the textarea and hides the keyboard after send. The
+    // built-in recovery path (the textarea's own onClick handler resets
+    // `inputmode` back to "text" on the user's next tap, expecting the keyboard
+    // to reopen) can fail on iPhone, leaving the textarea permanently focused
+    // but keyboard-suppressed after the first send - matching the reported
+    // "keyboard disappears, only Paste/AutoFill options shown" symptom.
+    //
+    // Sending via the Enter key already calls `submit('sendBox')` instead
+    // (keeps the keyboard open) and does not exhibit this bug on the same
+    // devices. This effect intercepts the Send button's click on iPhone only,
+    // in the capture phase (before WebChat's own click handler runs), and
+    // re-issues the submit using that same 'sendBox' method already proven
+    // safe for Enter-key send - reusing WebChat's own submit/focus pipeline
+    // rather than re-implementing it. Every other platform/browser (Android,
+    // iPad, desktop) is completely untouched by this effect.
+    useEffect(() => {
+        if (!isIPhoneDevice()) {
+            return;
+        }
+
+        const webChatRoot = document.getElementById("ms_lcw_webchat_root");
+        if (!webChatRoot) {
+            return;
+        }
+
+        const handleSendButtonClickCapture = createIOSSendBoxKeyboardFixHandler(submitSendBox, HtmlElementSelectors.sendButtonSelector);
+        webChatRoot.addEventListener("click", handleSendButtonClickCapture, true);
+        return () => webChatRoot.removeEventListener("click", handleSendButtonClickCapture, true);
+    }, [submitSendBox]);
 
     return (
         <>


### PR DESCRIPTION
## Problem (ICM 845629087)

iPhone (iOS 26+) customers using Bing app / Safari lose the ability to type after the first message exchange:

1. Customer sends a message using the **SendBox icon (airplane) button**.
2. Advocate/bot replies.
3. Customer taps the message input again — **the keyboard never reappears**. Only "Paste / AutoFill" options are shown.

Confirmed by the reporting team:
- Reproduces only when sending via the **icon button**, not the Enter key.
- Reproduces only on **iOS 26.52**, not iOS 18.7.9.
- iPad and Android are **not** affected.

## Root cause

`botframework-webchat`'s Send button issues `submit({ setFocus: 'sendBoxWithoutKeyboard' })`, which sets `inputmode="none"` on the textarea to intentionally hide the keyboard after send. The textarea's own `onClick` handler is supposed to reset `inputmode` back to `"text"` on the customer's next tap, letting the keyboard reopen.

Diffing the two `botframework-webchat` releases that straddle this incident's start date, the send-focus logic changed from fully synchronous to:

```js
waitUntil(async () => {
  if (noKeyboard) {
    await new Promise(requestAnimationFrame); // <-- new
    el.setAttribute('inputmode', 'none');
  }
  el.focus();
});
```

The added `await` before `.focus()` — present **only** in the `noKeyboard: true` (icon Send button) branch — breaks the synchronous "trusted user gesture" chain that iOS requires in order to auto-show the keyboard on `.focus()`. The Enter-key path (`submit('sendBox')`, `noKeyboard: false`) never awaits, stays inside the same tick as the user gesture, and is unaffected — matching the exact repro reported (icon breaks, Enter doesn't; iOS 26 only).

## Fix

`WebChatContainerStateful` now intercepts the Send button's click in the **capture phase** (before WebChat's own handler runs), **iPhone only** (`isIPhoneDevice()`, explicitly excluding iPad/iPod), and re-issues the send via WebChat's public `hooks.useSubmitSendBox()` using the `'sendBox'` method — the exact same method Enter-key send already uses safely. This reuses WebChat's own tested submit/focus pipeline instead of reimplementing message-posting logic, keeping the change small and low-risk.

The click-handling logic is extracted into a standalone, pure `createIOSSendBoxKeyboardFixHandler()` factory in `common/utils.ts` so it is directly unit-testable without mounting the full `WebChatContainerStateful` component tree.

**Blast radius:** Android, iPad, and desktop are untouched by construction — the new effect no-ops immediately unless `isIPhoneDevice()` returns `true`.

## Changes

- `src/common/utils.ts` — new `isIPhoneDevice()` and `createIOSSendBoxKeyboardFixHandler()` helpers.
- `src/common/Constants.ts` — new `HtmlElementSelectors.sendButtonSelector`.
- `src/components/webchatcontainerstateful/WebChatContainerStateful.tsx` — new iPhone-only capture-phase click interception effect.
- `src/common/utils.test.ts` — 11 new unit tests (see Testing below).
- `CHANGE_LOG.md` — `[Unreleased] > Fixed` / `> Tests` entries.

## Testing

- **New unit tests** (`src/common/utils.test.ts`):
  - `isIPhoneDevice()` — 8 cases: iPhone Safari, iPhone inside Bing app WebView, iPad (must be `false`), Android, desktop, case-insensitivity, `navigator.userAgent` fallback, empty UA.
  - `createIOSSendBoxKeyboardFixHandler()` — 3 cases: send-button click intercepted (`preventDefault`/`stopImmediatePropagation` called, `submitSendBox('sendBox')` invoked); non-send-button click ignored; missing/detached click target handled without throwing.
- **Full existing `test:unit` suite** re-run after the change: **59 suites / 718 tests, all passing** — no regressions.
- `tsc --noEmit` and `eslint` on all touched files show **zero new errors** (verified by diffing against a `git stash` baseline).
- Also exercised `WebChatContainerStateful.citation.test.tsx` (renders the component with the real `botframework-webchat` package, no mocks): it fails **identically before and after** this change, for a pre-existing, unrelated reason (missing `ChatContextStore.Provider` in that test's render). This test is also excluded from CI's `test:unit` run (`testPathIgnorePatterns` excludes `__tests__` folders), so it provides no regression signal either way — noted here for transparency.

## Confidence & residual risk

- **High confidence in root cause**: the version-diff finding (added `await` before `.focus()` in the icon-button-only branch) independently reconciles with the ICM's own empirical evidence (icon breaks, Enter doesn't; iOS 26 only, not iPad/Android).
- **Low-risk fix**: reuses WebChat's own already-proven `'sendBox'` submit path (identical to what Enter-key send already does safely) rather than reimplementing focus/message logic; scoped to iPhone only.
- **Full regression suite passes** (718 tests) with no changes in behavior for any non-iPhone platform.
- **Caveat**: no JS test runner (jsdom or Chromium-based Playwright visual tests) can simulate real native iOS on-screen keyboard show/hide behavior. I'd recommend a manual smoke test on a physical iPhone running iOS 26 before merging, to close the loop on the one thing automated tests structurally cannot verify.

Fixes ICM 845629087.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
