### PR TITLE
Fix iOS transcript loss on first send-box focus

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 - Stopped Storybook deploy from running on `w-v*` tags. Pushes to `main` still deploy Storybook.
 - Consolidated the Chat Widget 2.0.0 notes into one Breaking, Changed, Added, Tests, Fixed, and Security section and removed mid-auth entries.
 
+### Fixed
+- [iOS] Use the native send-box placeholder style to prevent Safari from scrolling chat content off-screen on first focus.
+
 ## [2.0.0] - 2026-08-18
 
 ### Breaking

--- a/chat-widget/src/common/utils.test.ts
+++ b/chat-widget/src/common/utils.test.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 
-import { changeLanguageCodeFormatForWebChat, escapeHtml, extractPreChatSurveyResponseValues, findParentFocusableElementsWithoutChildContainer, formatTemplateString, getBroadcastChannelName, getDomain, getIconText, getLocaleDirection, getTimestampHourMinute, getWidgetCacheId, getWidgetEndChatEventName, isNullOrEmptyString, isUndefinedOrEmpty, newGuid, parseAdaptiveCardPayload, parseLowerCaseString, setAriaHiddenForSiblings, preventFocusToMoveOutOfElement, setTabIndices } from "./utils";
+import { changeLanguageCodeFormatForWebChat, escapeHtml, extractPreChatSurveyResponseValues, findParentFocusableElementsWithoutChildContainer, formatTemplateString, getBroadcastChannelName, getDeviceType, getDomain, getIconText, getLocaleDirection, getTimestampHourMinute, getWidgetCacheId, getWidgetEndChatEventName, isNullOrEmptyString, isUndefinedOrEmpty, newGuid, parseAdaptiveCardPayload, parseLowerCaseString, setAriaHiddenForSiblings, preventFocusToMoveOutOfElement, setTabIndices } from "./utils";
 import { AriaTelemetryConstants } from "./Constants";
 import { Md5 } from "md5-typescript";
 import { cleanup } from "@testing-library/react";
@@ -148,6 +148,57 @@ describe("utils unit test", () => {
         const string6 = "测试";
         const result6 = getIconText(string6);
         expect(result6).toBe("测试");
+    });
+
+    describe("getDeviceType", () => {
+        const originalUserAgent = navigator.userAgent;
+        const originalMaxTouchPoints = navigator.maxTouchPoints;
+
+        afterEach(() => {
+            Object.defineProperty(navigator, "userAgent", {
+                configurable: true,
+                value: originalUserAgent
+            });
+            Object.defineProperty(navigator, "maxTouchPoints", {
+                configurable: true,
+                value: originalMaxTouchPoints
+            });
+        });
+
+        it("detects iPhone user agents", () => {
+            Object.defineProperty(navigator, "userAgent", {
+                configurable: true,
+                value: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)"
+            });
+
+            expect(getDeviceType()).toBe("ios");
+        });
+
+        it("detects iPadOS desktop-mode user agents", () => {
+            Object.defineProperty(navigator, "userAgent", {
+                configurable: true,
+                value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15"
+            });
+            Object.defineProperty(navigator, "maxTouchPoints", {
+                configurable: true,
+                value: 5
+            });
+
+            expect(getDeviceType()).toBe("ios");
+        });
+
+        it("does not classify a Mac without touch support as iOS", () => {
+            Object.defineProperty(navigator, "userAgent", {
+                configurable: true,
+                value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15"
+            });
+            Object.defineProperty(navigator, "maxTouchPoints", {
+                configurable: true,
+                value: 0
+            });
+
+            expect(getDeviceType()).toBe("standard");
+        });
     });
 
     it("Test escapeHtml", () => {

--- a/chat-widget/src/common/utils.ts
+++ b/chat-widget/src/common/utils.ts
@@ -561,9 +561,10 @@ export const setOcUserAgent = (chatSDK: any): void => { // eslint-disable-line @
 
 export function getDeviceType(): string {
     const userAgent = navigator.userAgent.toLowerCase();
+    const isIPadOSDesktop = /macintosh/.test(userAgent) && navigator.maxTouchPoints > 1;
     if (/android/.test(userAgent)) {
         return "android";
-    } else if (/iphone|ipad|ipod/.test(userAgent)) {
+    } else if (/iphone|ipad|ipod/.test(userAgent) || isIPadOSDesktop) {
         return "ios";
     } else {
         return "standard";

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -11,6 +11,7 @@ import {
     createTimer,
     getBroadcastChannelName,
     getConversationDetailsCall,
+    getDeviceType,
     getLocaleDirection,
     getStateFromCache,
     getWidgetCacheIdfromProps,
@@ -75,6 +76,7 @@ import StartChatOptionalParams from "@microsoft/omnichannel-chat-sdk/lib/core/St
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import WebChatContainerStateful from "../../webchatcontainerstateful/WebChatContainerStateful";
 import createDownloadTranscriptProps from "../common/createDownloadTranscriptProps";
+import { createIOSCompatibleStyleSet } from "../../webchatcontainerstateful/common/utils/createIOSCompatibleStyleSet";
 import { createFooter } from "../common/createFooter";
 import { createInternetConnectionChangeHandler } from "../common/createInternetConnectionChangeHandler";
 import { defaultAdaptiveCardStyles } from "../../webchatcontainerstateful/common/defaultStyles/defaultAdaptiveCardStyles";
@@ -930,6 +932,14 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
         bubbleBackground,
         bubbleTextColor
     }), [webChatStyles, bubbleBackground, bubbleTextColor]);
+    const isIOSDevice = getDeviceType() === "ios";
+    // Avoid Safari's native placeholder focus-scroll race while preserving all other WebChat styles.
+    const webChatStyleSet = React.useMemo(
+        () => isIOSDevice
+            ? createIOSCompatibleStyleSet(styleOptions, webChatProps.styleSet)
+            : webChatProps.styleSet,
+        [isIOSDevice, styleOptions, webChatProps.styleSet]
+    );
 
     // React to dynamic bot avatar initials updates from context
     useEffect(() => {
@@ -1072,6 +1082,7 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
             <DraggableChatWidget {...chatWidgetDraggableConfig}>
                 <Composer
                     {...webChatProps}
+                    styleSet={webChatStyleSet}
                     userID={userID}
                     styleOptions={styleOptions}
                     directLine={directLine}>

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/createIOSCompatibleStyleSet.test.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/createIOSCompatibleStyleSet.test.ts
@@ -1,0 +1,58 @@
+import { createIOSCompatibleStyleSet } from "./createIOSCompatibleStyleSet";
+import { createStyleSet } from "botframework-webchat";
+
+const sendBoxRootSelector = "&.webchat__send-box-text-box";
+const sendBoxInputSelector = "& .webchat__send-box-text-box__input, & .webchat__send-box-text-box__html-text-area";
+const placeholderSelector = "&::placeholder";
+
+const getSendBoxInputStyle = (styleSet: ReturnType<typeof createStyleSet>) =>
+    styleSet.sendBoxTextBox[sendBoxRootSelector][sendBoxInputSelector];
+const getPlaceholderStyle = (styleSet: ReturnType<typeof createStyleSet>) =>
+    getSendBoxInputStyle(styleSet)[placeholderSelector];
+
+describe("createIOSCompatibleStyleSet", () => {
+    beforeAll(() => {
+        Object.defineProperty(URL, "createObjectURL", {
+            configurable: true,
+            value: jest.fn()
+        });
+    });
+
+    it("removes the native placeholder pseudo-element style that triggers Safari focus scrolling", () => {
+        const styleSet = createStyleSet({});
+
+        expect(getPlaceholderStyle(styleSet)).toBeDefined();
+
+        const result = createIOSCompatibleStyleSet({}, styleSet);
+
+        expect(getPlaceholderStyle(result)).toBeUndefined();
+        expect(getPlaceholderStyle(styleSet)).toBeDefined();
+    });
+
+    it("removes placeholder styling from a caller-supplied style set", () => {
+        const styleSet = createStyleSet({});
+        const sendBoxRootStyle = styleSet.sendBoxTextBox[sendBoxRootSelector];
+        const sendBoxInputStyle = sendBoxRootStyle[sendBoxInputSelector];
+        const customStyleSet = {
+            ...styleSet,
+            sendBoxTextBox: {
+                ...styleSet.sendBoxTextBox,
+                [sendBoxRootSelector]: {
+                    ...sendBoxRootStyle,
+                    [sendBoxInputSelector]: {
+                        ...sendBoxInputStyle,
+                        [placeholderSelector]: {
+                            color: "Red"
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = createIOSCompatibleStyleSet({}, customStyleSet);
+
+        expect(getPlaceholderStyle(result)).toBeUndefined();
+        expect(getSendBoxInputStyle(result).backgroundColor).toBe("transparent");
+        expect(getPlaceholderStyle(customStyleSet)).toEqual({ color: "Red" });
+    });
+});

--- a/chat-widget/src/components/webchatcontainerstateful/common/utils/createIOSCompatibleStyleSet.ts
+++ b/chat-widget/src/components/webchatcontainerstateful/common/utils/createIOSCompatibleStyleSet.ts
@@ -1,0 +1,39 @@
+import { createStyleSet } from "botframework-webchat";
+import type { StyleOptions } from "botframework-webchat";
+
+type WebChatStyleSet = ReturnType<typeof createStyleSet>;
+
+const sendBoxRootSelector = "&.webchat__send-box-text-box";
+const sendBoxInputSelector = "& .webchat__send-box-text-box__input, & .webchat__send-box-text-box__html-text-area";
+const placeholderSelector = "&::placeholder";
+
+// Safari can make the document taller and scroll the send box off-screen when a form control's
+// native placeholder pseudo-element has any style rule. Keep the placeholder, but use its native style.
+// https://github.com/microsoft/BotFramework-WebChat/issues/4732
+export const createIOSCompatibleStyleSet = (
+    styleOptions: StyleOptions,
+    styleSet?: WebChatStyleSet
+): WebChatStyleSet => {
+    const resolvedStyleSet = styleSet ?? createStyleSet(styleOptions);
+    const sendBoxTextBox = resolvedStyleSet.sendBoxTextBox;
+    const sendBoxRootStyle = sendBoxTextBox?.[sendBoxRootSelector];
+    const sendBoxInputStyle = sendBoxRootStyle?.[sendBoxInputSelector];
+
+    if (!sendBoxInputStyle || !Object.prototype.hasOwnProperty.call(sendBoxInputStyle, placeholderSelector)) {
+        return resolvedStyleSet;
+    }
+
+    const sendBoxInputStyleWithoutPlaceholder = { ...sendBoxInputStyle };
+    Reflect.deleteProperty(sendBoxInputStyleWithoutPlaceholder, placeholderSelector);
+
+    return {
+        ...resolvedStyleSet,
+        sendBoxTextBox: {
+            ...sendBoxTextBox,
+            [sendBoxRootSelector]: {
+                ...sendBoxRootStyle,
+                [sendBoxInputSelector]: sendBoxInputStyleWithoutPlaceholder
+            }
+        }
+    };
+};


### PR DESCRIPTION
## Summary

On iOS, remove Web Chat's author style for the send-box `::placeholder` pseudo-element.

The native placeholder text remains visible. Desktop and Android behavior stays unchanged. The pinned Web Chat version remains `4.18.1-hotfix.20260308.b15b405`.

## Cause

iOS Safari can interrupt its form-control focus scroll when any author rule targets `::placeholder`. The iframe body then becomes taller. Chat content moves outside the visible viewport until the user scrolls manually.

The Web Chat maintainer's minimal repro shows that an empty `::placeholder` rule can cause the failure. Removing the rule prevents the failure.

PR #220 removed scrolling from the LCW iframe shell. The customer still reproduced the failure after that change reached PPE. This change removes the Web Chat CSS trigger instead.

## Change

- Build the normal Web Chat style set on iOS.
- Remove only the send-box `&::placeholder` rule.
- Preserve the caller's style-set object and all other style rules.
- Continue to support a caller-supplied `styleSet`.
- Use the native iOS placeholder color as the intentional visual tradeoff.

## Validation

- `yarn test:unit`: 61 suites and 713 tests passed.
- The focused regression test passes with the pinned Web Chat package.
- `yarn lint` passes.
- The ESM and CJS builds pass.
- The customer video replay detects the first-focus blank state and manual-scroll recovery.

A clean local install failed during a TLS handshake with `registry.yarnpkg.com`. Full local TypeScript checking used an older dependency tree and stopped on two unrelated Markdown-It module errors. CI will run with the locked dependency tree.

## Links

- IcM 31000000646399: https://portal.microsofticm.com/imp/v5/incidents/details/31000000646399/summary
- Web Chat issue: https://github.com/microsoft/BotFramework-WebChat/issues/4732
- Maintainer repro: https://github.com/compulim/experiment-safari-auto-scroll-keyboard
- Earlier LCW shell fix: https://github.com/microsoft/CRM.OmniChannel.LiveChatWidget/pull/220
