### PR TITLE
fix(chat): validate cached Loading conversations before new chat

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 - Stopped Storybook deploy from running on `w-v*` tags. Pushes to `main` still deploy Storybook.
 - Consolidated the Chat Widget 2.0.0 notes into one Breaking, Changed, Added, Tests, Fixed, and Security section and removed mid-auth entries.
 
+### Fixed
+- [Bug 6667146] Cached chat recovery now validates a persisted `Loading` conversation when a request ID is still available, instead of treating the transient UI state as a new-chat signal. Recovery eligibility emits privacy-safe reason-code telemetry and continues to exclude explicit terminal, post-chat, proactive, out-of-office, and reconnect-choice states.
+
 ## [2.0.0] - 2026-08-18
 
 ### Breaking

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Security
 - Pin `dompurify` to `3.4.13` (GHSA-55q2-fjhq-7xh7).
 - Pin `postcss` to `8.5.19` (CVE-2026-69153) and resolve nested `nanoid@3.3.18` (CVE-2026-67213 / CVE-2026-67214).
+- Pin direct `sanitize-html` to `2.17.7`; retain reviewed audit-only findings for the required WebChat hotfix's nested `sanitize-html@2.14.0`.
 
 ### Changed
 - Bumped `@microsoft/omnichannel-chat-sdk` to `2.0.0-main.2749962` in Chat Widget and automation tests.

--- a/chat-widget/package.json
+++ b/chat-widget/package.json
@@ -104,7 +104,7 @@
     "markdown-it-for-inline": "^0.1.1",
     "md5-typescript": "^1.0.5",
     "rxjs": "5.5.12",
-    "sanitize-html": "2.17.6",
+    "sanitize-html": "2.17.7",
     "simple-update-in": "2.2.0",
     "slack-markdown-it": "^1.0.5"
   },

--- a/chat-widget/scripts/validate-consumer-audit.cjs
+++ b/chat-widget/scripts/validate-consumer-audit.cjs
@@ -28,6 +28,8 @@ const allowedAdvisories = new Map([
     ["@babel/runtime@7.19.0 -> https://github.com/advisories/GHSA-968p-4wvh-cqc8", [WEBCHAT]], // Named-capture replacement ReDoS.
     ["@babel/runtime-corejs3@7.20.13 -> https://github.com/advisories/GHSA-968p-4wvh-cqc8", [WEBCHAT]], // Named-capture replacement ReDoS.
     ["sanitize-html@2.14.0 -> https://github.com/advisories/GHSA-vccv-cmxp-4j9h", [WEBCHAT]], // URI scheme validation gap.
+    ["sanitize-html@2.14.0 -> https://github.com/advisories/GHSA-g8qq-57p8-ggw5", [WEBCHAT]], // SVG SMIL URI-list bypass.
+    ["sanitize-html@2.14.0 -> https://github.com/advisories/GHSA-jxwj-j7wr-gfrw", [WEBCHAT]], // Solidus-close mutation XSS.
     ["swiper@8.4.7 -> https://github.com/advisories/GHSA-hmx5-qpq5-p643", [WEBCHAT]], // Prototype pollution.
     ["valibot@1.1.0 -> https://github.com/advisories/GHSA-5qjj-4xww-7phc", [WEBCHAT]], // Inherited-key flatten failure.
     ["valibot@1.1.0 -> https://github.com/advisories/GHSA-vqpr-j7v3-hqw9", [WEBCHAT]], // Emoji validation ReDoS.

--- a/chat-widget/src/common/telemetry/TelemetryConstants.ts
+++ b/chat-widget/src/common/telemetry/TelemetryConstants.ts
@@ -101,6 +101,7 @@ export enum TelemetryEvent {
     MidConversationAuthSucceeded = "MidConversationAuthSucceeded",
     MidConversationAuthFailed = "MidConversationAuthFailed",
     MidConversationAuthReset = "MidConversationAuthReset",
+    RecoveryEligibilityEvaluated = "RecoveryEligibilityEvaluated",
     GetConversationDetailsCallStarted = "GetConversationDetailsCallStarted",
     GetConversationDetailsCallFailed = "GetConversationDetailsCallFailed",
     EndChatSDKCallFailed = "EndChatSDKCallFailed",
@@ -424,6 +425,7 @@ export class TelemetryConstants {
             case TelemetryEvent.SecureEventBusDispatchError:
             case TelemetryEvent.AgentJoinedConversation:
             case TelemetryEvent.BrowserTabHidden:
+            case TelemetryEvent.RecoveryEligibilityEvaluated:
                 return ScenarioType.ACTIONS;
 
             case TelemetryEvent.StartChatSDKCall:

--- a/chat-widget/src/components/livechatwidget/common/recoveryEligibility.test.ts
+++ b/chat-widget/src/components/livechatwidget/common/recoveryEligibility.test.ts
@@ -1,0 +1,160 @@
+import { ConversationState } from "../../../contexts/common/ConversationState";
+import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
+import {
+    RecoveryEligibilityReason,
+    evaluateRecoveryEligibility,
+    getRecoveryEligibilityTelemetryProperties
+} from "./recoveryEligibility";
+
+function createState(
+    conversationState: unknown,
+    liveChatContext?: unknown,
+    reconnectId?: string
+): ILiveChatWidgetContext {
+    const cachedContext = arguments.length > 1
+        ? liveChatContext
+        : { requestId: "cached-request-id" };
+
+    return {
+        appStates: {
+            conversationState,
+            reconnectId
+        },
+        domainStates: {
+            liveChatContext: cachedContext
+        }
+    } as ILiveChatWidgetContext;
+}
+
+describe("evaluateRecoveryEligibility", () => {
+    const eligibleCachedStates = new Set([
+        ConversationState.Active,
+        ConversationState.Loading
+    ]);
+    const unsupportedCachedStates = Object.values(ConversationState)
+        .filter((value): value is ConversationState =>
+            typeof value === "number" && !eligibleCachedStates.has(value));
+
+    it.each(Object.values(ConversationState).filter((value) => typeof value === "number"))(
+        "prioritizes reconnectId for conversation state %s",
+        (conversationState) => {
+            const liveChatContext = { requestId: "cached-request-id" };
+            const decision = evaluateRecoveryEligibility(
+                createState(conversationState, liveChatContext, "reconnect-id")
+            );
+
+            expect(decision).toMatchObject({
+                eligible: true,
+                optionalParams: { reconnectId: "reconnect-id" },
+                hasReconnectId: true,
+                hasLiveChatContext: true,
+                hasRequestId: true,
+                reason: RecoveryEligibilityReason.ReconnectIdPresent
+            });
+        }
+    );
+
+    it("prioritizes reconnectId when cached context is absent", () => {
+        expect(evaluateRecoveryEligibility(
+            createState(ConversationState.Prechat, null, "reconnect-id")
+        )).toMatchObject({
+            eligible: true,
+            optionalParams: { reconnectId: "reconnect-id" },
+            hasReconnectId: true,
+            hasLiveChatContext: false,
+            hasRequestId: false,
+            reason: RecoveryEligibilityReason.ReconnectIdPresent
+        });
+    });
+
+    it.each([
+        [ConversationState.Active, RecoveryEligibilityReason.ActiveContextPresent],
+        [ConversationState.Loading, RecoveryEligibilityReason.LoadingContextPresent]
+    ])("validates cached context in %s state", (conversationState, reason) => {
+        const liveChatContext = { requestId: "cached-request-id" };
+        const decision = evaluateRecoveryEligibility(createState(conversationState, liveChatContext));
+
+        expect(decision).toMatchObject({
+            eligible: true,
+            optionalParams: { liveChatContext },
+            hasReconnectId: false,
+            hasLiveChatContext: true,
+            hasRequestId: true,
+            reason
+        });
+    });
+
+    it("keeps requestId-only cached context eligible for validation", () => {
+        const liveChatContext = { requestId: "cached-request-id" };
+
+        expect(evaluateRecoveryEligibility(
+            createState(ConversationState.Loading, liveChatContext)
+        ).optionalParams).toEqual({ liveChatContext });
+    });
+
+    it.each(unsupportedCachedStates)("does not recover cached context in state %s", (conversationState) => {
+        expect(evaluateRecoveryEligibility(createState(conversationState))).toMatchObject({
+            eligible: false,
+            reason: RecoveryEligibilityReason.UnsupportedState
+        });
+    });
+
+    it.each([
+        [undefined, RecoveryEligibilityReason.MissingContext],
+        [null, RecoveryEligibilityReason.MissingContext],
+        ["invalid", RecoveryEligibilityReason.MissingContext],
+        [{}, RecoveryEligibilityReason.MissingRequestId],
+        [{ requestId: "" }, RecoveryEligibilityReason.MissingRequestId],
+        [{ requestId: "   " }, RecoveryEligibilityReason.MissingRequestId]
+    ])("fails closed for invalid context %#", (liveChatContext, reason) => {
+        expect(evaluateRecoveryEligibility(
+            createState(ConversationState.Loading, liveChatContext)
+        )).toMatchObject({
+            eligible: false,
+            reason
+        });
+    });
+
+    it.each([undefined, "Loading", 999])("fails closed for malformed state %s", (conversationState) => {
+        const decision = evaluateRecoveryEligibility(createState(conversationState));
+
+        expect(decision).toMatchObject({
+            eligible: false,
+            conversationState: "Unknown",
+            reason: RecoveryEligibilityReason.UnsupportedState
+        });
+        expect(Object.values(RecoveryEligibilityReason)).toContain(decision.reason);
+    });
+
+    it("treats whitespace-only reconnectId as absent", () => {
+        expect(evaluateRecoveryEligibility(
+            createState(ConversationState.Prechat, null, "   ")
+        )).toMatchObject({
+            eligible: false,
+            hasReconnectId: false,
+            reason: RecoveryEligibilityReason.MissingContext
+        });
+    });
+
+    it("emits only privacy-safe decision properties", () => {
+        const decision = evaluateRecoveryEligibility(createState(ConversationState.Loading));
+        const properties = getRecoveryEligibilityTelemetryProperties(decision);
+
+        expect(Object.keys(properties).sort()).toEqual([
+            "conversationState",
+            "eligible",
+            "hasLiveChatContext",
+            "hasReconnectId",
+            "hasRequestId",
+            "reason"
+        ]);
+        expect(properties).toEqual({
+            conversationState: "Loading",
+            eligible: true,
+            hasLiveChatContext: true,
+            hasReconnectId: false,
+            hasRequestId: true,
+            reason: RecoveryEligibilityReason.LoadingContextPresent
+        });
+    });
+});

--- a/chat-widget/src/components/livechatwidget/common/recoveryEligibility.ts
+++ b/chat-widget/src/components/livechatwidget/common/recoveryEligibility.ts
@@ -1,0 +1,135 @@
+import StartChatOptionalParams from "@microsoft/omnichannel-chat-sdk/lib/core/StartChatOptionalParams";
+
+import { ConversationState } from "../../../contexts/common/ConversationState";
+import { ILiveChatWidgetContext } from "../../../contexts/common/ILiveChatWidgetContext";
+
+export enum RecoveryEligibilityReason {
+    ReconnectIdPresent = "ReconnectIdPresent",
+    ActiveContextPresent = "ActiveContextPresent",
+    LoadingContextPresent = "LoadingContextPresent",
+    MissingContext = "MissingContext",
+    MissingRequestId = "MissingRequestId",
+    UnsupportedState = "UnsupportedState"
+}
+
+export interface RecoveryEligibilityDecision {
+    eligible: boolean;
+    optionalParams: StartChatOptionalParams;
+    conversationState: string;
+    hasReconnectId: boolean;
+    hasLiveChatContext: boolean;
+    hasRequestId: boolean;
+    reason: RecoveryEligibilityReason;
+}
+
+export interface RecoveryEligibilityTelemetryProperties {
+    conversationState: string;
+    hasReconnectId: boolean;
+    hasLiveChatContext: boolean;
+    hasRequestId: boolean;
+    eligible: boolean;
+    reason: RecoveryEligibilityReason;
+}
+
+const hasNonEmptyString = (value: unknown): value is string =>
+    typeof value === "string" && value.trim().length > 0;
+
+const getConversationStateName = (conversationState: unknown): string => {
+    if (typeof conversationState !== "number") {
+        return "Unknown";
+    }
+
+    const stateName = ConversationState[conversationState];
+    return typeof stateName === "string" ? stateName : "Unknown";
+};
+
+export const evaluateRecoveryEligibility = (state: ILiveChatWidgetContext): RecoveryEligibilityDecision => {
+    const reconnectId = state.appStates?.reconnectId;
+    const liveChatContext = state.domainStates?.liveChatContext;
+    const conversationState = state.appStates?.conversationState;
+    const hasReconnectId = hasNonEmptyString(reconnectId);
+    const hasLiveChatContext = liveChatContext !== null && typeof liveChatContext === "object";
+    const hasRequestId = hasLiveChatContext && hasNonEmptyString(liveChatContext.requestId);
+    const conversationStateName = getConversationStateName(conversationState);
+
+    if (hasReconnectId) {
+        return {
+            eligible: true,
+            optionalParams: { reconnectId },
+            conversationState: conversationStateName,
+            hasReconnectId,
+            hasLiveChatContext,
+            hasRequestId,
+            reason: RecoveryEligibilityReason.ReconnectIdPresent
+        };
+    }
+
+    if (!hasLiveChatContext) {
+        return {
+            eligible: false,
+            optionalParams: {},
+            conversationState: conversationStateName,
+            hasReconnectId,
+            hasLiveChatContext,
+            hasRequestId,
+            reason: RecoveryEligibilityReason.MissingContext
+        };
+    }
+
+    if (!hasRequestId) {
+        return {
+            eligible: false,
+            optionalParams: {},
+            conversationState: conversationStateName,
+            hasReconnectId,
+            hasLiveChatContext,
+            hasRequestId,
+            reason: RecoveryEligibilityReason.MissingRequestId
+        };
+    }
+
+    if (conversationState === ConversationState.Active) {
+        return {
+            eligible: true,
+            optionalParams: { liveChatContext },
+            conversationState: conversationStateName,
+            hasReconnectId,
+            hasLiveChatContext,
+            hasRequestId,
+            reason: RecoveryEligibilityReason.ActiveContextPresent
+        };
+    }
+
+    if (conversationState === ConversationState.Loading) {
+        return {
+            eligible: true,
+            optionalParams: { liveChatContext },
+            conversationState: conversationStateName,
+            hasReconnectId,
+            hasLiveChatContext,
+            hasRequestId,
+            reason: RecoveryEligibilityReason.LoadingContextPresent
+        };
+    }
+
+    return {
+        eligible: false,
+        optionalParams: {},
+        conversationState: conversationStateName,
+        hasReconnectId,
+        hasLiveChatContext,
+        hasRequestId,
+        reason: RecoveryEligibilityReason.UnsupportedState
+    };
+};
+
+export const getRecoveryEligibilityTelemetryProperties = (
+    decision: RecoveryEligibilityDecision
+): RecoveryEligibilityTelemetryProperties => ({
+    conversationState: decision.conversationState,
+    hasReconnectId: decision.hasReconnectId,
+    hasLiveChatContext: decision.hasLiveChatContext,
+    hasRequestId: decision.hasRequestId,
+    eligible: decision.eligible,
+    reason: decision.reason
+});

--- a/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
+++ b/chat-widget/src/components/livechatwidget/livechatwidgetstateful/LiveChatWidgetStateful.tsx
@@ -18,7 +18,6 @@ import {
     isNullOrEmptyString,
     isNullOrUndefined,
     isThisSessionPopout,
-    isUndefinedOrEmpty,
     setAriaHiddenForSiblings,
     setOcUserAgent
 } from "../../../common/utils";
@@ -71,7 +70,6 @@ import ProactiveChatPaneStateful from "../../proactivechatpanestateful/Proactive
 import ReconnectChatPaneStateful from "../../reconnectchatpanestateful/ReconnectChatPaneStateful";
 import StartChatErrorPaneStateful from "../../startchaterrorpanestateful/StartChatErrorPaneStateful";
 import { StartChatFailureType } from "../../../contexts/common/StartChatFailureType";
-import StartChatOptionalParams from "@microsoft/omnichannel-chat-sdk/lib/core/StartChatOptionalParams";
 import { TelemetryHelper } from "../../../common/telemetry/TelemetryHelper";
 import WebChatContainerStateful from "../../webchatcontainerstateful/WebChatContainerStateful";
 import createDownloadTranscriptProps from "../common/createDownloadTranscriptProps";
@@ -96,6 +94,10 @@ import useChatContextStore from "../../../hooks/useChatContextStore";
 import useFacadeSDKStore from "../../../hooks/useFacadeChatSDKStore";
 import { getPostChatContext, initiatePostChat } from "../common/renderSurveyHelpers";
 import PostChatContext from "@microsoft/omnichannel-chat-sdk/lib/core/PostChatContext";
+import {
+    evaluateRecoveryEligibility,
+    getRecoveryEligibilityTelemetryProperties
+} from "../common/recoveryEligibility";
 
 let uiTimer : ITimer;
 
@@ -148,21 +150,18 @@ export const LiveChatWidgetStateful = (props: ILiveChatWidgetProps) => {
     let widgetStateEventId = "";
     const lastLWICheckTimeRef = useRef<number>(0);
     const callInProgress = useRef<boolean>(false);
-    let optionalParams: StartChatOptionalParams;
+    let optionalParams = {};
     let activeCachedChatExist = false;
 
     const setOptionalParams = () => {
-        if (!isUndefinedOrEmpty(state.appStates?.reconnectId)) {
-            activeCachedChatExist = true;
-            optionalParams = { reconnectId: state?.appStates?.reconnectId };
-        } else if (!isUndefinedOrEmpty(state?.domainStates?.liveChatContext) &&
-            state?.appStates?.conversationState === ConversationState.Active) {
-            activeCachedChatExist = true;
-            optionalParams = { liveChatContext: state?.domainStates?.liveChatContext };
-        } else {
-            activeCachedChatExist = false;
-            optionalParams = {};
-        }
+        const decision = evaluateRecoveryEligibility(state);
+        activeCachedChatExist = decision.eligible;
+        optionalParams = decision.optionalParams;
+
+        TelemetryHelper.logActionEvent(LogLevel.INFO, {
+            Event: TelemetryEvent.RecoveryEligibilityEvaluated,
+            CustomProperties: getRecoveryEligibilityTelemetryProperties(decision)
+        });
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/chat-widget/yarn.lock
+++ b/chat-widget/yarn.lock
@@ -17484,10 +17484,10 @@ sanitize-html@2.14.0:
     parse-srcset "^1.0.2"
     postcss "^8.3.11"
 
-sanitize-html@2.17.6:
-  version "2.17.6"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.17.6.tgz#c62a2e2e55d03004f3e0ecd6dbb9126d4b985d82"
-  integrity sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==
+sanitize-html@2.17.7:
+  version "2.17.7"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.17.7.tgz#b16417c348ea5f99c2451964b6e6621ca6b1da94"
+  integrity sha512-PGtEkc9cbnedU3s9TmzDbpsZ8w086g/0Q8k8/oIO1NLNU3i5k9yn835CrjJSajp1KMmkisbO1qPXxNKO3welAg==
   dependencies:
     deepmerge "^4.2.2"
     escape-string-regexp "^4.0.0"


### PR DESCRIPTION
## Problem

During a page reload or full-page navigation, the widget can restore a cached conversation in the transient `Loading` state. The existing recovery gate accepts cached context only when the local state is exactly `Active`, so it can skip authoritative conversation validation and proceed toward creating a new chat.

## Root cause

Recovery eligibility is decided from local UI state before `checkIfConversationStillValid()` consults the service. A cached conversation with stable identity but a transient `Loading` state is rejected before that validation call.

## Fix

| Change | Details |
|--------|---------|
| **Recovery eligibility** | Treat cached `Active` and `Loading` states as validation candidates when a nonempty request ID is available. |
| **Reconnect precedence** | Preserve the existing `reconnectId` path as the highest-priority recovery mechanism. |
| **Safety exclusions** | Continue to reject terminal, post-chat, proactive, out-of-office, reconnect-choice, malformed, and missing-identity states. |
| **Telemetry** | Add `RecoveryEligibilityEvaluated` with only allowlisted state/reason strings and booleans; no IDs, tokens, context payloads, or customer content. |
| **Scope** | Change only the initialization path that immediately performs authoritative conversation validation. Alternate paths without equivalent validation remain unchanged. |

## Pipeline security-audit refresh

The first PR run was interrupted by `sanitize-html` advisories published after the previous successful build. The follow-up commit:

- pins the widget's direct `sanitize-html` dependency to patched version `2.17.7`;
- records the two newly published advisories that remain only under the required `botframework-webchat` hotfix's exact nested `sanitize-html@2.14.0` dependency;
- keeps audit exceptions scoped to that exact version, advisory, and dependency owner.

## Testing

- 38 recovery eligibility and initialization tests passed.
- 16 related `startChat` tests passed.
- Changed-file ESLint passed with zero warnings.
- The packed-consumer dependency tree contains direct `sanitize-html@2.17.7` and nested `sanitize-html@2.14.0` only under `botframework-webchat`.
- The expected nested advisory ownership set passes `validate-consumer-audit.cjs`.
- Three independent correctness, architecture, and telemetry/privacy reviews found no blocking issues.

## Follow-up

This is a contained recovery-gate fix. A durable follow-up should represent validation as `Valid`, `Terminal`, or `Unknown`, and must not allow a transient validation failure to silently authorize new-chat creation.

Fixes AB#6667146
